### PR TITLE
fix: use the domain associated with a link to generate qrcodes

### DIFF
--- a/src/app/(main)/dashboard/_components/single-link/link-actions.tsx
+++ b/src/app/(main)/dashboard/_components/single-link/link-actions.tsx
@@ -1,26 +1,26 @@
 "use client";
 
 import {
-	Copy,
-	KeyRound,
-	MoreVertical,
-	Pencil,
-	PowerCircle,
-	QrCode,
-	RotateCcwIcon,
-	Trash2Icon,
-	Unlink,
+  Copy,
+  KeyRound,
+  MoreVertical,
+  Pencil,
+  PowerCircle,
+  QrCode,
+  RotateCcwIcon,
+  Trash2Icon,
+  Unlink,
 } from "lucide-react";
 import { useState } from "react";
 import { toast } from "sonner";
 
 import {
-	DropdownMenu,
-	DropdownMenuContent,
-	DropdownMenuGroup,
-	DropdownMenuItem,
-	DropdownMenuSeparator,
-	DropdownMenuTrigger,
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuGroup,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { copyToClipboard } from "@/lib/utils";
 import { api } from "@/trpc/react";
@@ -171,7 +171,7 @@ export const LinkActions = ({ link }: LinkActionsProps) => {
       <QRCodeModal
         open={qrModal}
         setOpen={setQrModal}
-        destinationUrl={`https://ishortn.ink/${link.alias}`}
+        destinationUrl={`https://${link.domain}/${link.alias}`}
       />
       <ChangeLinkPasswordModal
         open={openChangePasswordModal}


### PR DESCRIPTION
initially we were using a fixed entry, ishortn.ink to generate qrcode links. This breaks if the user is using a custom domain for that particular link. Now, we build the link based on the domain we are using
