### PR TITLE
feat: use `waitUntil` to log link analytics

### DIFF
--- a/src/app/(main)/[linkAlias]/page.tsx
+++ b/src/app/(main)/[linkAlias]/page.tsx
@@ -14,11 +14,17 @@ type LinkRedirectionPageProps = {
 const LinkRedirectionPage = async ({ params }: LinkRedirectionPageProps) => {
   const headersList = headers();
   const incomingDomain = headersList.get("x-forwarded-host") ?? headersList.get("host");
-  const domain = process.env.VERCEL_URL ? incomingDomain : "ishortn.ink"; // if we're on vercel, use the incoming domain else use the default domain
+
+  let domain: string;
+  if (process.env.VERCEL_URL && incomingDomain !== process.env.STAGING_DOMAIN) {
+    domain = incomingDomain ?? "ishortn.ink";
+  } else {
+    domain = "ishortn.ink";
+  }
 
   const link = await api.link.retrieveOriginalUrl.query({
     alias: params.linkAlias,
-    domain: domain!.replace("http://", "").replace("https://", "").replace("www.", ""),
+    domain: domain.replace("http://", "").replace("https://", "").replace("www.", ""),
   });
 
   if (!link) return notFound();

--- a/src/server/api/routers/link/link.service.ts
+++ b/src/server/api/routers/link/link.service.ts
@@ -1,3 +1,4 @@
+import { waitUntil } from "@vercel/functions";
 import bcrypt from "bcryptjs";
 import crypto from "crypto";
 import { subDays } from "date-fns";
@@ -6,9 +7,10 @@ import { and, count, desc, eq } from "drizzle-orm";
 import { retrieveDeviceAndGeolocationData } from "@/lib/core/analytics";
 import { Cache } from "@/lib/core/cache";
 import { generateShortLink } from "@/lib/core/links";
-import { parseReferrer } from "@/lib/utils";
 import { db } from "@/server/db";
 import { link, linkVisit, uniqueLinkVisit } from "@/server/db/schema";
+
+import { logAnalytics } from "./utils";
 
 import type { Link } from "@/server/db/schema";
 import type { ProtectedTRPCContext, PublicTRPCContext } from "../../trpc";
@@ -155,32 +157,11 @@ export const retrieveOriginalUrl = async (
     }
   }
 
-  // record the visit for both cached and non-cached links, unless the link is password protected
-  if (!link.passwordHash) {
-    const deviceDetails = await retrieveDeviceAndGeolocationData(ctx.headers);
+  // if (!link.passwordHash) {
+  //   waitUntil(logAnalytics(ctx, link));
+  // }
 
-    await ctx.db.insert(linkVisit).values({
-      linkId: link.id,
-      ...deviceDetails,
-      referer: parseReferrer(ctx.headers.get("referer")),
-    });
-
-    const ipHash = crypto
-      .createHash("sha256")
-      .update(ctx.headers.get("x-forwarded-for") ?? "")
-      .digest("hex");
-
-    const existingLinkVisit = await ctx.db.query.uniqueLinkVisit.findFirst({
-      where: (table, { eq, and }) => and(eq(table.linkId, link.id), eq(table.ipHash, ipHash)),
-    });
-
-    if (!existingLinkVisit) {
-      await ctx.db.insert(uniqueLinkVisit).values({
-        linkId: link.id,
-        ipHash,
-      });
-    }
-  }
+  waitUntil(logAnalytics(ctx, link));
 
   return link;
 };

--- a/src/server/api/routers/link/utils.ts
+++ b/src/server/api/routers/link/utils.ts
@@ -1,0 +1,38 @@
+import crypto from "crypto";
+
+import { retrieveDeviceAndGeolocationData } from "@/lib/core/analytics";
+import { parseReferrer } from "@/lib/utils";
+import { linkVisit, uniqueLinkVisit } from "@/server/db/schema";
+
+import type { Link } from "@/server/db/schema";
+import type { PublicTRPCContext } from "../../trpc";
+
+export async function logAnalytics(ctx: PublicTRPCContext, link: Link) {
+  if (link.passwordHash) {
+    return;
+  }
+
+  const deviceDetails = await retrieveDeviceAndGeolocationData(ctx.headers);
+
+  await ctx.db.insert(linkVisit).values({
+    linkId: link.id,
+    ...deviceDetails,
+    referer: parseReferrer(ctx.headers.get("referer")),
+  });
+
+  const ipHash = crypto
+    .createHash("sha256")
+    .update(ctx.headers.get("x-forwarded-for") ?? "")
+    .digest("hex");
+
+  const existingLinkVisit = await ctx.db.query.uniqueLinkVisit.findFirst({
+    where: (table, { eq, and }) => and(eq(table.linkId, link.id), eq(table.ipHash, ipHash)),
+  });
+
+  if (!existingLinkVisit) {
+    await ctx.db.insert(uniqueLinkVisit).values({
+      linkId: link.id,
+      ipHash,
+    });
+  }
+}


### PR DESCRIPTION
This ensures that the link is resolved and is sent immediately to the user, and afterwards, we log the analytics info
