### PR TITLE
fix(domains): hide add domain button for non-admin team members

### DIFF
--- a/content/changelogs/2026-01-04-domain-sharing.md
+++ b/content/changelogs/2026-01-04-domain-sharing.md
@@ -44,4 +44,4 @@ When you remove a domain from a workspace, only that workspace loses access. Oth
 
 ## Who can use this?
 
-Domain sharing is available to all users with custom domain access. Manage your domains at [/dashboard/domains](/dashboard/domains).
+Domain sharing is available to all users with custom domain access. In team workspaces, only **owners and admins** can add domains—team members can use existing domains but cannot add new ones. Manage your domains at [/dashboard/domains](/dashboard/domains).

--- a/src/app/(main)/dashboard/domains/_components/add-domain-modal.tsx
+++ b/src/app/(main)/dashboard/domains/_components/add-domain-modal.tsx
@@ -23,6 +23,7 @@ import { api } from "@/trpc/react";
 
 export function AddCustomDomainModal() {
   const { data: userSubscription } = api.subscriptions.get.useQuery();
+  const { data: workspace } = api.team.currentWorkspace.useQuery();
 
   const [domain, setDomain] = useState("");
   const [isOpen, setIsOpen] = useState(false);
@@ -72,6 +73,17 @@ export function AddCustomDomainModal() {
   };
 
   const isProUser = userSubscription?.subscriptions?.status === "active";
+
+  // In team workspaces, only owners and admins can add domains
+  const canAddDomains =
+    workspace?.type === "personal" ||
+    (workspace?.type === "team" &&
+      (workspace.role === "owner" || workspace.role === "admin"));
+
+  // Don't render anything if user lacks permission in a team workspace
+  if (workspace?.type === "team" && !canAddDomains) {
+    return null;
+  }
 
   return (
     <Dialog open={isOpen} onOpenChange={setIsOpen}>


### PR DESCRIPTION
## Summary

Hide the "Add Domain" button for team members who don't have permission to add domains. Only owners and admins can add domains in team workspaces.

## Changes

- Add permission check in `AddCustomDomainModal` to hide button for team members
- Update domain sharing changelog to clarify owner/admin-only domain addition

## Type of Change

- [x] fix: Bug fix

## Testing

- Verified TypeScript compiles without errors
- The backend already enforces this permission; this change makes the UI consistent

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Domain sharing in team workspaces now enforces role-based permissions. Only workspace owners and administrators can add new domains. Team members can continue to use existing domains but cannot add new ones. Documentation has been updated to clarify these permission requirements.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->