### PR TITLE
fix: prevent periods in alias when creating a link

### DIFF
--- a/src/server/api/routers/link/link.service.ts
+++ b/src/server/api/routers/link/link.service.ts
@@ -47,6 +47,10 @@ export const getLink = async (ctx: ProtectedTRPCContext, input: GetLinkInput) =>
 
 export const createLink = async (ctx: ProtectedTRPCContext, input: CreateLinkInput) => {
   if (input.alias) {
+    if (input.alias.includes(".")) {
+      throw new Error("Cannot include periods in alias");
+    }
+
     const aliasExists = await ctx.db
       .select()
       .from(link)


### PR DESCRIPTION
when creating a link with a custom alias, ensure that the user entered alias does not include a period as most include periods to create phishing urls
