### PR TITLE
Refactor getLinks to calculate total clicks across all links

### DIFF
--- a/src/app/(main)/dashboard/page.tsx
+++ b/src/app/(main)/dashboard/page.tsx
@@ -25,7 +25,7 @@ export default async function DashboardPage({ searchParams }: Props) {
   const orderBy = searchParams.orderBy as "createdAt" | "totalClicks";
   const orderDirection = searchParams.orderDirection as "desc" | "asc";
 
-  const { links, totalLinks, totalPages, currentPage } = await api.link.list.query({
+  const { links, totalLinks, totalPages, currentPage, totalClicks } = await api.link.list.query({
     page,
     pageSize,
     orderBy,
@@ -35,8 +35,6 @@ export default async function DashboardPage({ searchParams }: Props) {
   const userSubscription = await api.subscriptions.get.query();
   const subscriptions = userSubscription?.subscriptions;
   const userHasProPlan = subscriptions?.status === "active";
-
-  const totalClicks = links.reduce((acc, link) => acc + link.totalClicks, 0);
 
   return (
     <div>

--- a/src/server/api/routers/link/link.procedure.ts
+++ b/src/server/api/routers/link/link.procedure.ts
@@ -5,6 +5,7 @@ import * as inputs from "./link.input";
 import * as services from "./link.service";
 
 import type { PublicTRPCContext } from "../../trpc";
+
 export const linkRouter = createTRPCRouter({
   retrieveOriginalUrl: publicProcedure
     .input(inputs.retrieveOriginalUrlSchema)


### PR DESCRIPTION
- Modify totalClicks query to count all visits for user's links
- Use innerJoin to ensure only actual visits are counted
- Separate totalClicks calculation from paginated link query
- Improve accuracy of total click count independent of pagination

This change provides a more accurate total click count across all of
a user's links, regardless of the current page or filter settings.
