### PR TITLE
Add Sort By Recent Clicks Feature

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "@radix-ui/react-label": "^2.0.2",
     "@radix-ui/react-popover": "^1.0.7",
     "@radix-ui/react-progress": "^1.1.0",
+    "@radix-ui/react-scroll-area": "^1.2.2",
     "@radix-ui/react-select": "^2.0.0",
     "@radix-ui/react-separator": "^1.1.0",
     "@radix-ui/react-slider": "^1.2.0",

--- a/src/app/(main)/dashboard/_components/all-links-renderer.tsx
+++ b/src/app/(main)/dashboard/_components/all-links-renderer.tsx
@@ -79,6 +79,8 @@ const Links = (
           <SelectContent>
             <SelectItem value="createdAt-desc">Newest first</SelectItem>
             <SelectItem value="createdAt-asc">Oldest first</SelectItem>
+            <SelectItem value="lastClicked-desc">Recently clicked</SelectItem>
+            <SelectItem value="lastClicked-asc">Least recently clicked</SelectItem>
             <SelectItem value="totalClicks-desc">Most clicks</SelectItem>
             <SelectItem value="totalClicks-asc">Least clicks</SelectItem>
           </SelectContent>

--- a/src/components/ui/scroll-area.tsx
+++ b/src/components/ui/scroll-area.tsx
@@ -1,0 +1,48 @@
+"use client"
+
+import * as React from "react"
+import * as ScrollAreaPrimitive from "@radix-ui/react-scroll-area"
+
+import { cn } from "@/lib/utils"
+
+const ScrollArea = React.forwardRef<
+  React.ElementRef<typeof ScrollAreaPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof ScrollAreaPrimitive.Root>
+>(({ className, children, ...props }, ref) => (
+  <ScrollAreaPrimitive.Root
+    ref={ref}
+    className={cn("relative overflow-hidden", className)}
+    {...props}
+  >
+    <ScrollAreaPrimitive.Viewport className="h-full w-full rounded-[inherit]">
+      {children}
+    </ScrollAreaPrimitive.Viewport>
+    <ScrollBar />
+    <ScrollAreaPrimitive.Corner />
+  </ScrollAreaPrimitive.Root>
+))
+ScrollArea.displayName = ScrollAreaPrimitive.Root.displayName
+
+const ScrollBar = React.forwardRef<
+  React.ElementRef<typeof ScrollAreaPrimitive.ScrollAreaScrollbar>,
+  React.ComponentPropsWithoutRef<typeof ScrollAreaPrimitive.ScrollAreaScrollbar>
+>(({ className, orientation = "vertical", ...props }, ref) => (
+  <ScrollAreaPrimitive.ScrollAreaScrollbar
+    ref={ref}
+    orientation={orientation}
+    className={cn(
+      "flex touch-none select-none transition-colors",
+      orientation === "vertical" &&
+        "h-full w-2.5 border-l border-l-transparent p-[1px]",
+      orientation === "horizontal" &&
+        "h-2.5 flex-col border-t border-t-transparent p-[1px]",
+      className
+    )}
+    {...props}
+  >
+    <ScrollAreaPrimitive.ScrollAreaThumb className="relative flex-1 rounded-full bg-border" />
+  </ScrollAreaPrimitive.ScrollAreaScrollbar>
+))
+ScrollBar.displayName = ScrollAreaPrimitive.ScrollAreaScrollbar.displayName
+
+export { ScrollArea, ScrollBar }

--- a/src/server/api/routers/link/link.input.ts
+++ b/src/server/api/routers/link/link.input.ts
@@ -15,7 +15,7 @@ export const getLinkSchema = z.object({
 export const listLinksSchema = z.object({
   page: z.number().min(1).default(1),
   pageSize: z.number().min(1).max(100).default(10),
-  orderBy: z.enum(["createdAt", "totalClicks"]).default("createdAt"),
+  orderBy: z.enum(["createdAt", "totalClicks", "lastClicked"]).default("createdAt"),
   orderDirection: z.enum(["asc", "desc"]).default("desc"),
 });
 

--- a/src/server/api/routers/link/link.service.ts
+++ b/src/server/api/routers/link/link.service.ts
@@ -39,7 +39,12 @@ function constructCacheKey(domain: string, alias: string) {
 export const getLinks = async (ctx: ProtectedTRPCContext, input: ListLinksInput) => {
   const { page, pageSize, orderBy, orderDirection } = input;
 
-  const orderColumn = orderBy === "totalClicks" ? count(linkVisit.id) : link.createdAt;
+  const orderColumn = 
+    orderBy === "totalClicks" 
+      ? count(linkVisit.id) 
+      : orderBy === "lastClicked"
+        ? sql`MAX(${linkVisit.createdAt})`
+        : link.createdAt;
   const orderFunc = orderDirection === "desc" ? desc : asc;
 
   const [totalLinksResult, totalClicksResult, links] = await Promise.all([


### PR DESCRIPTION
## Overview
This PR adds the ability to sort links by their most recent click timestamps, allowing users to see which links have been clicked most recently.

## Changes
- Added `lastClicked` as a new sorting option in the link list API
- Modified the database query to support sorting by the most recent click timestamp using `MAX(linkVisit.createdAt)`
- Added new UI options in the dashboard dropdown for "Recently clicked" and "Least recently clicked"

## Technical Details
- Updated `listLinksSchema` to include `lastClicked` in the valid `orderBy` enum values
- Modified the [getLinks](cci:1://file:///Users/kelvinamoaba/Work/ishortn.ink/src/server/api/routers/link/link.service.ts:38:0-80:2) query to handle the new sorting option using SQL's MAX function on the `linkVisit.createdAt` column
- Added new SelectItem components in the sorting dropdown UI