### PR TITLE
fix: Independent scrolling for shortened links (#89)

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "@radix-ui/react-dropdown-menu": "^2.0.6",
     "@radix-ui/react-label": "^2.0.2",
     "@radix-ui/react-popover": "^1.0.7",
+    "@radix-ui/react-scroll-area": "^1.0.5",
     "@radix-ui/react-select": "^2.0.0",
     "@radix-ui/react-slot": "^1.0.2",
     "@radix-ui/react-tabs": "^1.0.4",

--- a/src/components/dashboard/link-overview/link-showcase.tsx
+++ b/src/components/dashboard/link-overview/link-showcase.tsx
@@ -132,7 +132,7 @@ const LinkShowcase = ({ link }: { link: Link }) => {
   };
 
   return (
-    <div className="flex items-center justify-between px-6 py-4 rounded-md bg-slate-50">
+    <div className="flex items-center justify-between my-5 px-6 py-4 rounded-md bg-slate-50">
       <div className="flex flex-col gap-2">
         <div className="flex items-center gap-3">
           <p

--- a/src/components/dashboard/link-overview/links-view.tsx
+++ b/src/components/dashboard/link-overview/links-view.tsx
@@ -33,7 +33,10 @@ const LinksView = ({ links }: { links: Link[] }) => {
         value={search}
         onChange={(e) => handleSearch(e)}
       />
-      <ScrollArea className="flex flex-col gap-5 mt-6 w-fit h-[30rem]">
+      <ScrollArea
+        className="flex flex-col  w-fit h-[30rem]
+"
+      >
         {filteredLinks.map((link) => (
           <LinkShowcase key={link.id} link={link} />
         ))}

--- a/src/components/dashboard/link-overview/links-view.tsx
+++ b/src/components/dashboard/link-overview/links-view.tsx
@@ -5,6 +5,7 @@ import React, { useState } from "react";
 
 import { Input } from "@/components/ui/input";
 
+import { ScrollArea } from "@/components/ui/scroll-area";
 import LinkShowcase from "./link-showcase";
 
 type Link = Prisma.LinkGetPayload<{
@@ -32,11 +33,11 @@ const LinksView = ({ links }: { links: Link[] }) => {
         value={search}
         onChange={(e) => handleSearch(e)}
       />
-      <div className="flex flex-col gap-5 mt-6">
+      <ScrollArea className="flex flex-col gap-5 mt-6 w-fit h-[30rem]">
         {filteredLinks.map((link) => (
           <LinkShowcase key={link.id} link={link} />
         ))}
-      </div>
+      </ScrollArea>
     </main>
   );
 };

--- a/src/components/ui/scroll-area.tsx
+++ b/src/components/ui/scroll-area.tsx
@@ -1,0 +1,48 @@
+"use client";
+
+import * as React from "react";
+import * as ScrollAreaPrimitive from "@radix-ui/react-scroll-area";
+
+import { cn } from "@/lib/utils";
+
+const ScrollArea = React.forwardRef<
+  React.ElementRef<typeof ScrollAreaPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof ScrollAreaPrimitive.Root>
+>(({ className, children, ...props }, ref) => (
+  <ScrollAreaPrimitive.Root
+    ref={ref}
+    className={cn("relative overflow-hidden", className)}
+    {...props}
+  >
+    <ScrollAreaPrimitive.Viewport className="h-full w-full rounded-[inherit]">
+      {children}
+    </ScrollAreaPrimitive.Viewport>
+    <ScrollBar />
+    <ScrollAreaPrimitive.Corner />
+  </ScrollAreaPrimitive.Root>
+));
+ScrollArea.displayName = ScrollAreaPrimitive.Root.displayName;
+
+const ScrollBar = React.forwardRef<
+  React.ElementRef<typeof ScrollAreaPrimitive.ScrollAreaScrollbar>,
+  React.ComponentPropsWithoutRef<typeof ScrollAreaPrimitive.ScrollAreaScrollbar>
+>(({ className, orientation = "vertical", ...props }, ref) => (
+  <ScrollAreaPrimitive.ScrollAreaScrollbar
+    ref={ref}
+    orientation={orientation}
+    className={cn(
+      "flex touch-none select-none transition-colors",
+      orientation === "vertical" &&
+        "h-full w-2.5 border-l border-l-transparent p-[1px]",
+      orientation === "horizontal" &&
+        "h-2.5 flex-col border-t border-t-transparent p-[1px]",
+      className,
+    )}
+    {...props}
+  >
+    <ScrollAreaPrimitive.ScrollAreaThumb className="relative flex-1 rounded-full bg-border" />
+  </ScrollAreaPrimitive.ScrollAreaScrollbar>
+));
+ScrollBar.displayName = ScrollAreaPrimitive.ScrollAreaScrollbar.displayName;
+
+export { ScrollArea, ScrollBar };


### PR DESCRIPTION
Made the list of shortened links scrollable independently without affecting the left column. This fixes issue #89.