### PR TITLE
fix: use an absolute title on landing page title

### DIFF
--- a/src/app/(landing)/page.tsx
+++ b/src/app/(landing)/page.tsx
@@ -9,7 +9,9 @@ import { InfiniteMovingCards } from "./_components/infinite-moving-cards";
 
 import type { Metadata } from "next";
 export const metadata: Metadata = {
-  title: "iShortn",
+  title: {
+    absolute: "iShortn",
+  },
   description: "URL Shortener with analytics, custom domains, and password protection.",
 };
 


### PR DESCRIPTION
this prevents the user of templates in constructing the title of the page and as such, removes the `iShortn | iShortn` on the landing page
