### PR TITLE
chore: update database connection to use connection pooling

### DIFF
--- a/src/server/db/index.ts
+++ b/src/server/db/index.ts
@@ -5,10 +5,9 @@ import { env } from "@/env";
 
 import * as schema from "./schema";
 
-export const connection = await mysql.createConnection({
+export const connection = mysql.createPool({
   uri: env.DATABASE_URL,
-  enableKeepAlive: true,
-  keepAliveInitialDelay: 1000,
+  connectionLimit: 20,
 });
 
 export const db = drizzle(connection, { schema, mode: "default" });


### PR DESCRIPTION
- Replaced `createConnection` with `createPool` to enable connection pooling for better performance and scalability
- Set `connectionLimit` to 20 to limit the number of concurrent connections
