### PR TITLE
fix(analytics): if there are no link visits, return early

### DIFF
--- a/src/server/api/routers/link/link.service.ts
+++ b/src/server/api/routers/link/link.service.ts
@@ -229,8 +229,14 @@ export const getLinkVisits = async (
     },
   });
 
-  if (!link) {
-    return { totalVisits: [], uniqueVisits: [] };
+  if (!link || link?.linkVisits.length === 0) {
+    return {
+      totalVisits: [],
+      uniqueVisits: [],
+      topCountry: "N/A",
+      referers: {},
+      topReferrer: "N/A",
+    };
   }
 
   const countryVisits = link.linkVisits.reduce(
@@ -259,23 +265,6 @@ export const getLinkVisits = async (
     topReferrer: topReferrer !== "null" ? topReferrer : "Direct",
     isProPlan: userHasProPlan,
   };
-};
-
-export const toggleLinkStatus = async (ctx: ProtectedTRPCContext, input: GetLinkInput) => {
-  const fetchedLink = await ctx.db.query.link.findFirst({
-    where: (table, { eq }) => eq(table.id, input.id),
-  });
-
-  if (!fetchedLink) {
-    return null;
-  }
-
-  return await ctx.db
-    .update(link)
-    .set({
-      disabled: !fetchedLink.disabled,
-    })
-    .where(and(eq(link.id, input.id), eq(link.userId, ctx.auth.userId)));
 };
 
 export const togglePublicStats = async (ctx: ProtectedTRPCContext, input: GetLinkInput) => {

--- a/src/server/api/routers/link/link.service.ts
+++ b/src/server/api/routers/link/link.service.ts
@@ -284,6 +284,23 @@ export const togglePublicStats = async (ctx: ProtectedTRPCContext, input: GetLin
     .where(and(eq(link.id, input.id), eq(link.userId, ctx.auth.userId)));
 };
 
+export const toggleLinkStatus = async (ctx: ProtectedTRPCContext, input: GetLinkInput) => {
+  const fetchedLink = await ctx.db.query.link.findFirst({
+    where: (table, { eq }) => eq(table.id, input.id),
+  });
+
+  if (!fetchedLink) {
+    return null;
+  }
+
+  return await ctx.db
+    .update(link)
+    .set({
+      disabled: !fetchedLink.disabled,
+    })
+    .where(and(eq(link.id, input.id), eq(link.userId, ctx.auth.userId)));
+};
+
 export const resetLinkStatistics = async (ctx: ProtectedTRPCContext, input: GetLinkInput) => {
   const fetchedLink = await ctx.db.query.link.findFirst({
     where: (table, { eq }) => eq(table.id, input.id),


### PR DESCRIPTION
this takes care of the error that happens because we are trying to call reduce on an empty array


