### PR TITLE
feat: reset links statistics 

### DIFF
--- a/src/app/(main)/dashboard/_components/qrcode-modal.tsx
+++ b/src/app/(main)/dashboard/_components/qrcode-modal.tsx
@@ -1,0 +1,57 @@
+import QRCode from "qrcode.react";
+import { useRef } from "react";
+
+import { Button } from "@/components/ui/button";
+import {
+	Dialog,
+	DialogContent,
+	DialogDescription,
+	DialogHeader,
+	DialogTitle,
+} from "@/components/ui/dialog";
+
+type QRCodeModalProps = {
+  open: boolean;
+  setOpen: React.Dispatch<React.SetStateAction<boolean>>;
+  destinationUrl: string;
+};
+
+export function QRCodeModal({ open, setOpen, destinationUrl }: QRCodeModalProps) {
+  const qrCodeCanvasRef = useRef(null);
+
+  const handleQRCodeDownload = () => {
+    if (!destinationUrl) return;
+    const canvas = document.getElementById("qr-gen") as HTMLCanvasElement;
+    const pngUrl = canvas.toDataURL("image/png").replace("image/png", "image/octet-stream");
+    const downloadLink = document.createElement("a");
+    downloadLink.href = pngUrl;
+    downloadLink.download = `qrcode.png`;
+    document.body.appendChild(downloadLink);
+    downloadLink.click();
+    document.body.removeChild(downloadLink);
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogContent className="sm:max-w-[425px]">
+        <DialogHeader>
+          <DialogTitle>QR Code</DialogTitle>
+          <DialogDescription>Here is your QR Code for the link.</DialogDescription>
+        </DialogHeader>
+        <div className="flex flex-col items-center">
+          <QRCode
+            id="qr-gen"
+            value={destinationUrl}
+            size={300}
+            level={"H"}
+            includeMargin={true}
+            ref={qrCodeCanvasRef}
+          />
+          <Button className="mt-4" onClick={handleQRCodeDownload}>
+            Download Image
+          </Button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/app/(main)/dashboard/_components/tab-switcher.tsx
+++ b/src/app/(main)/dashboard/_components/tab-switcher.tsx
@@ -24,7 +24,7 @@ const TabSwitcher = ({ className }: TabSwitcherProps) => {
   return (
     <div
       className={cn(
-        "border-b border-gray-200 text-center text-sm font-medium text-gray-500 dark:border-gray-700 dark:text-gray-400",
+        "flex items-center border-b border-gray-200 text-center text-sm font-medium text-gray-500 dark:border-gray-700 dark:text-gray-400",
         className,
       )}
     >
@@ -42,9 +42,18 @@ const TabSwitcher = ({ className }: TabSwitcherProps) => {
             </Link>
           </li>
         ))}
+        <span
+          className="relative inline-block rounded-t-lg border-b-2 border-transparent p-4 hover:cursor-pointer hover:border-gray-300 hover:text-gray-600 dark:hover:text-gray-300"
+          onClick={() => rnw("show")}
+        >
+          <div className="rn-badge" />
+          Release Notes
+        </span>
       </ul>
     </div>
   );
 };
 
 export { TabSwitcher };
+
+declare function rnw(...args: unknown[]): void;

--- a/src/app/(main)/layout.tsx
+++ b/src/app/(main)/layout.tsx
@@ -5,6 +5,7 @@ import { Footer } from "./footer";
 const MainLayout = ({ children }: { children: ReactNode }) => {
   return (
     <>
+      <rn-banner background-color="#2563eb" border-radius="0" margin="0" />
       {children}
       <Footer />
     </>

--- a/src/app/(main)/release-notes-banner.d.ts
+++ b/src/app/(main)/release-notes-banner.d.ts
@@ -1,0 +1,13 @@
+import type * as React from "react";
+
+declare global {
+  namespace JSX {
+    interface IntrinsicElements {
+      "rn-banner": React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement> & {
+        "background-color"?: string;
+        "border-radius"?: string;
+        margin?: string;
+      };
+    }
+  }
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -34,6 +34,22 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
       {env.UMAMI_TRACKING_ID && (
         <Script defer src={env.UMAMI_URL} data-website-id={env.UMAMI_TRACKING_ID} />
       )}
+      <Script
+        id=""
+        strategy="lazyOnload"
+        dangerouslySetInnerHTML={{
+          __html: `
+            (function (w,d,s,o,f,js,fjs) { w['ReleaseNotesWidget']=o;w[o] = w[o] || function () { (w[o].q = w[o].q || []).push(arguments) }; js = d.createElement(s), fjs = d.getElementsByTagName(s)[0]; js.id = o; js.src = f; js.async = 1; fjs.parentNode.insertBefore(js, fjs); }
+            (window, document, 'script', 'rnw', 'https://s3.amazonaws.com/cdn.releasenotes.io/v1/bootstrap.js'));
+
+            rnw('init', {
+                account: 'ishortn.releasenotes.io',
+                selector: '.rn-badge', // change the CSS selector to apply the badge and link to
+                title: 'Latest Updates from iShortn',
+            });
+        `,
+        }}
+      />
       <html lang="en" suppressHydrationWarning>
         <body className={cn("min-h-screen bg-background font-sans antialiased", fontSans.variable)}>
           {/* we ship dark theme later, now light theme */}

--- a/src/server/api/routers/link/link.procedure.ts
+++ b/src/server/api/routers/link/link.procedure.ts
@@ -55,4 +55,8 @@ export const linkRouter = createTRPCRouter({
   togglePublicStats: protectedProcedure.input(inputs.getLinkSchema).mutation(({ ctx, input }) => {
     return services.togglePublicStats(ctx, input);
   }),
+
+  resetLinkStatistics: protectedProcedure.input(inputs.getLinkSchema).mutation(({ ctx, input }) => {
+    return services.resetLinkStatistics(ctx, input);
+  }),
 });

--- a/src/server/api/routers/link/link.service.ts
+++ b/src/server/api/routers/link/link.service.ts
@@ -198,3 +198,17 @@ export const togglePublicStats = async (ctx: ProtectedTRPCContext, input: GetLin
     })
     .where(and(eq(link.alias, input.alias), eq(link.userId, ctx.auth.userId)));
 };
+
+export const resetLinkStatistics = async (ctx: ProtectedTRPCContext, input: GetLinkInput) => {
+  const fetchedLink = await ctx.db.query.link.findFirst({
+    where: (table, { eq }) => eq(table.alias, input.alias),
+  });
+
+  if (!fetchedLink) {
+    return null;
+  }
+
+  await ctx.db.delete(linkVisit).where(eq(linkVisit.linkId, fetchedLink.id));
+
+  return fetchedLink;
+};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,25 +8,32 @@
     "resolveJsonModule": true,
     "moduleDetection": "force",
     "isolatedModules": true,
-
     /* Strictness */
     "strict": true,
     "noUncheckedIndexedAccess": true,
     "checkJs": true,
-
     /* Bundled projects */
-    "lib": ["dom", "dom.iterable", "ES2022"],
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "ES2022"
+    ],
     "noEmit": true,
     "module": "ESNext",
     "moduleResolution": "Bundler",
     "jsx": "preserve",
-    "plugins": [{ "name": "next" }],
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ],
     "incremental": true,
-
     /* Path Aliases */
     "baseUrl": ".",
     "paths": {
-      "@/*": ["./src/*"]
+      "@/*": [
+        "./src/*"
+      ]
     }
   },
   "include": [
@@ -36,7 +43,11 @@
     "**/*.tsx",
     "**/*.cjs",
     "**/*.js",
-    ".next/types/**/*.ts"
+    ".next/types/**/*.ts",
+    // include the .d.ts files
+    "**/*.d.ts"
   ],
-  "exclude": ["node_modules"]
+  "exclude": [
+    "node_modules"
+  ]
 }


### PR DESCRIPTION
Users can now reset the click counter for their shortened URLs. This allows for a clear distinction between test clicks and live campaign clicks, ensuring more accurate tracking and reporting.