### PR TITLE
fix(analytics): close team link cleanup gap and preserve historical data with daily summaries

### DIFF
--- a/drizzle/0052_dry_lily_hollister.sql
+++ b/drizzle/0052_dry_lily_hollister.sql
@@ -1,0 +1,11 @@
+CREATE TABLE `LinkVisitDailySummary` (
+	`id` serial AUTO_INCREMENT NOT NULL,
+	`linkId` int NOT NULL,
+	`date` date NOT NULL,
+	`clicks` int NOT NULL DEFAULT 0,
+	`uniqueClicks` int NOT NULL DEFAULT 0,
+	CONSTRAINT `LinkVisitDailySummary_id` PRIMARY KEY(`id`),
+	CONSTRAINT `link_date_unique` UNIQUE(`linkId`,`date`)
+);
+--> statement-breakpoint
+ALTER TABLE `Token` MODIFY COLUMN `token` varchar(255);

--- a/drizzle/meta/0052_snapshot.json
+++ b/drizzle/meta/0052_snapshot.json
@@ -1,0 +1,2499 @@
+{
+  "version": "5",
+  "dialect": "mysql",
+  "id": "2943b25f-8efb-495d-ab6f-0d7b0d96f51a",
+  "prevId": "9c7f2515-7626-4711-b16c-f69b39e64140",
+  "tables": {
+    "AccountTransfer": {
+      "name": "AccountTransfer",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "fromUserId": {
+          "name": "fromUserId",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "toEmail": {
+          "name": "toEmail",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "toUserId": {
+          "name": "toUserId",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "enum('pending','accepted','cancelled','expired','declined')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "linksCount": {
+          "name": "linksCount",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "customDomainsCount": {
+          "name": "customDomainsCount",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "qrCodesCount": {
+          "name": "qrCodesCount",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "foldersCount": {
+          "name": "foldersCount",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "tagsCount": {
+          "name": "tagsCount",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "utmTemplatesCount": {
+          "name": "utmTemplatesCount",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "qrPresetsCount": {
+          "name": "qrPresetsCount",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "acceptedAt": {
+          "name": "acceptedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "fromUser_idx": {
+          "name": "fromUser_idx",
+          "columns": [
+            "fromUserId"
+          ],
+          "isUnique": false
+        },
+        "toEmail_idx": {
+          "name": "toEmail_idx",
+          "columns": [
+            "toEmail"
+          ],
+          "isUnique": false
+        },
+        "status_idx": {
+          "name": "status_idx",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "AccountTransfer_id": {
+          "name": "AccountTransfer_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "AccountTransfer_token_unique": {
+          "name": "AccountTransfer_token_unique",
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "checkConstraint": {}
+    },
+    "BlockedDomain": {
+      "name": "BlockedDomain",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "domain": {
+          "name": "domain",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "createdByUserId": {
+          "name": "createdByUserId",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "BlockedDomain_id": {
+          "name": "BlockedDomain_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "BlockedDomain_domain_unique": {
+          "name": "BlockedDomain_domain_unique",
+          "columns": [
+            "domain"
+          ]
+        }
+      },
+      "checkConstraint": {}
+    },
+    "CustomDomain": {
+      "name": "CustomDomain",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "domain": {
+          "name": "domain",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "teamId": {
+          "name": "teamId",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "status": {
+          "name": "status",
+          "type": "enum('pending','active','invalid')",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "verificationDetails": {
+          "name": "verificationDetails",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "lastReminderSentAt": {
+          "name": "lastReminderSentAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "teamIdForUnique": {
+          "name": "teamIdForUnique",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "generated": {
+            "as": "COALESCE(`teamId`, 0)",
+            "type": "stored"
+          }
+        }
+      },
+      "indexes": {
+        "userId_idx": {
+          "name": "userId_idx",
+          "columns": [
+            "userId"
+          ],
+          "isUnique": false
+        },
+        "teamId_idx": {
+          "name": "teamId_idx",
+          "columns": [
+            "teamId"
+          ],
+          "isUnique": false
+        },
+        "status_createdAt_idx": {
+          "name": "status_createdAt_idx",
+          "columns": [
+            "status",
+            "createdAt"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "CustomDomain_id": {
+          "name": "CustomDomain_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "domain_workspace_unique": {
+          "name": "domain_workspace_unique",
+          "columns": [
+            "domain",
+            "userId",
+            "teamIdForUnique"
+          ]
+        }
+      },
+      "checkConstraint": {}
+    },
+    "FlaggedLink": {
+      "name": "FlaggedLink",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "linkId": {
+          "name": "linkId",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "flagStatus": {
+          "name": "flagStatus",
+          "type": "enum('pending','blocked','dismissed')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "flaggedAt": {
+          "name": "flaggedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "resolvedAt": {
+          "name": "resolvedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "resolvedByUserId": {
+          "name": "resolvedByUserId",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "linkId_idx": {
+          "name": "linkId_idx",
+          "columns": [
+            "linkId"
+          ],
+          "isUnique": false
+        },
+        "status_idx": {
+          "name": "status_idx",
+          "columns": [
+            "flagStatus"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "FlaggedLink_id": {
+          "name": "FlaggedLink_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "Folder": {
+      "name": "Folder",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "teamId": {
+          "name": "teamId",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "isRestricted": {
+          "name": "isRestricted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "onUpdate": true
+        }
+      },
+      "indexes": {
+        "userId_idx": {
+          "name": "userId_idx",
+          "columns": [
+            "userId"
+          ],
+          "isUnique": false
+        },
+        "teamId_idx": {
+          "name": "teamId_idx",
+          "columns": [
+            "teamId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "Folder_id": {
+          "name": "Folder_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "FolderPermission": {
+      "name": "FolderPermission",
+      "columns": {
+        "folderId": {
+          "name": "folderId",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "userId_idx": {
+          "name": "userId_idx",
+          "columns": [
+            "userId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "FolderPermission_folderId_userId_pk": {
+          "name": "FolderPermission_folderId_userId_pk",
+          "columns": [
+            "folderId",
+            "userId"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "GeoRule": {
+      "name": "GeoRule",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "linkId": {
+          "name": "linkId",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "enum('country','continent')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "condition": {
+          "name": "condition",
+          "type": "enum('in','not_in')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'in'"
+        },
+        "values": {
+          "name": "values",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "action": {
+          "name": "action",
+          "type": "enum('redirect','block')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "destination": {
+          "name": "destination",
+          "type": "varchar(2048)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "blockMessage": {
+          "name": "blockMessage",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "priority": {
+          "name": "priority",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "linkId_idx": {
+          "name": "linkId_idx",
+          "columns": [
+            "linkId"
+          ],
+          "isUnique": false
+        },
+        "priority_idx": {
+          "name": "priority_idx",
+          "columns": [
+            "linkId",
+            "priority"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "GeoRule_id": {
+          "name": "GeoRule_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "Link": {
+      "name": "Link",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "alias": {
+          "name": "alias",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "domain": {
+          "name": "domain",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'ishortn.ink'"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "disableLinkAfterClicks": {
+          "name": "disableLinkAfterClicks",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "disableLinkAfterDate": {
+          "name": "disableLinkAfterDate",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "disabled": {
+          "name": "disabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "publicStats": {
+          "name": "publicStats",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "teamId": {
+          "name": "teamId",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdByUserId": {
+          "name": "createdByUserId",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "passwordHash": {
+          "name": "passwordHash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "note": {
+          "name": "note",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "utmParams": {
+          "name": "utmParams",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "('[]')"
+        },
+        "archived": {
+          "name": "archived",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "folderId": {
+          "name": "folderId",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cloaking": {
+          "name": "cloaking",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "isQrCode": {
+          "name": "isQrCode",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "blocked": {
+          "name": "blocked",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "blockedAt": {
+          "name": "blockedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "blockedReason": {
+          "name": "blockedReason",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "userId_idx": {
+          "name": "userId_idx",
+          "columns": [
+            "userId"
+          ],
+          "isUnique": false
+        },
+        "teamId_idx": {
+          "name": "teamId_idx",
+          "columns": [
+            "teamId"
+          ],
+          "isUnique": false
+        },
+        "aliasDomain_idx": {
+          "name": "aliasDomain_idx",
+          "columns": [
+            "alias",
+            "domain"
+          ],
+          "isUnique": false
+        },
+        "folderId_idx": {
+          "name": "folderId_idx",
+          "columns": [
+            "folderId"
+          ],
+          "isUnique": false
+        },
+        "createdAt_idx": {
+          "name": "createdAt_idx",
+          "columns": [
+            "createdAt"
+          ],
+          "isUnique": false
+        },
+        "blocked_blockedAt_idx": {
+          "name": "blocked_blockedAt_idx",
+          "columns": [
+            "blocked",
+            "blockedAt"
+          ],
+          "isUnique": false
+        },
+        "domain_idx": {
+          "name": "domain_idx",
+          "columns": [
+            "domain"
+          ],
+          "isUnique": false
+        },
+        "listing_idx": {
+          "name": "listing_idx",
+          "columns": [
+            "userId",
+            "teamId",
+            "isQrCode",
+            "archived"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "Link_id": {
+          "name": "Link_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "unique_alias_domain": {
+          "name": "unique_alias_domain",
+          "columns": [
+            "alias",
+            "domain"
+          ]
+        }
+      },
+      "checkConstraint": {}
+    },
+    "LinkTag": {
+      "name": "LinkTag",
+      "columns": {
+        "linkId": {
+          "name": "linkId",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tagId": {
+          "name": "tagId",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "tagId_idx": {
+          "name": "tagId_idx",
+          "columns": [
+            "tagId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "LinkTag_linkId_tagId_pk": {
+          "name": "LinkTag_linkId_tagId_pk",
+          "columns": [
+            "linkId",
+            "tagId"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "LinkVisit": {
+      "name": "LinkVisit",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "linkId": {
+          "name": "linkId",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "device": {
+          "name": "device",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "browser": {
+          "name": "browser",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "os": {
+          "name": "os",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "referer": {
+          "name": "referer",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "country": {
+          "name": "country",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "city": {
+          "name": "city",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "continent": {
+          "name": "continent",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'N/A'"
+        },
+        "matchedGeoRuleId": {
+          "name": "matchedGeoRuleId",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "linkId_idx": {
+          "name": "linkId_idx",
+          "columns": [
+            "linkId"
+          ],
+          "isUnique": false
+        },
+        "geoRuleId_idx": {
+          "name": "geoRuleId_idx",
+          "columns": [
+            "matchedGeoRuleId"
+          ],
+          "isUnique": false
+        },
+        "linkId_createdAt_idx": {
+          "name": "linkId_createdAt_idx",
+          "columns": [
+            "linkId",
+            "createdAt"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "LinkVisit_id": {
+          "name": "LinkVisit_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "LinkVisitDailySummary": {
+      "name": "LinkVisitDailySummary",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "linkId": {
+          "name": "linkId",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "clicks": {
+          "name": "clicks",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "uniqueClicks": {
+          "name": "uniqueClicks",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "LinkVisitDailySummary_id": {
+          "name": "LinkVisitDailySummary_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "link_date_unique": {
+          "name": "link_date_unique",
+          "columns": [
+            "linkId",
+            "date"
+          ]
+        }
+      },
+      "checkConstraint": {}
+    },
+    "QrPreset": {
+      "name": "QrPreset",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "teamId": {
+          "name": "teamId",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pixelStyle": {
+          "name": "pixelStyle",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'rounded'"
+        },
+        "markerShape": {
+          "name": "markerShape",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'square'"
+        },
+        "markerInnerShape": {
+          "name": "markerInnerShape",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'auto'"
+        },
+        "darkColor": {
+          "name": "darkColor",
+          "type": "varchar(9)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'#000000'"
+        },
+        "lightColor": {
+          "name": "lightColor",
+          "type": "varchar(9)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'#ffffff'"
+        },
+        "effect": {
+          "name": "effect",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'none'"
+        },
+        "effectRadius": {
+          "name": "effectRadius",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 12
+        },
+        "marginNoise": {
+          "name": "marginNoise",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "marginNoiseRate": {
+          "name": "marginNoiseRate",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'0.5'"
+        },
+        "logoImage": {
+          "name": "logoImage",
+          "type": "longtext",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "logoSize": {
+          "name": "logoSize",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 25
+        },
+        "logoMargin": {
+          "name": "logoMargin",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 4
+        },
+        "logoBorderRadius": {
+          "name": "logoBorderRadius",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 8
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "onUpdate": true
+        }
+      },
+      "indexes": {
+        "userId_idx": {
+          "name": "userId_idx",
+          "columns": [
+            "userId"
+          ],
+          "isUnique": false
+        },
+        "teamId_idx": {
+          "name": "teamId_idx",
+          "columns": [
+            "teamId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "QrPreset_id": {
+          "name": "QrPreset_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "QrCode": {
+      "name": "QrCode",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "qrCode": {
+          "name": "qrCode",
+          "type": "longtext",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "teamId": {
+          "name": "teamId",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "linkId": {
+          "name": "linkId",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "contentType": {
+          "name": "contentType",
+          "type": "enum('link','text')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "patternStyle": {
+          "name": "patternStyle",
+          "type": "enum('square','diamond','star','fluid','rounded','tile','stripe','fluid-line','stripe-column')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "cornerStyle": {
+          "name": "cornerStyle",
+          "type": "enum('circle','circle-diamond','square','square-diamond','rounded-circle','rounded','circle-star')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "color": {
+          "name": "color",
+          "type": "varchar(7)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "userId_idx": {
+          "name": "userId_idx",
+          "columns": [
+            "userId"
+          ],
+          "isUnique": false
+        },
+        "teamId_idx": {
+          "name": "teamId_idx",
+          "columns": [
+            "teamId"
+          ],
+          "isUnique": false
+        },
+        "linkId_idx": {
+          "name": "linkId_idx",
+          "columns": [
+            "linkId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "QrCode_id": {
+          "name": "QrCode_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "SiteSettings": {
+      "name": "SiteSettings",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "teamId": {
+          "name": "teamId",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "defaultDomain": {
+          "name": "defaultDomain",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'ishortn.ink'"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "onUpdate": true
+        }
+      },
+      "indexes": {
+        "userId_idx": {
+          "name": "userId_idx",
+          "columns": [
+            "userId"
+          ],
+          "isUnique": false
+        },
+        "teamId_idx": {
+          "name": "teamId_idx",
+          "columns": [
+            "teamId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "SiteSettings_id": {
+          "name": "SiteSettings_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "Subscription": {
+      "name": "Subscription",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "orderId": {
+          "name": "orderId",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "subscriptionId": {
+          "name": "subscriptionId",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "customerId": {
+          "name": "customerId",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "renewsAt": {
+          "name": "renewsAt",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "endsAt": {
+          "name": "endsAt",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "plan": {
+          "name": "plan",
+          "type": "enum('free','pro','ultra')",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'free'"
+        },
+        "variantId": {
+          "name": "variantId",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "productId": {
+          "name": "productId",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "cardBrand": {
+          "name": "cardBrand",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "cardLastFour": {
+          "name": "cardLastFour",
+          "type": "varchar(4)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "''"
+        }
+      },
+      "indexes": {
+        "userId_idx": {
+          "name": "userId_idx",
+          "columns": [
+            "userId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "Subscription_id": {
+          "name": "Subscription_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "Subscription_userId_unique": {
+          "name": "Subscription_userId_unique",
+          "columns": [
+            "userId"
+          ]
+        }
+      },
+      "checkConstraint": {}
+    },
+    "Tag": {
+      "name": "Tag",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "teamId": {
+          "name": "teamId",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "name_idx": {
+          "name": "name_idx",
+          "columns": [
+            "name"
+          ],
+          "isUnique": false
+        },
+        "userId_idx": {
+          "name": "userId_idx",
+          "columns": [
+            "userId"
+          ],
+          "isUnique": false
+        },
+        "teamId_idx": {
+          "name": "teamId_idx",
+          "columns": [
+            "teamId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "Tag_id": {
+          "name": "Tag_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "unique_tag_team": {
+          "name": "unique_tag_team",
+          "columns": [
+            "name",
+            "teamId"
+          ]
+        }
+      },
+      "checkConstraint": {}
+    },
+    "Team": {
+      "name": "Team",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "avatarUrl": {
+          "name": "avatarUrl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "defaultDomain": {
+          "name": "defaultDomain",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'ishortn.ink'"
+        },
+        "ownerId": {
+          "name": "ownerId",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "onUpdate": true
+        },
+        "deletedAt": {
+          "name": "deletedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "ownerId_idx": {
+          "name": "ownerId_idx",
+          "columns": [
+            "ownerId"
+          ],
+          "isUnique": false
+        },
+        "deletedAt_idx": {
+          "name": "deletedAt_idx",
+          "columns": [
+            "deletedAt"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "Team_id": {
+          "name": "Team_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "Team_slug_unique": {
+          "name": "Team_slug_unique",
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "checkConstraint": {}
+    },
+    "TeamInvite": {
+      "name": "TeamInvite",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "teamId": {
+          "name": "teamId",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "inviteRole": {
+          "name": "inviteRole",
+          "type": "enum('admin','member')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'member'"
+        },
+        "token": {
+          "name": "token",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "invitedBy": {
+          "name": "invitedBy",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "acceptedAt": {
+          "name": "acceptedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "team_idx": {
+          "name": "team_idx",
+          "columns": [
+            "teamId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "TeamInvite_id": {
+          "name": "TeamInvite_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "TeamInvite_token_unique": {
+          "name": "TeamInvite_token_unique",
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "checkConstraint": {}
+    },
+    "TeamMember": {
+      "name": "TeamMember",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "teamId": {
+          "name": "teamId",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "enum('owner','admin','member')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "onUpdate": true
+        }
+      },
+      "indexes": {
+        "team_user_idx": {
+          "name": "team_user_idx",
+          "columns": [
+            "teamId",
+            "userId"
+          ],
+          "isUnique": false
+        },
+        "user_idx": {
+          "name": "user_idx",
+          "columns": [
+            "userId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "TeamMember_id": {
+          "name": "TeamMember_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "unique_team_user": {
+          "name": "unique_team_user",
+          "columns": [
+            "teamId",
+            "userId"
+          ]
+        }
+      },
+      "checkConstraint": {}
+    },
+    "Token": {
+      "name": "Token",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "token": {
+          "name": "token",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "userId_idx": {
+          "name": "userId_idx",
+          "columns": [
+            "userId"
+          ],
+          "isUnique": false
+        },
+        "token_idx": {
+          "name": "token_idx",
+          "columns": [
+            "token"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "Token_id": {
+          "name": "Token_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "UniqueLinkVisit": {
+      "name": "UniqueLinkVisit",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "linkId": {
+          "name": "linkId",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ipHash": {
+          "name": "ipHash",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "linkId_idx": {
+          "name": "linkId_idx",
+          "columns": [
+            "linkId"
+          ],
+          "isUnique": false
+        },
+        "ipHash_idx": {
+          "name": "ipHash_idx",
+          "columns": [
+            "ipHash"
+          ],
+          "isUnique": false
+        },
+        "unique_visit_idx": {
+          "name": "unique_visit_idx",
+          "columns": [
+            "linkId",
+            "ipHash"
+          ],
+          "isUnique": false
+        },
+        "linkId_createdAt_idx": {
+          "name": "linkId_createdAt_idx",
+          "columns": [
+            "linkId",
+            "createdAt"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "UniqueLinkVisit_id": {
+          "name": "UniqueLinkVisit_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "User": {
+      "name": "User",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "imageUrl": {
+          "name": "imageUrl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "qrCodeCount": {
+          "name": "qrCodeCount",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "monthlyLinkCount": {
+          "name": "monthlyLinkCount",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "lastLinkCountReset": {
+          "name": "lastLinkCountReset",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "monthlyEventCount": {
+          "name": "monthlyEventCount",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "lastEventCountReset": {
+          "name": "lastEventCountReset",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "eventUsageAlertLevel": {
+          "name": "eventUsageAlertLevel",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "lastViewedChangelogSlug": {
+          "name": "lastViewedChangelogSlug",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "deletedAt": {
+          "name": "deletedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "isAdmin": {
+          "name": "isAdmin",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "banned": {
+          "name": "banned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "bannedAt": {
+          "name": "bannedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "bannedReason": {
+          "name": "bannedReason",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "deletedAt_idx": {
+          "name": "deletedAt_idx",
+          "columns": [
+            "deletedAt"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "User_id": {
+          "name": "User_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "User_email_unique": {
+          "name": "User_email_unique",
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "checkConstraint": {}
+    },
+    "UtmTemplate": {
+      "name": "UtmTemplate",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "utmSource": {
+          "name": "utmSource",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "utmMedium": {
+          "name": "utmMedium",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "utmCampaign": {
+          "name": "utmCampaign",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "utmTerm": {
+          "name": "utmTerm",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "utmContent": {
+          "name": "utmContent",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "teamId": {
+          "name": "teamId",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "onUpdate": true
+        }
+      },
+      "indexes": {
+        "userId_idx": {
+          "name": "userId_idx",
+          "columns": [
+            "userId"
+          ],
+          "isUnique": false
+        },
+        "teamId_idx": {
+          "name": "teamId_idx",
+          "columns": [
+            "teamId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "UtmTemplate_id": {
+          "name": "UtmTemplate_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    }
+  },
+  "views": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "tables": {},
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -365,6 +365,13 @@
       "when": 1773057423808,
       "tag": "0051_plain_ultimatum",
       "breakpoints": true
+    },
+    {
+      "idx": 52,
+      "version": "5",
+      "when": 1773062567548,
+      "tag": "0052_dry_lily_hollister",
+      "breakpoints": true
     }
   ]
 }

--- a/src/app/api/cron/cleanup-analytics/route.ts
+++ b/src/app/api/cron/cleanup-analytics/route.ts
@@ -73,7 +73,8 @@ export async function GET(request: Request) {
     console.log(
       `[Analytics Cleanup] Completed in ${duration}ms. ` +
         `Deleted ${result.linkVisitsDeleted} link visits, ` +
-        `${result.uniqueLinkVisitsDeleted} unique visits.`
+        `${result.uniqueLinkVisitsDeleted} unique visits. ` +
+        `Created ${result.dailySummariesCreated} daily summaries.`
     );
 
     return NextResponse.json({

--- a/src/server/api/routers/analytics/analytics-cleanup.service.ts
+++ b/src/server/api/routers/analytics/analytics-cleanup.service.ts
@@ -1,10 +1,12 @@
-import { and, eq, inArray, lt, sql } from "drizzle-orm";
+import { and, count, eq, inArray, isNotNull, isNull, lt, sql } from "drizzle-orm";
 
 import { db } from "@/server/db";
 import {
   link,
   linkVisit,
+  linkVisitDailySummary,
   subscription,
+  team,
   uniqueLinkVisit,
 } from "@/server/db/schema";
 
@@ -15,19 +17,29 @@ const PRO_RETENTION_DAYS = 365; // 1 year
 interface AnalyticsCleanupResult {
   linkVisitsDeleted: number;
   uniqueLinkVisitsDeleted: number;
-  freeUsersProcessed: number;
-  proUsersProcessed: number;
+  dailySummariesCreated: number;
+  freeLinksProcessed: number;
+  proLinksProcessed: number;
 }
 
 // Batch size for paginated queries and deletes
 const QUERY_BATCH_SIZE = 5000;
 const DELETE_BATCH_SIZE = 1000;
 
+// SQL predicate: user has no active paid subscription (free tier)
+const IS_FREE_TIER = sql`(${subscription.id} IS NULL OR ${subscription.status} != 'active' OR ${subscription.plan} = 'free')`;
+
 /**
  * Clean up old analytics data based on user subscription plan.
  * - Free users: Delete LinkVisit and UniqueLinkVisit records older than 30 days
  * - Pro users: Delete LinkVisit and UniqueLinkVisit records older than 1 year
  * - Ultra users: No cleanup (unlimited retention)
+ *
+ * Before deleting, aggregates raw visits into LinkVisitDailySummary to preserve
+ * historical click trends beyond the retention window.
+ *
+ * Handles both personal workspace links (plan resolved via user's subscription)
+ * and team workspace links (plan resolved via team owner's subscription).
  *
  * Uses cursor-based pagination to avoid memory issues with large datasets.
  * Should be called by a weekly cron job.
@@ -36,8 +48,9 @@ export async function cleanupAnalyticsData(): Promise<AnalyticsCleanupResult> {
   const result: AnalyticsCleanupResult = {
     linkVisitsDeleted: 0,
     uniqueLinkVisitsDeleted: 0,
-    freeUsersProcessed: 0,
-    proUsersProcessed: 0,
+    dailySummariesCreated: 0,
+    freeLinksProcessed: 0,
+    proLinksProcessed: 0,
   };
 
   // Calculate cutoff dates
@@ -47,144 +60,265 @@ export async function cleanupAnalyticsData(): Promise<AnalyticsCleanupResult> {
   const proCutoffDate = new Date();
   proCutoffDate.setDate(proCutoffDate.getDate() - PRO_RETENTION_DAYS);
 
-  // Process free users with cursor-based pagination
-  // A user is free if they don't have an entry in subscription table,
-  // or their subscription status is not 'active', or their plan is 'free'
-  let lastFreeId = 0;
-  let hasMoreFree = true;
-
-  while (hasMoreFree) {
-    const freeUserLinks = await db
-      .select({ linkId: link.id })
-      .from(link)
-      .leftJoin(subscription, eq(link.userId, subscription.userId))
-      .where(
-        and(
-          sql`${link.id} > ${lastFreeId}`,
-          sql`${link.teamId} IS NULL`, // Only personal workspace links
-          sql`(${subscription.id} IS NULL OR ${subscription.status} != 'active' OR ${subscription.plan} = 'free')`
+  // --- Free tier: personal workspace links ---
+  await processLinkBatch(
+    result,
+    "free",
+    freeCutoffDate,
+    (lastId) =>
+      db
+        .select({ linkId: link.id })
+        .from(link)
+        .leftJoin(subscription, eq(link.userId, subscription.userId))
+        .where(
+          and(
+            sql`${link.id} > ${lastId}`,
+            isNull(link.teamId),
+            IS_FREE_TIER,
+          ),
         )
-      )
-      .orderBy(link.id)
-      .limit(QUERY_BATCH_SIZE);
+        .orderBy(link.id)
+        .limit(QUERY_BATCH_SIZE),
+  );
 
-    if (freeUserLinks.length === 0) {
-      hasMoreFree = false;
-      break;
-    }
-
-    const freeLinkIds = freeUserLinks.map((l) => l.linkId);
-    lastFreeId = freeLinkIds[freeLinkIds.length - 1] ?? lastFreeId;
-    result.freeUsersProcessed += freeLinkIds.length;
-
-    // Delete old link visits for free users in batches
-    for (let i = 0; i < freeLinkIds.length; i += DELETE_BATCH_SIZE) {
-      const batch = freeLinkIds.slice(i, i + DELETE_BATCH_SIZE);
-
-      // Delete LinkVisit records
-      const linkVisitResult = await db
-        .delete(linkVisit)
+  // --- Free tier: team workspace links (team owner has no active paid subscription) ---
+  await processLinkBatch(
+    result,
+    "free",
+    freeCutoffDate,
+    (lastId) =>
+      db
+        .select({ linkId: link.id })
+        .from(link)
+        .innerJoin(team, eq(link.teamId, team.id))
+        .leftJoin(subscription, eq(team.ownerId, subscription.userId))
         .where(
           and(
-            inArray(linkVisit.linkId, batch),
-            lt(linkVisit.createdAt, freeCutoffDate)
-          )
-        );
-      result.linkVisitsDeleted += linkVisitResult[0].affectedRows;
-
-      // Delete UniqueLinkVisit records
-      const uniqueVisitResult = await db
-        .delete(uniqueLinkVisit)
-        .where(
-          and(
-            inArray(uniqueLinkVisit.linkId, batch),
-            lt(uniqueLinkVisit.createdAt, freeCutoffDate)
-          )
-        );
-      result.uniqueLinkVisitsDeleted += uniqueVisitResult[0].affectedRows;
-    }
-
-    // If we got fewer results than the batch size, we've reached the end
-    if (freeUserLinks.length < QUERY_BATCH_SIZE) {
-      hasMoreFree = false;
-    }
-  }
-
-  // Process pro users with cursor-based pagination
-  let lastProId = 0;
-  let hasMorePro = true;
-
-  while (hasMorePro) {
-    const proUserLinks = await db
-      .select({ linkId: link.id })
-      .from(link)
-      .innerJoin(subscription, eq(link.userId, subscription.userId))
-      .where(
-        and(
-          sql`${link.id} > ${lastProId}`,
-          sql`${link.teamId} IS NULL`, // Only personal workspace links
-          eq(subscription.status, "active"),
-          eq(subscription.plan, "pro")
+            sql`${link.id} > ${lastId}`,
+            isNotNull(link.teamId),
+            IS_FREE_TIER,
+          ),
         )
-      )
-      .orderBy(link.id)
-      .limit(QUERY_BATCH_SIZE);
+        .orderBy(link.id)
+        .limit(QUERY_BATCH_SIZE),
+  );
 
-    if (proUserLinks.length === 0) {
-      hasMorePro = false;
-      break;
-    }
-
-    const proLinkIds = proUserLinks.map((l) => l.linkId);
-    lastProId = proLinkIds[proLinkIds.length - 1] ?? lastProId;
-    result.proUsersProcessed += proLinkIds.length;
-
-    // Delete old link visits for pro users in batches
-    for (let i = 0; i < proLinkIds.length; i += DELETE_BATCH_SIZE) {
-      const batch = proLinkIds.slice(i, i + DELETE_BATCH_SIZE);
-
-      // Delete LinkVisit records
-      const linkVisitResult = await db
-        .delete(linkVisit)
+  // --- Pro tier: personal workspace links ---
+  await processLinkBatch(
+    result,
+    "pro",
+    proCutoffDate,
+    (lastId) =>
+      db
+        .select({ linkId: link.id })
+        .from(link)
+        .innerJoin(subscription, eq(link.userId, subscription.userId))
         .where(
           and(
-            inArray(linkVisit.linkId, batch),
-            lt(linkVisit.createdAt, proCutoffDate)
-          )
-        );
-      result.linkVisitsDeleted += linkVisitResult[0].affectedRows;
+            sql`${link.id} > ${lastId}`,
+            isNull(link.teamId),
+            eq(subscription.status, "active"),
+            eq(subscription.plan, "pro"),
+          ),
+        )
+        .orderBy(link.id)
+        .limit(QUERY_BATCH_SIZE),
+  );
 
-      // Delete UniqueLinkVisit records
-      const uniqueVisitResult = await db
-        .delete(uniqueLinkVisit)
+  // --- Pro tier: team workspace links (team owner has active pro subscription) ---
+  await processLinkBatch(
+    result,
+    "pro",
+    proCutoffDate,
+    (lastId) =>
+      db
+        .select({ linkId: link.id })
+        .from(link)
+        .innerJoin(team, eq(link.teamId, team.id))
+        .innerJoin(subscription, eq(team.ownerId, subscription.userId))
         .where(
           and(
-            inArray(uniqueLinkVisit.linkId, batch),
-            lt(uniqueLinkVisit.createdAt, proCutoffDate)
-          )
-        );
-      result.uniqueLinkVisitsDeleted += uniqueVisitResult[0].affectedRows;
-    }
+            sql`${link.id} > ${lastId}`,
+            isNotNull(link.teamId),
+            eq(subscription.status, "active"),
+            eq(subscription.plan, "pro"),
+          ),
+        )
+        .orderBy(link.id)
+        .limit(QUERY_BATCH_SIZE),
+  );
 
-    // If we got fewer results than the batch size, we've reached the end
-    if (proUserLinks.length < QUERY_BATCH_SIZE) {
-      hasMorePro = false;
-    }
-  }
-
-  // Note: Ultra users have unlimited retention, so no cleanup for them
-  // Note: Team links inherit from team owner's plan - for simplicity, we skip team links here
-  // Team analytics cleanup could be added as a separate feature if needed
+  // Note: Ultra users (personal and team) have unlimited retention — no cleanup
 
   return result;
 }
 
 /**
+ * Process a batch of links for a given tier: aggregate old visits into daily
+ * summaries, then delete the raw records.
+ */
+async function processLinkBatch(
+  result: AnalyticsCleanupResult,
+  tier: "free" | "pro",
+  cutoffDate: Date,
+  queryFn: (
+    lastId: number,
+  ) => Promise<{ linkId: number }[]>,
+): Promise<void> {
+  let lastId = 0;
+
+  while (true) {
+    const links = await queryFn(lastId);
+    if (links.length === 0) break;
+
+    const linkIds = links.map((l) => l.linkId);
+    lastId = linkIds[linkIds.length - 1] ?? lastId;
+
+    if (tier === "free") {
+      result.freeLinksProcessed += linkIds.length;
+    } else {
+      result.proLinksProcessed += linkIds.length;
+    }
+
+    // Process in delete-sized batches
+    for (let i = 0; i < linkIds.length; i += DELETE_BATCH_SIZE) {
+      const batch = linkIds.slice(i, i + DELETE_BATCH_SIZE);
+
+      // Step 1: Aggregate old visits into daily summaries before deletion
+      result.dailySummariesCreated += await aggregateDailySummaries(
+        batch,
+        cutoffDate,
+      );
+
+      // Step 2: Delete old raw records from both tables (independent, safe to parallelize)
+      const [linkVisitResult, uniqueVisitResult] = await Promise.all([
+        db
+          .delete(linkVisit)
+          .where(
+            and(
+              inArray(linkVisit.linkId, batch),
+              lt(linkVisit.createdAt, cutoffDate),
+            ),
+          ),
+        db
+          .delete(uniqueLinkVisit)
+          .where(
+            and(
+              inArray(uniqueLinkVisit.linkId, batch),
+              lt(uniqueLinkVisit.createdAt, cutoffDate),
+            ),
+          ),
+      ]);
+      result.linkVisitsDeleted += linkVisitResult[0].affectedRows;
+      result.uniqueLinkVisitsDeleted += uniqueVisitResult[0].affectedRows;
+    }
+
+    if (links.length < QUERY_BATCH_SIZE) break;
+  }
+}
+
+/**
+ * Aggregate raw LinkVisit and UniqueLinkVisit records older than the cutoff
+ * into LinkVisitDailySummary rows (one per link per day). Uses INSERT ... ON
+ * DUPLICATE KEY UPDATE to merge with any existing summaries.
+ *
+ * Returns the number of summary rows upserted.
+ */
+async function aggregateDailySummaries(
+  linkIds: number[],
+  cutoffDate: Date,
+): Promise<number> {
+  // Aggregate total clicks and unique clicks per link per day (in parallel)
+  const [clickAgg, uniqueAgg] = await Promise.all([
+    db
+      .select({
+        linkId: linkVisit.linkId,
+        date: sql<string>`DATE(${linkVisit.createdAt})`.as("visit_date"),
+        clicks: count().as("clicks"),
+      })
+      .from(linkVisit)
+      .where(
+        and(inArray(linkVisit.linkId, linkIds), lt(linkVisit.createdAt, cutoffDate)),
+      )
+      .groupBy(linkVisit.linkId, sql`visit_date`),
+    db
+      .select({
+        linkId: uniqueLinkVisit.linkId,
+        date: sql<string>`DATE(${uniqueLinkVisit.createdAt})`.as("visit_date"),
+        uniqueClicks: count().as("unique_clicks"),
+      })
+      .from(uniqueLinkVisit)
+      .where(
+        and(
+          inArray(uniqueLinkVisit.linkId, linkIds),
+          lt(uniqueLinkVisit.createdAt, cutoffDate),
+        ),
+      )
+      .groupBy(uniqueLinkVisit.linkId, sql`visit_date`),
+  ]);
+
+  if (clickAgg.length === 0 && uniqueAgg.length === 0) {
+    return 0;
+  }
+
+  // Merge clicks and unique clicks into a single map keyed by "linkId:date"
+  const summaryMap = new Map<
+    string,
+    { linkId: number; date: string; clicks: number; uniqueClicks: number }
+  >();
+
+  for (const row of clickAgg) {
+    const key = `${row.linkId}:${row.date}`;
+    summaryMap.set(key, {
+      linkId: row.linkId,
+      date: row.date,
+      clicks: row.clicks,
+      uniqueClicks: 0,
+    });
+  }
+
+  for (const row of uniqueAgg) {
+    const key = `${row.linkId}:${row.date}`;
+    const existing = summaryMap.get(key);
+    if (existing) {
+      existing.uniqueClicks = row.uniqueClicks;
+    } else {
+      summaryMap.set(key, {
+        linkId: row.linkId,
+        date: row.date,
+        clicks: 0,
+        uniqueClicks: row.uniqueClicks,
+      });
+    }
+  }
+
+  const rows = Array.from(summaryMap.values());
+  if (rows.length === 0) return 0;
+
+  // Upsert in batches — ON DUPLICATE KEY UPDATE overwrites (not accumulates)
+  // so that retries after a partial failure are idempotent.
+  const UPSERT_BATCH = 500;
+  let upserted = 0;
+
+  for (let i = 0; i < rows.length; i += UPSERT_BATCH) {
+    const batch = rows.slice(i, i + UPSERT_BATCH);
+    await db
+      .insert(linkVisitDailySummary)
+      .values(batch)
+      .onDuplicateKeyUpdate({
+        set: {
+          clicks: sql`VALUES(clicks)`,
+          uniqueClicks: sql`VALUES(uniqueClicks)`,
+        },
+      });
+    upserted += batch.length;
+  }
+
+  return upserted;
+}
+
+/**
  * Get stats about analytics data pending cleanup (for monitoring).
- * Counts are filtered by subscription tier to accurately reflect what will be deleted:
- * - Free tier visits: Records older than 30 days for users without active pro/ultra subscription
- * - Pro tier visits: Records older than 1 year for users with active pro subscription
- * - Ultra tier visits are never deleted (not counted here)
  */
 export async function getAnalyticsCleanupStats() {
   const freeCutoffDate = new Date();
@@ -193,39 +327,73 @@ export async function getAnalyticsCleanupStats() {
   const proCutoffDate = new Date();
   proCutoffDate.setDate(proCutoffDate.getDate() - PRO_RETENTION_DAYS);
 
-  // Count LinkVisit records for free users older than 30 days
-  // Free users: no subscription, inactive subscription, or free plan
-  const oldFreeVisits = await db
-    .select({ count: sql<number>`count(*)` })
-    .from(linkVisit)
-    .innerJoin(link, eq(linkVisit.linkId, link.id))
-    .leftJoin(subscription, eq(link.userId, subscription.userId))
-    .where(
-      and(
-        lt(linkVisit.createdAt, freeCutoffDate),
-        sql`${link.teamId} IS NULL`,
-        sql`(${subscription.id} IS NULL OR ${subscription.status} != 'active' OR ${subscription.plan} = 'free')`
-      )
-    );
-
-  // Count LinkVisit records for pro users older than 1 year
-  const oldProVisits = await db
-    .select({ count: sql<number>`count(*)` })
-    .from(linkVisit)
-    .innerJoin(link, eq(linkVisit.linkId, link.id))
-    .innerJoin(subscription, eq(link.userId, subscription.userId))
-    .where(
-      and(
-        lt(linkVisit.createdAt, proCutoffDate),
-        sql`${link.teamId} IS NULL`,
-        eq(subscription.status, "active"),
-        eq(subscription.plan, "pro")
-      )
-    );
+  const [oldFreeVisits, oldProVisits, oldFreeTeamVisits, oldProTeamVisits] =
+    await Promise.all([
+      // Free personal workspace visits
+      db
+        .select({ count: sql<number>`count(*)` })
+        .from(linkVisit)
+        .innerJoin(link, eq(linkVisit.linkId, link.id))
+        .leftJoin(subscription, eq(link.userId, subscription.userId))
+        .where(
+          and(
+            lt(linkVisit.createdAt, freeCutoffDate),
+            isNull(link.teamId),
+            IS_FREE_TIER,
+          ),
+        ),
+      // Pro personal workspace visits
+      db
+        .select({ count: sql<number>`count(*)` })
+        .from(linkVisit)
+        .innerJoin(link, eq(linkVisit.linkId, link.id))
+        .innerJoin(subscription, eq(link.userId, subscription.userId))
+        .where(
+          and(
+            lt(linkVisit.createdAt, proCutoffDate),
+            isNull(link.teamId),
+            eq(subscription.status, "active"),
+            eq(subscription.plan, "pro"),
+          ),
+        ),
+      // Free team workspace visits
+      db
+        .select({ count: sql<number>`count(*)` })
+        .from(linkVisit)
+        .innerJoin(link, eq(linkVisit.linkId, link.id))
+        .innerJoin(team, eq(link.teamId, team.id))
+        .leftJoin(subscription, eq(team.ownerId, subscription.userId))
+        .where(
+          and(
+            lt(linkVisit.createdAt, freeCutoffDate),
+            isNotNull(link.teamId),
+            IS_FREE_TIER,
+          ),
+        ),
+      // Pro team workspace visits
+      db
+        .select({ count: sql<number>`count(*)` })
+        .from(linkVisit)
+        .innerJoin(link, eq(linkVisit.linkId, link.id))
+        .innerJoin(team, eq(link.teamId, team.id))
+        .innerJoin(subscription, eq(team.ownerId, subscription.userId))
+        .where(
+          and(
+            lt(linkVisit.createdAt, proCutoffDate),
+            isNotNull(link.teamId),
+            eq(subscription.status, "active"),
+            eq(subscription.plan, "pro"),
+          ),
+        ),
+    ]);
 
   return {
-    freeUserVisitsPendingCleanup: Number(oldFreeVisits[0]?.count ?? 0),
-    proUserVisitsPendingCleanup: Number(oldProVisits[0]?.count ?? 0),
+    freeUserVisitsPendingCleanup:
+      Number(oldFreeVisits[0]?.count ?? 0) +
+      Number(oldFreeTeamVisits[0]?.count ?? 0),
+    proUserVisitsPendingCleanup:
+      Number(oldProVisits[0]?.count ?? 0) +
+      Number(oldProTeamVisits[0]?.count ?? 0),
     freeRetentionDays: FREE_RETENTION_DAYS,
     proRetentionDays: PRO_RETENTION_DAYS,
   };

--- a/src/server/db/schema.ts
+++ b/src/server/db/schema.ts
@@ -1,6 +1,7 @@
 import { relations, sql } from "drizzle-orm";
 import {
   boolean,
+  date,
   datetime,
   index,
   int,
@@ -308,6 +309,33 @@ export const uniqueLinkVisit = mysqlTable(
     ipHashIdx: index("ipHash_idx").on(table.ipHash),
     uniqueVisitIdx: index("unique_visit_idx").on(table.linkId, table.ipHash),
     linkCreatedAtIdx: index("linkId_createdAt_idx").on(table.linkId, table.createdAt),
+  }),
+);
+
+// Daily rollup of link visit analytics.
+// Created by the analytics cleanup job before deleting raw LinkVisit/UniqueLinkVisit
+// records, preserving historical click trends beyond the retention window.
+export const linkVisitDailySummary = mysqlTable(
+  "LinkVisitDailySummary",
+  {
+    id: serial("id").primaryKey(),
+    linkId: int("linkId").notNull(),
+    date: date("date", { mode: "string" }).notNull(),
+    clicks: int("clicks").notNull().default(0),
+    uniqueClicks: int("uniqueClicks").notNull().default(0),
+  },
+  (table) => ({
+    linkDateUnique: unique("link_date_unique").on(table.linkId, table.date),
+  }),
+);
+
+export const linkVisitDailySummaryRelations = relations(
+  linkVisitDailySummary,
+  ({ one }) => ({
+    link: one(link, {
+      fields: [linkVisitDailySummary.linkId],
+      references: [link.id],
+    }),
   }),
 );
 


### PR DESCRIPTION
## Summary

Fix two gaps in the analytics cleanup cron job: team workspace links were never cleaned up (only personal links), and raw visit data was permanently lost on deletion with no aggregation.

## Changes

- Add `LinkVisitDailySummary` rollup table to preserve historical click trends beyond retention windows
- Aggregate raw visits into daily summaries before deleting, with idempotent upserts (safe to retry)
- Extend cleanup to team workspace links by resolving plan via team owner's subscription
- Extract shared `processLinkBatch()` for cursor-based batch processing across all tier/workspace combinations
- Extract `IS_FREE_TIER` SQL predicate constant to eliminate 4x duplication
- Parallelize independent DELETE and aggregation queries with `Promise.all`
- Update `getAnalyticsCleanupStats()` to include team workspace visit counts
- Include daily summaries count in cron job log output

## Type of Change

- [x] fix: Bug fix

## Testing

- TypeScript compilation passes with no errors
- Code reviewed for correctness via /review-changes and /simplify

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Implemented daily aggregation of link analytics data for improved reporting efficiency.

* **Chores**
  * Refactored analytics cleanup process to optimize handling across different subscription tiers.
  * Enhanced data retention workflows with improved aggregation and archival mechanisms.
  * Updated database schema to support analytics data summarization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->