### PR TITLE
feat(admin): add more analytics to admin dashboard

### DIFF
--- a/src/app/(main)/dashboard/admin/_components/daily-activity-chart.tsx
+++ b/src/app/(main)/dashboard/admin/_components/daily-activity-chart.tsx
@@ -1,0 +1,91 @@
+"use client";
+
+import {
+  Bar,
+  BarChart as RechartsBarChart,
+  CartesianGrid,
+  XAxis,
+  YAxis,
+} from "recharts";
+
+import { Card } from "@/components/ui/card";
+import {
+  ChartContainer,
+  ChartLegend,
+  ChartLegendContent,
+  ChartTooltip,
+  ChartTooltipContent,
+} from "@/components/ui/chart";
+import { formatChartDate } from "@/lib/utils";
+
+import type { ChartConfig } from "@/components/ui/chart";
+
+const chartConfig = {
+  links: {
+    label: "Links Created",
+    color: "#2563eb",
+  },
+  users: {
+    label: "New Users",
+    color: "#10b981",
+  },
+} satisfies ChartConfig;
+
+type DailyActivityChartProps = {
+  data: { date: string; links: number; users: number }[];
+};
+
+export function DailyActivityChart({ data }: DailyActivityChartProps) {
+  return (
+    <Card className="overflow-hidden rounded-xl border-neutral-200 shadow-none">
+      <div className="border-b border-neutral-100 px-5 pb-4 pt-5">
+        <div className="space-y-0.5">
+          <h2 className="text-[14px] font-semibold tracking-tight text-neutral-900">
+            Daily Activity
+          </h2>
+          <p className="text-[12px] text-neutral-400">
+            Links created and new user signups over the last 14 days
+          </p>
+        </div>
+      </div>
+
+      <div className="px-2 pb-5 pt-4 sm:px-5 sm:pt-5">
+        <ChartContainer
+          config={chartConfig}
+          className="aspect-auto h-64 w-full"
+        >
+          <RechartsBarChart data={data}>
+            <CartesianGrid vertical={false} />
+            <XAxis
+              dataKey="date"
+              tickLine={false}
+              axisLine={false}
+              tickMargin={8}
+              minTickGap={32}
+              tickFormatter={formatChartDate}
+            />
+            <YAxis
+              tickLine={false}
+              axisLine={false}
+              tickMargin={4}
+              width={32}
+              allowDecimals={false}
+            />
+            <ChartTooltip
+              cursor={false}
+              content={
+                <ChartTooltipContent
+                  labelFormatter={(value) => formatChartDate(String(value))}
+                  indicator="dashed"
+                />
+              }
+            />
+            <Bar dataKey="links" fill="var(--color-links)" radius={4} />
+            <Bar dataKey="users" fill="var(--color-users)" radius={4} />
+            <ChartLegend content={<ChartLegendContent />} />
+          </RechartsBarChart>
+        </ChartContainer>
+      </div>
+    </Card>
+  );
+}

--- a/src/app/(main)/dashboard/admin/page.tsx
+++ b/src/app/(main)/dashboard/admin/page.tsx
@@ -1,7 +1,8 @@
 import {
   IconBan,
-  IconFlag,
   IconLink,
+  IconTrendingUp,
+  IconUserPlus,
   IconUsers,
 } from "@tabler/icons-react";
 import { Link } from "next-view-transitions";
@@ -9,6 +10,8 @@ import { Link } from "next-view-transitions";
 import { QuickInfoCard } from "@/app/(main)/dashboard/analytics/[alias]/_components/quick-info-card";
 import { Card } from "@/components/ui/card";
 import { api } from "@/trpc/server";
+
+import { DailyActivityChart } from "./_components/daily-activity-chart";
 
 export const dynamic = "force-dynamic";
 
@@ -26,9 +29,11 @@ function timeAgo(date: Date | null): string {
 }
 
 export default async function AdminPage() {
-  const [stats, activity] = await Promise.all([
+  const [stats, activity, dailyStats, recentUsers] = await Promise.all([
     api.admin.getStats.query(),
     api.admin.getRecentActivity.query(),
+    api.admin.getDailyStats.query(),
+    api.admin.getRecentUsers.query(),
   ]);
 
   return (
@@ -44,7 +49,7 @@ export default async function AdminPage() {
       </div>
 
       {/* Stats */}
-      <div className="grid grid-cols-1 gap-4 md:grid-cols-4">
+      <div className="grid grid-cols-2 gap-4 sm:grid-cols-3 lg:grid-cols-5">
         <QuickInfoCard
           title="Total Links"
           value={stats.totalLinks.toLocaleString()}
@@ -56,19 +61,96 @@ export default async function AdminPage() {
           icon={<IconUsers size={16} stroke={1.5} className="text-blue-600" />}
         />
         <QuickInfoCard
+          title="Links Today"
+          value={stats.linksToday.toLocaleString()}
+          icon={
+            <IconTrendingUp
+              size={16}
+              stroke={1.5}
+              className="text-blue-600"
+            />
+          }
+        />
+        <QuickInfoCard
+          title="Users Today"
+          value={stats.usersToday.toLocaleString()}
+          icon={
+            <IconUserPlus size={16} stroke={1.5} className="text-blue-600" />
+          }
+        />
+        <QuickInfoCard
           title="Blocked Links"
           value={stats.blockedLinks.toLocaleString()}
           icon={<IconBan size={16} stroke={1.5} className="text-blue-600" />}
         />
-        <QuickInfoCard
-          title="Pending Flags"
-          value={stats.pendingFlagged.toLocaleString()}
-          icon={<IconFlag size={16} stroke={1.5} className="text-blue-600" />}
-        />
       </div>
 
-      {/* Activity panels */}
+      {/* Daily activity chart */}
+      <div className="mt-8">
+        <DailyActivityChart data={dailyStats} />
+      </div>
+
+      {/* New users + Recent links */}
       <div className="mt-8 grid grid-cols-1 gap-4 lg:grid-cols-2">
+        {/* New users */}
+        <Card className="flex flex-col rounded-xl border-neutral-200 shadow-none">
+          <div className="flex items-center justify-between border-b border-neutral-100 px-5 py-4">
+            <p className="text-[14px] font-semibold tracking-tight text-neutral-900">
+              New Users
+            </p>
+            <Link
+              href="/dashboard/admin/users"
+              className="text-[12px] font-medium text-neutral-400 transition-colors hover:text-neutral-600"
+            >
+              View all
+            </Link>
+          </div>
+          {recentUsers.length === 0 ? (
+            <div className="flex flex-1 items-center justify-center px-5 py-12">
+              <p className="text-[13px] text-neutral-400">No users yet</p>
+            </div>
+          ) : (
+            <div className="divide-y divide-neutral-100">
+              {recentUsers.map((u) => (
+                <div
+                  key={u.id}
+                  className="flex items-center justify-between px-5 py-3"
+                >
+                  <div className="flex min-w-0 flex-1 items-center gap-3">
+                    {u.imageUrl ? (
+                      <img
+                        src={u.imageUrl}
+                        alt=""
+                        className="h-7 w-7 shrink-0 rounded-full bg-neutral-100 object-cover"
+                      />
+                    ) : (
+                      <div className="flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-neutral-100 text-[11px] font-medium text-neutral-500">
+                        {(u.name ?? u.email ?? "?").charAt(0).toUpperCase()}
+                      </div>
+                    )}
+                    <div className="min-w-0">
+                      <p className="truncate text-[13px] font-medium text-neutral-700">
+                        {u.name ?? "Unnamed"}
+                      </p>
+                      <p className="truncate text-[11px] text-neutral-400">
+                        {u.email}
+                      </p>
+                    </div>
+                  </div>
+                  <div className="shrink-0 pl-4 text-right">
+                    <p className="text-[11px] tabular-nums text-neutral-400">
+                      {u.linkCount} {u.linkCount === 1 ? "link" : "links"}
+                    </p>
+                    <p className="text-[11px] text-neutral-300">
+                      {timeAgo(u.createdAt)}
+                    </p>
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
+        </Card>
+
         {/* Recent links */}
         <Card className="flex flex-col rounded-xl border-neutral-200 shadow-none">
           <div className="flex items-center justify-between border-b border-neutral-100 px-5 py-4">
@@ -84,12 +166,17 @@ export default async function AdminPage() {
           </div>
           {activity.recentLinks.length === 0 ? (
             <div className="flex flex-1 items-center justify-center px-5 py-12">
-              <p className="text-[13px] text-neutral-400">No links created yet</p>
+              <p className="text-[13px] text-neutral-400">
+                No links created yet
+              </p>
             </div>
           ) : (
             <div className="divide-y divide-neutral-100">
               {activity.recentLinks.map((l) => (
-                <div key={l.id} className="flex items-center justify-between px-5 py-3">
+                <div
+                  key={l.id}
+                  className="flex items-center justify-between px-5 py-3"
+                >
                   <div className="min-w-0 flex-1">
                     <p className="truncate text-[13px] font-medium text-neutral-700">
                       <span className="text-neutral-400">{l.domain}/</span>
@@ -100,7 +187,9 @@ export default async function AdminPage() {
                     </p>
                   </div>
                   <div className="shrink-0 pl-4 text-right">
-                    <p className="text-[11px] text-neutral-400">{l.userEmail}</p>
+                    <p className="text-[11px] text-neutral-400">
+                      {l.userEmail}
+                    </p>
                     <p className="text-[11px] text-neutral-300">
                       {timeAgo(l.createdAt)}
                     </p>
@@ -110,8 +199,10 @@ export default async function AdminPage() {
             </div>
           )}
         </Card>
+      </div>
 
-        {/* Recently blocked */}
+      {/* Recently blocked */}
+      <div className="mt-4">
         <Card className="flex flex-col rounded-xl border-neutral-200 shadow-none">
           <div className="flex items-center justify-between border-b border-neutral-100 px-5 py-4">
             <p className="text-[14px] font-semibold tracking-tight text-neutral-900">
@@ -131,7 +222,10 @@ export default async function AdminPage() {
           ) : (
             <div className="divide-y divide-neutral-100">
               {activity.recentBlocked.map((l) => (
-                <div key={l.id} className="flex items-center justify-between px-5 py-3">
+                <div
+                  key={l.id}
+                  className="flex items-center justify-between px-5 py-3"
+                >
                   <div className="min-w-0 flex-1">
                     <p className="truncate text-[13px] font-medium text-neutral-700">
                       <span className="text-neutral-400">{l.domain}/</span>
@@ -142,7 +236,9 @@ export default async function AdminPage() {
                     </p>
                   </div>
                   <div className="shrink-0 pl-4 text-right">
-                    <p className="text-[11px] text-neutral-400">{l.userEmail}</p>
+                    <p className="text-[11px] text-neutral-400">
+                      {l.userEmail}
+                    </p>
                     <p className="text-[11px] text-neutral-300">
                       {timeAgo(l.blockedAt)}
                     </p>

--- a/src/app/(main)/dashboard/analytics/[alias]/_components/bar-chart.tsx
+++ b/src/app/(main)/dashboard/analytics/[alias]/_components/bar-chart.tsx
@@ -24,25 +24,11 @@ import {
   ChartTooltip,
   ChartTooltipContent,
 } from "@/components/ui/chart";
-import { cn } from "@/lib/utils";
+import { cn, formatChartDate } from "@/lib/utils";
 
 import UpgradeText from "../../../qrcodes/_components/upgrade-text";
 
 import type { ChartConfig } from "@/components/ui/chart";
-
-/**
- * Formats a "YYYY-MM-DD" date string as UTC to prevent timezone shifts.
- * Parses the string manually to avoid local timezone interpretation.
- */
-function formatDate(dateString: string): string {
-  const [year, month, day] = dateString.split("-").map(Number);
-  const utcDate = new Date(Date.UTC(year!, month! - 1, day!));
-  return utcDate.toLocaleDateString("en-US", {
-    month: "short",
-    day: "numeric",
-    timeZone: "UTC",
-  });
-}
 
 const chartConfig = {
   clicks: {
@@ -321,13 +307,13 @@ export function BarChart({
                   axisLine={false}
                   tickMargin={8}
                   minTickGap={32}
-                  tickFormatter={formatDate}
+                  tickFormatter={formatChartDate}
                 />
                 <ChartTooltip
                   cursor={false}
                   content={
                     <ChartTooltipContent
-                      labelFormatter={(value) => formatDate(String(value))}
+                      labelFormatter={(value) => formatChartDate(String(value))}
                       indicator="dot"
                     />
                   }
@@ -357,13 +343,13 @@ export function BarChart({
                   axisLine={false}
                   tickMargin={8}
                   minTickGap={32}
-                  tickFormatter={formatDate}
+                  tickFormatter={formatChartDate}
                 />
                 <ChartTooltip
                   cursor={false}
                   content={
                     <ChartTooltipContent
-                      labelFormatter={(value) => formatDate(String(value))}
+                      labelFormatter={(value) => formatChartDate(String(value))}
                       indicator="dashed"
                     />
                   }

--- a/src/app/(main)/dashboard/analytics/overview/_components/overall-clicks-chart.tsx
+++ b/src/app/(main)/dashboard/analytics/overview/_components/overall-clicks-chart.tsx
@@ -16,6 +16,7 @@ import {
   ChartTooltip,
   ChartTooltipContent,
 } from "@/components/ui/chart";
+import { formatChartDate } from "@/lib/utils";
 
 import type { ChartConfig } from "@/components/ui/chart";
 
@@ -29,19 +30,6 @@ const chartConfig = {
     color: "#93c5fd",
   },
 } satisfies ChartConfig;
-
-/**
- * Formats a "YYYY-MM-DD" date string as UTC to prevent timezone shifts.
- */
-function formatDate(dateString: string): string {
-  const [year, month, day] = dateString.split("-").map(Number);
-  const utcDate = new Date(Date.UTC(year!, month! - 1, day!));
-  return utcDate.toLocaleDateString("en-US", {
-    month: "short",
-    day: "numeric",
-    timeZone: "UTC",
-  });
-}
 
 type OverallClicksChartProps = {
   clicksPerDate: Record<string, number>;
@@ -104,13 +92,13 @@ export function OverallClicksChart({
               axisLine={false}
               tickMargin={8}
               minTickGap={32}
-              tickFormatter={formatDate}
+              tickFormatter={formatChartDate}
             />
             <ChartTooltip
               cursor={false}
               content={
                 <ChartTooltipContent
-                  labelFormatter={(value) => formatDate(String(value))}
+                  labelFormatter={(value) => formatChartDate(String(value))}
                   indicator="dashed"
                 />
               }

--- a/src/lib/utils/index.ts
+++ b/src/lib/utils/index.ts
@@ -131,3 +131,17 @@ export function parseReferrer(referrer: string | null): string {
 export function normalizeAlias(alias: string): string {
   return alias.toLowerCase();
 }
+
+/**
+ * Formats a "YYYY-MM-DD" date string as UTC to prevent timezone shifts.
+ * Used by chart components for x-axis tick labels and tooltips.
+ */
+export function formatChartDate(dateString: string): string {
+  const [year, month, day] = dateString.split("-").map(Number);
+  const utcDate = new Date(Date.UTC(year!, month! - 1, day!));
+  return utcDate.toLocaleDateString("en-US", {
+    month: "short",
+    day: "numeric",
+    timeZone: "UTC",
+  });
+}

--- a/src/server/api/routers/admin/admin.procedure.ts
+++ b/src/server/api/routers/admin/admin.procedure.ts
@@ -10,6 +10,14 @@ export const adminRouter = createTRPCRouter({
     services.getRecentActivity(ctx),
   ),
 
+  getDailyStats: adminProcedure.query(({ ctx }) =>
+    services.getDailyStats(ctx),
+  ),
+
+  getRecentUsers: adminProcedure.query(({ ctx }) =>
+    services.getRecentUsers(ctx),
+  ),
+
   searchLinks: adminProcedure
     .input(inputs.searchLinksSchema)
     .query(({ ctx, input }) => services.searchLinks(ctx, input)),

--- a/src/server/api/routers/admin/admin.service.ts
+++ b/src/server/api/routers/admin/admin.service.ts
@@ -26,24 +26,29 @@ import type {
 } from "./admin.input";
 
 export async function getStats(ctx: ProtectedTRPCContext) {
+  const today = new Date();
+  today.setHours(0, 0, 0, 0);
+
   const [
     linkStatsResult,
     userStatsResult,
     pendingFlaggedResult,
     blockedDomainsResult,
   ] = await Promise.all([
-    // Single scan: total links + blocked links
+    // Single scan: total links + blocked links + today's links
     ctx.db
       .select({
         total: count(),
         blocked: sql<number>`SUM(${link.blocked} = true)`,
+        today: sql<number>`SUM(${link.createdAt} >= ${today})`,
       })
       .from(link),
-    // Single scan: total users + banned users
+    // Single scan: total users + banned users + today's users
     ctx.db
       .select({
         total: count(),
         banned: sql<number>`SUM(${user.banned} = true)`,
+        today: sql<number>`SUM(${user.createdAt} >= ${today})`,
       })
       .from(user),
     ctx.db
@@ -60,7 +65,76 @@ export async function getStats(ctx: ProtectedTRPCContext) {
     pendingFlagged: pendingFlaggedResult[0]?.count ?? 0,
     bannedUsers: userStatsResult[0]?.banned ?? 0,
     blockedDomains: blockedDomainsResult[0]?.count ?? 0,
+    linksToday: linkStatsResult[0]?.today ?? 0,
+    usersToday: userStatsResult[0]?.today ?? 0,
   };
+}
+
+export async function getDailyStats(ctx: ProtectedTRPCContext) {
+  const fourteenDaysAgo = new Date();
+  fourteenDaysAgo.setDate(fourteenDaysAgo.getDate() - 13);
+  fourteenDaysAgo.setHours(0, 0, 0, 0);
+
+  const [dailyLinks, dailyUsers] = await Promise.all([
+    ctx.db
+      .select({
+        date: sql<string>`DATE(${link.createdAt})`,
+        count: count(),
+      })
+      .from(link)
+      .where(sql`${link.createdAt} >= ${fourteenDaysAgo}`)
+      .groupBy(sql`DATE(${link.createdAt})`)
+      .orderBy(sql`DATE(${link.createdAt})`),
+    ctx.db
+      .select({
+        date: sql<string>`DATE(${user.createdAt})`,
+        count: count(),
+      })
+      .from(user)
+      .where(sql`${user.createdAt} >= ${fourteenDaysAgo}`)
+      .groupBy(sql`DATE(${user.createdAt})`)
+      .orderBy(sql`DATE(${user.createdAt})`),
+  ]);
+
+  // Index by date string for O(1) lookups (normalize in case driver returns Date)
+  const linksByDate = new Map(
+    dailyLinks.map((l) => [String(l.date).split("T")[0], l.count]),
+  );
+  const usersByDate = new Map(
+    dailyUsers.map((u) => [String(u.date).split("T")[0], u.count]),
+  );
+
+  // Fill in all 14 days (including days with 0 activity)
+  const result: { date: string; links: number; users: number }[] = [];
+  for (let i = 0; i < 14; i++) {
+    const d = new Date(fourteenDaysAgo);
+    d.setDate(d.getDate() + i);
+    const dateStr = d.toISOString().split("T")[0]!;
+    result.push({
+      date: dateStr,
+      links: linksByDate.get(dateStr) ?? 0,
+      users: usersByDate.get(dateStr) ?? 0,
+    });
+  }
+
+  return result;
+}
+
+export async function getRecentUsers(ctx: ProtectedTRPCContext) {
+  return ctx.db
+    .select({
+      id: user.id,
+      name: user.name,
+      email: user.email,
+      imageUrl: user.imageUrl,
+      createdAt: user.createdAt,
+      banned: user.banned,
+      linkCount:
+        sql<number>`(SELECT COUNT(*) FROM Link WHERE Link.userId = ${user.id})`,
+    })
+    .from(user)
+    .orderBy(desc(user.createdAt))
+    .limit(8);
 }
 
 export async function getRecentActivity(ctx: ProtectedTRPCContext) {


### PR DESCRIPTION
## Summary

Expand the admin dashboard with daily activity trends, today's stats, and a new users panel for better platform visibility.

## Changes

- Add "Links Today" and "Users Today" stat cards (merged into existing aggregate queries to avoid extra table scans)
- Add 14-day daily activity bar chart showing links created and new user signups per day
- Add "New Users" panel showing recent signups with avatar, name, email, link count
- Extract duplicated `formatChartDate` utility from three chart components into `lib/utils`
- Use `Map` for O(1) date gap-fill lookups in daily stats query

## Type of Change

- [x] feat: New feature
- [x] refactor: Code refactoring

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Daily Activity Chart displaying links created and new users over the last 14 days
  * New "Links Today" and "Users Today" stat cards on admin dashboard
  * New Users panel showing recent user information with link counts and join timestamps
  * Enhanced admin dashboard layout with improved responsive grid design

<!-- end of auto-generated comment: release notes by coderabbit.ai -->