### PR TITLE
fix(qr): replace qrcode.react with custom generator in QR modal

### DIFF
--- a/src/app/(main)/dashboard/_components/links/link-card/qrcode-modal.tsx
+++ b/src/app/(main)/dashboard/_components/links/link-card/qrcode-modal.tsx
@@ -1,5 +1,6 @@
-import QRCode from "qrcode.react";
-import { useRef } from "react";
+"use client";
+
+import { useCallback, useEffect, useRef } from "react";
 
 import { Button } from "@/components/ui/button";
 import {
@@ -11,6 +12,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
+import { generateQRCode, defaultGeneratorState } from "@/lib/qr-generator";
 
 type QRCodeModalProps = {
   open: boolean;
@@ -23,20 +25,52 @@ export function QRCodeModal({
   setOpen,
   destinationUrl,
 }: QRCodeModalProps) {
-  const qrCodeCanvasRef = useRef(null);
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+
+  const renderQRCode = useCallback(async () => {
+    if (!canvasRef.current || !destinationUrl) return;
+
+    try {
+      await generateQRCode(canvasRef.current, {
+        ...defaultGeneratorState(),
+        text: destinationUrl,
+        scale: 10,
+        margin: 2,
+      });
+    } catch (error) {
+      console.error("[QR:modal] Failed to generate QR code:", error);
+    }
+  }, [destinationUrl]);
+
+  useEffect(() => {
+    if (open) {
+      // Small delay to ensure canvas is mounted in the dialog
+      const timer = setTimeout(renderQRCode, 50);
+      return () => clearTimeout(timer);
+    }
+  }, [open, renderQRCode]);
 
   const handleQRCodeDownload = () => {
-    if (!destinationUrl) return;
-    const canvas = document.getElementById("qr-gen") as HTMLCanvasElement;
-    const pngUrl = canvas
-      .toDataURL("image/png")
-      .replace("image/png", "image/octet-stream");
-    const downloadLink = document.createElement("a");
-    downloadLink.href = pngUrl;
-    downloadLink.download = "qrcode.png";
-    document.body.appendChild(downloadLink);
-    downloadLink.click();
-    document.body.removeChild(downloadLink);
+    if (!canvasRef.current || !destinationUrl) return;
+
+    // Generate a high-quality version for download
+    const downloadCanvas = document.createElement("canvas");
+    generateQRCode(downloadCanvas, {
+      ...defaultGeneratorState(),
+      text: destinationUrl,
+      scale: 20,
+      margin: 2,
+    }).then(() => {
+      const pngUrl = downloadCanvas
+        .toDataURL("image/png")
+        .replace("image/png", "image/octet-stream");
+      const downloadLink = document.createElement("a");
+      downloadLink.href = pngUrl;
+      downloadLink.download = "qrcode.png";
+      document.body.appendChild(downloadLink);
+      downloadLink.click();
+      document.body.removeChild(downloadLink);
+    });
   };
 
   return (
@@ -51,14 +85,17 @@ export function QRCodeModal({
 
         <DialogBody className="flex justify-center">
           <div className="rounded-lg border border-border bg-white p-2">
-            <QRCode
-              id="qr-gen"
-              value={destinationUrl}
-              size={240}
-              level={"H"}
-              includeMargin={true}
-              ref={qrCodeCanvasRef}
-            />
+            {destinationUrl ? (
+              <canvas
+                ref={canvasRef}
+                className="block"
+                style={{ width: "240px", height: "240px" }}
+              />
+            ) : (
+              <div className="flex h-[240px] w-[240px] items-center justify-center text-sm text-gray-400">
+                No URL provided
+              </div>
+            )}
           </div>
         </DialogBody>
 

--- a/src/app/(main)/dashboard/_components/links/link-card/qrcode-modal.tsx
+++ b/src/app/(main)/dashboard/_components/links/link-card/qrcode-modal.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useCallback, useEffect, useRef } from "react";
+import { toast } from "sonner";
 
 import { Button } from "@/components/ui/button";
 import {
@@ -50,17 +51,19 @@ export function QRCodeModal({
     }
   }, [open, renderQRCode]);
 
-  const handleQRCodeDownload = () => {
+  const handleQRCodeDownload = async () => {
     if (!canvasRef.current || !destinationUrl) return;
 
-    // Generate a high-quality version for download
-    const downloadCanvas = document.createElement("canvas");
-    generateQRCode(downloadCanvas, {
-      ...defaultGeneratorState(),
-      text: destinationUrl,
-      scale: 20,
-      margin: 2,
-    }).then(() => {
+    try {
+      // Generate a high-quality version for download
+      const downloadCanvas = document.createElement("canvas");
+      await generateQRCode(downloadCanvas, {
+        ...defaultGeneratorState(),
+        text: destinationUrl,
+        scale: 20,
+        margin: 2,
+      });
+
       const pngUrl = downloadCanvas
         .toDataURL("image/png")
         .replace("image/png", "image/octet-stream");
@@ -70,7 +73,10 @@ export function QRCodeModal({
       document.body.appendChild(downloadLink);
       downloadLink.click();
       document.body.removeChild(downloadLink);
-    });
+    } catch (error) {
+      console.error("[QR:modal] Failed to download QR code:", error);
+      toast.error("Failed to download QR code");
+    }
   };
 
   return (


### PR DESCRIPTION
## Summary

The QR code modal (opened from link card actions) rendered a blank canvas because `qrcode.react` v3.2.0 is incompatible with React 19. React 19 passes `ref` as a regular prop, which overwrites the library's internal canvas ref and prevents drawing.

## Changes

- Replace `qrcode.react` dependency with the custom `generateQRCode` from `@/lib/qr-generator` in the QR code modal
- Generate high-quality (scale 20) QR codes for downloads
- Add fallback UI when no destination URL is provided

## Type of Change

- [x] fix: Bug fix

## Testing

- Open a link card's action menu and click "QR code"
- Verify the QR code renders in the modal
- Verify the download button produces a valid high-resolution QR code PNG

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * High-quality QR download: save QR images at improved resolution.

* **Improvements**
  * Faster, more reliable QR rendering when the modal opens.
  * Clear placeholder shown when no URL is provided.
  * Improved error handling with user-friendly messages on download or generation failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->