### PR TITLE
Update label for custom domain links

### DIFF
--- a/src/app/(main)/[linkAlias]/link-password-verification.tsx
+++ b/src/app/(main)/[linkAlias]/link-password-verification.tsx
@@ -12,6 +12,9 @@ export const LinkPasswordVerification = ({ id }: { id: number }) => {
   const verifyPasswordMutation = api.link.verifyLinkPassword.useMutation();
   const router = useTransitionRouter();
 
+  // Get link information by ID to determine domain
+  const { data: linkData } = api.link.get.useQuery({ id });
+
   const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     const formData = new FormData(e.currentTarget);
@@ -40,11 +43,17 @@ export const LinkPasswordVerification = ({ id }: { id: number }) => {
     router.push(result.url!);
   };
 
+  // Determine what to display based on domain
+  const getDisplayTitle = () => {
+    if (!linkData?.domain) return "iShortn";
+    return linkData.domain === "ishortn.ink" ? "iShortn" : linkData.domain;
+  };
+
   return (
     <div
       className={`flex h-screen flex-col items-center justify-center ${satoshi.className}`}
     >
-      <h1 className="mb-10 text-4xl font-bold">iShortn</h1>
+      <h1 className="mb-10 text-4xl font-bold">{getDisplayTitle()}</h1>
 
       <h1 className="text-2xl font-bold">This link is password protected</h1>
       <form

--- a/src/app/(main)/verify-password/[linkId]/page.tsx
+++ b/src/app/(main)/verify-password/[linkId]/page.tsx
@@ -20,6 +20,9 @@ export default function VerifyPasswordPage({ params }: VerifyPasswordPageProps) 
   const verifyPasswordMutation = api.link.verifyLinkPassword.useMutation();
   const router = useTransitionRouter();
 
+  // Get link information by ID to determine domain
+  const { data: linkData } = api.link.get.useQuery({ id: parseInt(linkId) });
+
   const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     const formData = new FormData(e.currentTarget);
@@ -47,11 +50,17 @@ export default function VerifyPasswordPage({ params }: VerifyPasswordPageProps) 
     router.push(result.url!);
   };
 
+  // Determine what to display based on domain
+  const getDisplayTitle = () => {
+    if (!linkData?.domain) return "iShortn";
+    return linkData.domain === "ishortn.ink" ? "iShortn" : linkData.domain;
+  };
+
   return (
     <div
       className={`flex h-screen flex-col items-center justify-center ${satoshi.className}`}
     >
-      <h1 className="mb-10 text-4xl font-bold">iShortn</h1>
+      <h1 className="mb-10 text-4xl font-bold">{getDisplayTitle()}</h1>
 
       <h1 className="text-2xl font-bold">This link is password protected</h1>
       <form


### PR DESCRIPTION
# Description

This PR updates the password-protected link verification pages to dynamically display the custom domain name instead of the hardcoded "iShortn" label when a custom domain is in use.

Previously, both `verify-password/[linkId]/page.tsx` and `[linkAlias]/link-password-verification.tsx` displayed "iShortn" for all links. This change fetches the link's domain information and, if a custom domain is present and not `ishortn.ink`, it displays the custom domain. This improves branding consistency for users utilizing custom domains.

Fixes # (issue)

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
- [ ] This change requires installing new dependencies