### PR TITLE
fix(links): enforce disableLinkAfterClicks and disableLinkAfterDate in redirect path

### DIFF
--- a/src/app/(main)/[linkAlias]/page.tsx
+++ b/src/app/(main)/[linkAlias]/page.tsx
@@ -98,6 +98,14 @@ const LinkRedirectionPage = async (props: LinkRedirectionPageProps) => {
 
   if (!link) return notFound();
 
+  // Check link expiration (disabled flag and date-based)
+  if (link.disabled) {
+    redirect(`/expired/${link.id}`);
+  }
+  if (link.disableLinkAfterDate && new Date() >= link.disableLinkAfterDate) {
+    redirect(`/expired/${link.id}`);
+  }
+
   if (link.passwordHash) {
     return <LinkPasswordVerification id={link.id} />;
   }

--- a/src/app/(main)/expired/[linkId]/page.tsx
+++ b/src/app/(main)/expired/[linkId]/page.tsx
@@ -1,11 +1,11 @@
 import { IconClockOff } from "@tabler/icons-react";
-import { eq } from "drizzle-orm";
+import { count, eq } from "drizzle-orm";
 import { Funnel_Sans } from "next/font/google";
 import { notFound } from "next/navigation";
 
 import { cn } from "@/lib/utils";
 import { db } from "@/server/db";
-import { link } from "@/server/db/schema";
+import { link, linkVisit } from "@/server/db/schema";
 
 const funnelSans = Funnel_Sans({
   subsets: ["latin"],
@@ -33,11 +33,30 @@ export default async function ExpiredPage({ params }: ExpiredPageProps) {
     notFound();
   }
 
+  // Determine which expiration condition is active
+  const dateExpired =
+    linkRecord.disableLinkAfterDate != null &&
+    new Date(linkRecord.disableLinkAfterDate) <= new Date();
+
+  let clicksExpired = false;
+  if (linkRecord.disableLinkAfterClicks != null) {
+    const result = await db
+      .select({ clickCount: count(linkVisit.id) })
+      .from(linkVisit)
+      .where(eq(linkVisit.linkId, linkRecord.id));
+    clicksExpired =
+      (result[0]?.clickCount ?? 0) >= linkRecord.disableLinkAfterClicks;
+  }
+
+  if (!linkRecord.disabled && !dateExpired && !clicksExpired) {
+    notFound();
+  }
+
   let reason: string;
 
-  if (linkRecord.disableLinkAfterDate) {
+  if (dateExpired) {
     reason = "This link has expired and is no longer accepting visits.";
-  } else if (linkRecord.disableLinkAfterClicks) {
+  } else if (clicksExpired) {
     reason = "This link has reached its maximum number of visits and is no longer accessible.";
   } else {
     reason = "This link has been deactivated by its owner.";

--- a/src/app/(main)/expired/[linkId]/page.tsx
+++ b/src/app/(main)/expired/[linkId]/page.tsx
@@ -1,0 +1,79 @@
+import { IconClockOff } from "@tabler/icons-react";
+import { eq } from "drizzle-orm";
+import { Funnel_Sans } from "next/font/google";
+import { notFound } from "next/navigation";
+
+import { cn } from "@/lib/utils";
+import { db } from "@/server/db";
+import { link } from "@/server/db/schema";
+
+const funnelSans = Funnel_Sans({
+  subsets: ["latin"],
+  weight: ["400", "700"],
+});
+
+interface ExpiredPageProps {
+  params: Promise<{ linkId: string }>;
+}
+
+export default async function ExpiredPage({ params }: ExpiredPageProps) {
+  const { linkId } = await params;
+
+  const linkRecord = await db.query.link.findFirst({
+    where: eq(link.id, Number(linkId)),
+    columns: {
+      id: true,
+      disabled: true,
+      disableLinkAfterDate: true,
+      disableLinkAfterClicks: true,
+    },
+  });
+
+  if (!linkRecord) {
+    notFound();
+  }
+
+  let reason: string;
+
+  if (linkRecord.disableLinkAfterDate) {
+    reason = "This link has expired and is no longer accepting visits.";
+  } else if (linkRecord.disableLinkAfterClicks) {
+    reason = "This link has reached its maximum number of visits and is no longer accessible.";
+  } else {
+    reason = "This link has been deactivated by its owner.";
+  }
+
+  return (
+    <div
+      className={cn(
+        "flex min-h-screen items-center justify-center bg-neutral-50 px-4",
+        funnelSans.className,
+      )}
+    >
+      <div className="w-full max-w-md text-center">
+        <div className="mx-auto mb-6 flex h-12 w-12 items-center justify-center rounded-full bg-amber-50">
+          <IconClockOff size={24} stroke={1.5} className="text-amber-600" />
+        </div>
+        <h1 className="text-xl font-semibold tracking-tight text-neutral-900">
+          Link Expired
+        </h1>
+        <p className="mt-2 text-[13px] leading-relaxed text-neutral-500">
+          The link you are trying to visit is no longer active.
+        </p>
+        <div className="mt-5 rounded-lg border border-neutral-200 bg-white px-4 py-3">
+          <p className="text-[12px] font-medium text-neutral-400">Details</p>
+          <p className="mt-1 text-[13px] text-neutral-700">{reason}</p>
+        </div>
+        <p className="mt-6 text-[12px] text-neutral-400">
+          If you believe this is a mistake, please contact the link owner or{" "}
+          <a
+            href="mailto:support@ishortn.ink"
+            className="text-neutral-600 underline underline-offset-2"
+          >
+            support@ishortn.ink
+          </a>
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/src/app/api/link/route.ts
+++ b/src/app/api/link/route.ts
@@ -1,7 +1,10 @@
-import { asc, eq } from "drizzle-orm";
+import { asc, count, eq } from "drizzle-orm";
 import type { NextRequest } from "next/server";
 
 import {
+  type Link,
+  buildCacheKey,
+  deleteFromCache,
   getGeoRulesFromCache,
   setGeoRulesInCache,
 } from "@/lib/core/cache";
@@ -11,7 +14,53 @@ import {
   recordUserClickWithGeoRule,
 } from "@/middlewares/record-click";
 import { db } from "@/server/db";
-import { geoRule } from "@/server/db/schema";
+import { geoRule, link as linkTable, linkVisit } from "@/server/db/schema";
+
+/** Fire-and-forget: mark a link as disabled in the DB and purge its cache entry. */
+function autoDisableLink(linkId: number, cacheKey: string): void {
+  void db
+    .update(linkTable)
+    .set({ disabled: true })
+    .where(eq(linkTable.id, linkId))
+    .then(() => deleteFromCache(cacheKey))
+    .catch((err) => console.error("Failed to auto-disable link:", err));
+}
+
+/**
+ * Check if a link has expired by date, click threshold, or manual disable.
+ * When a threshold is crossed, auto-disables the link in the DB and invalidates the cache.
+ */
+async function checkLinkExpiration(
+  link: Link,
+  cacheKey: string,
+): Promise<boolean> {
+  if (link.disabled) {
+    return true;
+  }
+
+  // Date-based expiration
+  if (link.disableLinkAfterDate && new Date() >= link.disableLinkAfterDate) {
+    autoDisableLink(link.id, cacheKey);
+    return true;
+  }
+
+  // Click-based expiration
+  if (link.disableLinkAfterClicks) {
+    const result = await db
+      .select({ clickCount: count(linkVisit.id) })
+      .from(linkVisit)
+      .where(eq(linkVisit.linkId, link.id));
+
+    const clickCount = result[0]?.clickCount ?? 0;
+
+    if (clickCount >= link.disableLinkAfterClicks) {
+      autoDisableLink(link.id, cacheKey);
+      return true;
+    }
+  }
+
+  return false;
+}
 
 type UtmParams = {
   utm_source?: string;
@@ -84,16 +133,22 @@ export async function GET(request: NextRequest) {
 
     console.log("Link found:", link);
 
+    const baseUrl = request.url.split("/api/link")[0];
+    const cacheKey = buildCacheKey(domain, alias);
+
     // Redirect to blocked page for admin-blocked links
     if (link.blocked) {
-      const baseUrl = request.url.split("/api/link")[0];
       return Response.json({ url: `${baseUrl}/blocked/${link.id}` });
+    }
+
+    // Check link expiration (disabled, date-based, click-based)
+    if (await checkLinkExpiration(link, cacheKey)) {
+      return Response.json({ url: `${baseUrl}/expired/${link.id}` });
     }
 
     // Redirect to password verification page for protected links
     if (link.passwordHash) {
-      const verifyUrl = `${request.url.split("/api/link")[0]}/verify-password/${link.id}`;
-      return Response.json({ url: verifyUrl });
+      return Response.json({ url: `${baseUrl}/verify-password/${link.id}` });
     }
 
     // Fetch geo rules (cache first, then DB)
@@ -115,7 +170,6 @@ export async function GET(request: NextRequest) {
 
     if (geoResult.matched) {
       if (geoResult.action === "block") {
-        const baseUrl = request.url.split('/api/link')[0];
         const geoParam = geoResult.ruleId ? `?geo=${geoResult.ruleId}` : "";
         return Response.json({ url: `${baseUrl}/blocked/${link.id}${geoParam}` });
       }

--- a/src/lib/core/cache/index.ts
+++ b/src/lib/core/cache/index.ts
@@ -233,7 +233,20 @@ async function deleteGeoRulesFromCache(linkId: number): Promise<boolean> {
   }
 }
 
+/** Normalize a raw domain by stripping protocol, www prefix, and mapping localhost to default. */
+function normalizeDomain(domain: string): string {
+  const cleaned = domain.replace(/^https?:\/\//, "").replace(/^www\./, "");
+  return domain.includes("localhost") ? "ishortn.ink" : cleaned;
+}
+
+/** Build a Redis cache key from a raw (possibly protocol-prefixed) domain and alias. */
+function buildCacheKey(domain: string, alias: string): string {
+  return `${normalizeDomain(domain)}:${alias}`;
+}
+
 export {
+  buildCacheKey,
+  normalizeDomain,
   deleteFromCache,
   deleteGeoRulesFromCache,
   getFromCache,

--- a/src/lib/core/cache/index.ts
+++ b/src/lib/core/cache/index.ts
@@ -241,7 +241,7 @@ function normalizeDomain(domain: string): string {
 
 /** Build a Redis cache key from a raw (possibly protocol-prefixed) domain and alias. */
 function buildCacheKey(domain: string, alias: string): string {
-  return `${normalizeDomain(domain)}:${alias}`;
+  return `${normalizeDomain(domain)}:${alias.toLowerCase()}`;
 }
 
 export {

--- a/src/middlewares/record-click.ts
+++ b/src/middlewares/record-click.ts
@@ -3,7 +3,7 @@ import { waitUntil } from "@vercel/functions";
 import { sql } from "drizzle-orm";
 import { UAParser } from "ua-parser-js";
 
-import { type Link, getFromCache, setInCache } from "@/lib/core/cache";
+import { type Link, buildCacheKey, normalizeDomain, getFromCache, setInCache } from "@/lib/core/cache";
 import { getContinentName, getCountryFullName } from "@/lib/countries";
 import { isBot } from "@/lib/utils/is-bot";
 import { db } from "@/server/db";
@@ -150,8 +150,7 @@ export async function recordUserClickForLink(
   continent: string,
   skipAnalytics = false,
 ) {
-  const cleanedDomain = domain.replace(/^https?:\/\//, "").replace(/^www\./, "");
-  const cacheKey = `${domain.includes("localhost") ? "ishortn.ink" : cleanedDomain}:${alias}`;
+  const cacheKey = buildCacheKey(domain, alias);
   const cachedLink: Link | null = await getFromCache(cacheKey);
 
   if (cachedLink) {
@@ -164,7 +163,7 @@ export async function recordUserClickForLink(
   const link = await db.query.link.findFirst({
     where: (table, { and, eq }) =>
       and(
-        eq(table.domain, domain.includes("localhost") ? "ishortn.ink" : cleanedDomain),
+        eq(table.domain, normalizeDomain(domain)),
         sql`lower(${table.alias}) = lower(${alias.replace("/", "")})`,
       ),
   });
@@ -240,12 +239,7 @@ export async function recordUserClickWithGeoRule(
   continent: string,
   matchedGeoRuleId: number
 ) {
-  const cleanedDomain = domain
-    .replace(/^https?:\/\//, "")
-    .replace(/^www\./, "");
-  const cacheKey = `${
-    domain.includes("localhost") ? "ishortn.ink" : cleanedDomain
-  }:${alias}`;
+  const cacheKey = buildCacheKey(domain, alias);
   const cachedLink: Link | null = await getFromCache(cacheKey);
 
   if (cachedLink) {
@@ -267,10 +261,7 @@ export async function recordUserClickWithGeoRule(
   const link = await db.query.link.findFirst({
     where: (table, { and, eq }) =>
       and(
-        eq(
-          table.domain,
-          domain.includes("localhost") ? "ishortn.ink" : cleanedDomain
-        ),
+        eq(table.domain, normalizeDomain(domain)),
         sql`lower(${table.alias}) = lower(${alias.replace("/", "")})`
       ),
   });

--- a/src/server/api/routers/admin/admin.service.ts
+++ b/src/server/api/routers/admin/admin.service.ts
@@ -1,6 +1,6 @@
 import { and, count, desc, eq, like, or, sql } from "drizzle-orm";
 
-import { deleteFromCache } from "@/lib/core/cache";
+import { buildCacheKey, deleteFromCache } from "@/lib/core/cache";
 import {
   blockedDomain,
   flaggedLink,
@@ -177,7 +177,7 @@ export async function blockLink(
     .where(eq(link.id, input.linkId));
 
   // Invalidate cache so the blocked status takes effect immediately
-  await deleteFromCache(`${linkRecord.domain}:${linkRecord.alias}`);
+  await deleteFromCache(buildCacheKey(linkRecord.domain, linkRecord.alias!));
 }
 
 export async function unblockLink(
@@ -202,7 +202,7 @@ export async function unblockLink(
     })
     .where(eq(link.id, input.linkId));
 
-  await deleteFromCache(`${linkRecord.domain}:${linkRecord.alias}`);
+  await deleteFromCache(buildCacheKey(linkRecord.domain, linkRecord.alias!));
 }
 
 export async function searchUsers(
@@ -294,7 +294,7 @@ export async function banUser(
   // Invalidate cache after commit
   if (userLinks.length > 0) {
     await Promise.all(
-      userLinks.map((l) => deleteFromCache(`${l.domain}:${l.alias}`)),
+      userLinks.map((l) => deleteFromCache(buildCacheKey(l.domain, l.alias!))),
     );
   }
 }
@@ -345,7 +345,7 @@ export async function unbanUser(
   // Invalidate cache after commit
   if (bannedLinks.length > 0) {
     await Promise.all(
-      bannedLinks.map((l) => deleteFromCache(`${l.domain}:${l.alias}`)),
+      bannedLinks.map((l) => deleteFromCache(buildCacheKey(l.domain, l.alias!))),
     );
   }
 }

--- a/src/server/api/routers/link/link.service.ts
+++ b/src/server/api/routers/link/link.service.ts
@@ -24,6 +24,7 @@ import {
 import { assertUrlSafe } from "@/server/lib/phishing";
 import { retrieveDeviceAndGeolocationData } from "@/lib/core/analytics";
 import {
+  buildCacheKey,
   deleteFromCache,
   deleteGeoRulesFromCache,
   getFromCache,
@@ -74,10 +75,6 @@ import type {
   ToggleArchiveInput,
   UpdateLinkInput,
 } from "./link.input";
-
-function constructCacheKey(domain: string, alias: string) {
-  return `${domain}:${alias}`;
-}
 
 export const getLinks = async (
   ctx: WorkspaceTRPCContext,
@@ -654,12 +651,12 @@ export const updateLink = async (
     existingLink.domain !== updatedLink.domain
   ) {
     await deleteFromCache(
-      constructCacheKey(existingLink.domain, existingLink.alias!),
+      buildCacheKey(existingLink.domain, existingLink.alias!),
     );
   }
   // Always set the new cache entry with updated values
   await setInCache(
-    constructCacheKey(updatedLink.domain, updatedLink.alias!),
+    buildCacheKey(updatedLink.domain, updatedLink.alias!),
     updatedLinkWithTags,
   );
 };
@@ -696,7 +693,7 @@ export const deleteLink = async (
 
   await Promise.all([
     deleteFromCache(
-      constructCacheKey(linkToDelete.domain, linkToDelete.alias!),
+      buildCacheKey(linkToDelete.domain, linkToDelete.alias!),
     ),
     ctx.db
       .delete(link)
@@ -788,7 +785,7 @@ export const bulkDeleteLinks = async (
   // Invalidate cache for all deleted links (async, don't block)
   void Promise.all(
     linksToDelete.map((l) =>
-      deleteFromCache(constructCacheKey(l.domain, l.alias!)),
+      deleteFromCache(buildCacheKey(l.domain, l.alias!)),
     ),
   ).catch((err) => {
     console.error("Failed to invalidate cache for deleted links:", err);
@@ -906,7 +903,7 @@ export const bulkToggleLinkStatus = async (
   await Promise.all(
     linksToUpdate
       .filter((l) => l.alias)
-      .map((l) => deleteFromCache(constructCacheKey(l.domain, l.alias!))),
+      .map((l) => deleteFromCache(buildCacheKey(l.domain, l.alias!))),
   );
 
   return { success: true, count: linksToUpdate.length, disabled: disable };
@@ -917,7 +914,7 @@ export const retrieveOriginalUrl = async (
   input: RetrieveOriginalUrlInput,
 ) => {
   const { alias, domain } = input;
-  const cacheKey = `${domain}:${alias}`;
+  const cacheKey = buildCacheKey(domain, alias);
 
   let link: Link | undefined | null = await getFromCache(cacheKey);
 
@@ -934,7 +931,7 @@ export const retrieveOriginalUrl = async (
       return null;
     }
 
-    await setInCache(`${link.domain}:${link.alias}`, link);
+    await setInCache(buildCacheKey(link.domain, link.alias!), link);
   }
 
   // waitUntil(logAnalytics(ctx, link, input.from));
@@ -1390,7 +1387,7 @@ export const toggleLinkStatus = async (
   // Invalidate cache so the status change takes effect immediately
   if (fetchedLink.alias) {
     await deleteFromCache(
-      constructCacheKey(fetchedLink.domain, fetchedLink.alias),
+      buildCacheKey(fetchedLink.domain, fetchedLink.alias),
     );
   }
 
@@ -1489,7 +1486,7 @@ export const changeLinkPassword = async (
   });
 
   await deleteFromCache(
-    constructCacheKey(updatedLink!.domain, updatedLink!.alias!),
+    buildCacheKey(updatedLink!.domain, updatedLink!.alias!),
   );
 
   return updatedLink;
@@ -1620,7 +1617,7 @@ export const toggleArchive = async (
   // Invalidate cache if necessary (if the link was cached)
   // Consider if archived links should be cached differently or not at all
   // For simplicity, let's remove it for now
-  // await deleteFromCache(constructCacheKey(link.domain, link.alias)); // Need domain/alias
+  // await deleteFromCache(buildCacheKey(link.domain, link.alias)); // Need domain/alias
 
   return { success: true, archived: newArchivedStatus };
 };

--- a/src/server/api/routers/link/link.service.ts
+++ b/src/server/api/routers/link/link.service.ts
@@ -902,6 +902,13 @@ export const bulkToggleLinkStatus = async (
     .set({ disabled: disable })
     .where(inArray(link.id, validLinkIds));
 
+  // Invalidate cache for all affected links
+  await Promise.all(
+    linksToUpdate
+      .filter((l) => l.alias)
+      .map((l) => deleteFromCache(constructCacheKey(l.domain, l.alias!))),
+  );
+
   return { success: true, count: linksToUpdate.length, disabled: disable };
 };
 
@@ -1368,7 +1375,7 @@ export const toggleLinkStatus = async (
     return null;
   }
 
-  return ctx.db
+  const result = await ctx.db
     .update(link)
     .set({
       disabled: !fetchedLink.disabled,
@@ -1379,6 +1386,15 @@ export const toggleLinkStatus = async (
         workspaceFilter(ctx.workspace, link.userId, link.teamId),
       ),
     );
+
+  // Invalidate cache so the status change takes effect immediately
+  if (fetchedLink.alias) {
+    await deleteFromCache(
+      constructCacheKey(fetchedLink.domain, fetchedLink.alias),
+    );
+  }
+
+  return result;
 };
 
 export const resetLinkStatistics = async (

--- a/src/server/api/routers/qrcode/qrcode.service.ts
+++ b/src/server/api/routers/qrcode/qrcode.service.ts
@@ -1,7 +1,7 @@
 import { TRPCError } from "@trpc/server";
 import { and, count, eq, inArray, sql } from "drizzle-orm";
 
-import { deleteFromCache } from "@/lib/core/cache";
+import { buildCacheKey, deleteFromCache } from "@/lib/core/cache";
 import { generateShortLink } from "@/lib/core/links";
 import { assertUrlSafe } from "@/server/lib/phishing";
 import { link, linkVisit, qrcode, qrPreset, uniqueLinkVisit } from "@/server/db/schema";
@@ -212,7 +212,7 @@ export async function deleteQrCode(ctx: WorkspaceTRPCContext, id: number) {
       where: eq(link.id, qrCode.linkId),
     });
     if (hiddenLink?.alias) {
-      cacheKey = `${hiddenLink.domain}:${hiddenLink.alias}`;
+      cacheKey = buildCacheKey(hiddenLink.domain, hiddenLink.alias);
     }
   }
 


### PR DESCRIPTION
## Summary

The `disableLinkAfterClicks`, `disableLinkAfterDate`, and `disabled` fields existed in the schema
but were never checked during redirects. Links that should have been dead were still serving
redirects. This PR adds enforcement in both redirect paths and fixes related cache invalidation gaps.

## Changes

- Add expiration checks (disabled, date-based, click-based) to the primary redirect API route
- Add expiration checks (disabled, date-based) to the server-rendered page path (bot/fallback)
- Auto-disable links in the DB when a threshold is crossed so subsequent requests short-circuit
- Fix `toggleLinkStatus` and `bulkToggleLinkStatus` not invalidating the Redis cache (24h TTL)
- Add dedicated `/expired/[linkId]` page with appropriate messaging
- Extract `normalizeDomain` and `buildCacheKey` utilities to eliminate 4x duplication

## Type of Change

- [x] fix: Bug fix

## Testing

- Type-checked with `tsc --noEmit` (clean build)
- Manual review of all redirect code paths confirmed expiration checks are in place

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Links can now auto-expire by date or after a maximum click count.
  * Expired links show a new "Link Expired" page with the expiration reason (date, visit limit, or deactivated) and contact info.
  * Expiration is checked during redirection so expired/disabled links immediately lead to the expired page.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->