### PR TITLE
feat(qrcode): add actions dropdown and edit drawer for dynamic QR codes

### DIFF
--- a/content/changelogs/2026-03-10-dynamic-qr-codes.md
+++ b/content/changelogs/2026-03-10-dynamic-qr-codes.md
@@ -1,0 +1,48 @@
+---
+date: 2026-03-10T18:00:00
+version: 2.3.0
+title: Dynamic QR Codes
+shortDesc: Edit your QR code destination, toggle status, and manage everything from one menu
+category: feature
+---
+
+QR codes are now fully dynamic. Print a QR code once and change where it points as many times as you want — no need to reprint. Plus, every QR code now has a full actions menu for managing it right from your dashboard.
+
+## What's new?
+
+### Edit destination URL anytime
+
+Change the URL your QR code points to without regenerating the image. Since every QR code encodes your short link (not the raw URL), updating the destination is instant and the printed QR code keeps working.
+
+Open the edit drawer from the actions menu on any QR code card to update:
+
+- **Destination URL** — Change where scans redirect to
+- **Title** — Rename your QR code for easier identification
+- **Note** — Add internal notes for your team
+- **Tags** — Organize QR codes with the same tagging system used for links
+
+### Advanced link settings
+
+The edit drawer also gives you access to the same advanced settings available on short links:
+
+- **UTM Parameters** — Append tracking parameters to your destination URL (Ultra)
+- **Geotargeting Rules** — Redirect scanners to different URLs based on their country or continent (Pro/Ultra)
+- **Auto-disable** — Set a QR code to stop redirecting after a specific number of scans or after a certain date
+
+### Actions menu
+
+Every QR code card now has a three-dot menu with quick actions:
+
+- **Edit QR code** — Open the full edit drawer
+- **Download** — Save the QR code image
+- **Activate / Deactivate** — Toggle whether the QR code redirects or is paused
+- **Reset statistics** — Clear all scan data and start fresh
+- **Delete** — Permanently remove the QR code and its scan history
+
+### Deactivate without deleting
+
+Need to temporarily pause a QR code? Toggle it to inactive and scans will stop redirecting. Reactivate it whenever you're ready — no data is lost.
+
+## Who can use this?
+
+Dynamic QR codes are available to all users. UTM parameters require Ultra, and geotargeting requires Pro or Ultra. Manage your QR codes at [/dashboard/qrcodes](/dashboard/qrcodes).

--- a/src/app/(main)/dashboard/_components/links/link-card/edit-link-drawer.tsx
+++ b/src/app/(main)/dashboard/_components/links/link-card/edit-link-drawer.tsx
@@ -5,9 +5,7 @@ import { format } from "date-fns";
 import { AnimatePresence, motion } from "framer-motion";
 import {
   IconCalendar,
-  IconChevronDown,
   IconClick,
-  IconDiamond,
   IconLoader2,
   IconX,
 } from "@tabler/icons-react";
@@ -26,6 +24,7 @@ const GeoRulesForm = dynamic(
 );
 import { MilestoneEditor } from "@/app/(main)/dashboard/_components/milestone-form";
 import type { MilestoneEntry } from "@/app/(main)/dashboard/_components/milestone-form";
+import { PlanBadge, SectionToggle } from "@/app/(main)/dashboard/_components/section-toggle";
 import { UtmParamsForm } from "@/app/(main)/dashboard/_components/utm-params-form";
 import { UtmTemplateSelector } from "@/app/(main)/dashboard/_components/utm-template-selector";
 import { OgImageUploader } from "@/app/(main)/dashboard/link/new/_components/og-image-uploader";
@@ -71,70 +70,6 @@ type EditLinkDrawerProps = {
   open: boolean;
   onClose: () => void;
 };
-
-function SectionToggle({
-  title,
-  description,
-  isOpen,
-  onToggle,
-  badge,
-  children,
-}: {
-  title: string;
-  description: string;
-  isOpen: boolean;
-  onToggle: () => void;
-  badge?: React.ReactNode;
-  children: React.ReactNode;
-}) {
-  return (
-    <div className="rounded-lg border border-neutral-200 p-4">
-      <button
-        type="button"
-        className="flex w-full items-center justify-between text-left"
-        onClick={onToggle}
-      >
-        <div className="flex flex-col gap-0.5">
-          <p className="flex items-center gap-2 text-[14px] font-semibold text-neutral-900">
-            {title}
-            {badge}
-          </p>
-          <span className="text-[12px] text-neutral-400">{description}</span>
-        </div>
-        <IconChevronDown
-          size={16}
-          stroke={1.5}
-          className={cn(
-            "shrink-0 text-neutral-400 transition-transform duration-200",
-            isOpen && "rotate-180"
-          )}
-        />
-      </button>
-      <AnimatePresence>
-        {isOpen && (
-          <motion.div
-            initial={{ height: 0, opacity: 0 }}
-            animate={{ height: "auto", opacity: 1 }}
-            exit={{ height: 0, opacity: 0 }}
-            transition={{ duration: 0.2 }}
-            className="overflow-hidden"
-          >
-            <div className="mt-4 space-y-4">{children}</div>
-          </motion.div>
-        )}
-      </AnimatePresence>
-    </div>
-  );
-}
-
-function PlanBadge({ plan }: { plan: string }) {
-  return (
-    <span className="inline-flex items-center gap-1 rounded-full border border-neutral-200 bg-neutral-50 px-2 py-px text-[11px] font-medium uppercase text-neutral-500">
-      <IconDiamond size={12} stroke={1.5} className="text-neutral-400" />
-      {plan}
-    </span>
-  );
-}
 
 export function EditLinkDrawer({ link, open, onClose }: EditLinkDrawerProps) {
   const [tags, setTags] = useState<string[]>((link.tags as string[]) || []);

--- a/src/app/(main)/dashboard/_components/section-toggle.tsx
+++ b/src/app/(main)/dashboard/_components/section-toggle.tsx
@@ -1,0 +1,70 @@
+"use client";
+
+import { AnimatePresence, motion } from "framer-motion";
+import { IconChevronDown, IconDiamond } from "@tabler/icons-react";
+
+import { cn } from "@/lib/utils";
+
+export function SectionToggle({
+  title,
+  description,
+  isOpen,
+  onToggle,
+  badge,
+  children,
+}: {
+  title: string;
+  description: string;
+  isOpen: boolean;
+  onToggle: () => void;
+  badge?: React.ReactNode;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="rounded-lg border border-neutral-200 p-4">
+      <button
+        type="button"
+        className="flex w-full items-center justify-between text-left"
+        onClick={onToggle}
+      >
+        <div className="flex flex-col gap-0.5">
+          <p className="flex items-center gap-2 text-[14px] font-semibold text-neutral-900">
+            {title}
+            {badge}
+          </p>
+          <span className="text-[12px] text-neutral-400">{description}</span>
+        </div>
+        <IconChevronDown
+          size={16}
+          stroke={1.5}
+          className={cn(
+            "shrink-0 text-neutral-400 transition-transform duration-200",
+            isOpen && "rotate-180"
+          )}
+        />
+      </button>
+      <AnimatePresence>
+        {isOpen && (
+          <motion.div
+            initial={{ height: 0, opacity: 0 }}
+            animate={{ height: "auto", opacity: 1 }}
+            exit={{ height: 0, opacity: 0 }}
+            transition={{ duration: 0.2 }}
+            className="overflow-hidden"
+          >
+            <div className="mt-4 space-y-4">{children}</div>
+          </motion.div>
+        )}
+      </AnimatePresence>
+    </div>
+  );
+}
+
+export function PlanBadge({ plan }: { plan: string }) {
+  return (
+    <span className="inline-flex items-center gap-1 rounded-full border border-neutral-200 bg-neutral-50 px-2 py-px text-[11px] font-medium uppercase text-neutral-500">
+      <IconDiamond size={12} stroke={1.5} className="text-neutral-400" />
+      {plan}
+    </span>
+  );
+}

--- a/src/app/(main)/dashboard/_components/utm-template-selector.tsx
+++ b/src/app/(main)/dashboard/_components/utm-template-selector.tsx
@@ -61,7 +61,7 @@ export function UtmTemplateSelector({
   }
 
   return (
-    <DropdownMenu>
+    <DropdownMenu modal={false}>
       <DropdownMenuTrigger asChild>
         <Button
           variant="outline"

--- a/src/app/(main)/dashboard/link/new/page.tsx
+++ b/src/app/(main)/dashboard/link/new/page.tsx
@@ -6,7 +6,6 @@ import { AnimatePresence, motion } from "framer-motion";
 import {
   IconChevronDown,
   IconChevronUp,
-  IconDiamond,
   IconLoader2,
   IconSparkles,
   IconX,
@@ -38,7 +37,6 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { Switch } from "@/components/ui/switch";
-import { cn } from "@/lib/utils";
 import { fetchMetadataInfo } from "@/lib/utils/fetch-link-metadata";
 import { createLinkSchema } from "@/server/api/routers/link/link.input";
 import { api } from "@/trpc/react";
@@ -50,6 +48,7 @@ const GeoRulesForm = dynamic(
 );
 import { LinkExpirationDatePicker } from "../../_components/links/link-card/update-modal";
 import { UtmParamsForm } from "../../_components/utm-params-form";
+import { PlanBadge, SectionToggle } from "../../_components/section-toggle";
 import { UtmTemplateSelector } from "../../_components/utm-template-selector";
 import { revalidateHomepage } from "../../revalidate-homepage";
 
@@ -66,70 +65,6 @@ type MetaData = {
   image: string;
   favicon: string;
 };
-
-function SectionToggle({
-  title,
-  description,
-  isOpen,
-  onToggle,
-  badge,
-  children,
-}: {
-  title: string;
-  description: string;
-  isOpen: boolean;
-  onToggle: () => void;
-  badge?: React.ReactNode;
-  children: React.ReactNode;
-}) {
-  return (
-    <div className="rounded-lg border border-neutral-200 p-4">
-      <button
-        type="button"
-        className="flex w-full items-center justify-between text-left"
-        onClick={onToggle}
-      >
-        <div className="flex flex-col gap-0.5">
-          <p className="flex items-center gap-2 text-[14px] font-semibold text-neutral-900">
-            {title}
-            {badge}
-          </p>
-          <span className="text-[12px] text-neutral-400">{description}</span>
-        </div>
-        <IconChevronDown
-          size={16}
-          stroke={1.5}
-          className={cn(
-            "shrink-0 text-neutral-400 transition-transform duration-200",
-            isOpen && "rotate-180"
-          )}
-        />
-      </button>
-      <AnimatePresence>
-        {isOpen && (
-          <motion.div
-            initial={{ height: 0, opacity: 0 }}
-            animate={{ height: "auto", opacity: 1 }}
-            exit={{ height: 0, opacity: 0 }}
-            transition={{ duration: 0.2 }}
-            className="overflow-hidden"
-          >
-            <div className="mt-4 space-y-4">{children}</div>
-          </motion.div>
-        )}
-      </AnimatePresence>
-    </div>
-  );
-}
-
-function PlanBadge({ plan }: { plan: string }) {
-  return (
-    <span className="inline-flex items-center gap-1 rounded-full border border-neutral-200 bg-neutral-50 px-2 py-px text-[11px] font-medium uppercase text-neutral-500">
-      <IconDiamond size={12} stroke={1.5} className="text-neutral-400" />
-      {plan}
-    </span>
-  );
-}
 
 export default function CreateLinkPage() {
   const router = useTransitionRouter();

--- a/src/app/(main)/dashboard/qrcodes/_components/edit-qrcode-drawer.tsx
+++ b/src/app/(main)/dashboard/qrcodes/_components/edit-qrcode-drawer.tsx
@@ -1,0 +1,508 @@
+"use client";
+
+import { zodResolver } from "@hookform/resolvers/zod";
+import { format } from "date-fns";
+import { AnimatePresence, motion } from "framer-motion";
+import {
+  IconCalendar,
+  IconClick,
+  IconQrcode,
+  IconX,
+} from "@tabler/icons-react";
+import dynamic from "next/dynamic";
+import { useEffect, useMemo, useState } from "react";
+import { useForm } from "react-hook-form";
+import { toast } from "sonner";
+
+const GeoRulesForm = dynamic(
+  () =>
+    import("@/app/(main)/dashboard/_components/geo-rules-form").then(
+      (mod) => mod.GeoRulesForm
+    ),
+  { ssr: false }
+);
+import { PlanBadge, SectionToggle } from "@/app/(main)/dashboard/_components/section-toggle";
+import { UtmParamsForm } from "@/app/(main)/dashboard/_components/utm-params-form";
+import { UtmTemplateSelector } from "@/app/(main)/dashboard/_components/utm-template-selector";
+import { revalidateRoute } from "@/app/(main)/dashboard/revalidate-homepage";
+import { Button } from "@/components/ui/button";
+import { Calendar } from "@/components/ui/calendar";
+import {
+  Form,
+  FormControl,
+  FormDescription,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
+import { Input } from "@/components/ui/input";
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+import { cn } from "@/lib/utils";
+import { qrcodeUpdateInput } from "@/server/api/routers/qrcode/qrcode.input";
+import { api } from "@/trpc/react";
+
+import type { RouterOutputs } from "@/trpc/shared";
+import type { z } from "zod";
+
+type EditQRCodeFormValues = z.infer<typeof qrcodeUpdateInput>;
+
+type EditQRCodeDrawerProps = {
+  qr: RouterOutputs["qrCode"]["list"][number];
+  open: boolean;
+  onClose: () => void;
+};
+
+type QRCodeData = RouterOutputs["qrCode"]["list"][number];
+type GeoRulesData = RouterOutputs["geoRules"]["getByLinkId"];
+
+function getFormDefaults(
+  qrData: QRCodeData,
+  geoRules?: GeoRulesData,
+): EditQRCodeFormValues {
+  return {
+    id: qrData.id,
+    title: qrData.title ?? "",
+    url: qrData.link?.url ?? qrData.content ?? "",
+    note: qrData.link?.note ?? undefined,
+    tags: (qrData.link?.tags as string[]) || [],
+    utmParams:
+      (qrData.link?.utmParams as {
+        utm_source?: string;
+        utm_medium?: string;
+        utm_campaign?: string;
+        utm_term?: string;
+        utm_content?: string;
+      }) ?? undefined,
+    geoRules:
+      geoRules?.map((rule) => ({
+        type: rule.type,
+        condition: rule.condition,
+        values: rule.values,
+        action: rule.action,
+        destination: rule.destination ?? undefined,
+        blockMessage: rule.blockMessage ?? undefined,
+      })) ?? [],
+    disableLinkAfterClicks: qrData.link?.disableLinkAfterClicks ?? undefined,
+    disableLinkAfterDate: qrData.link?.disableLinkAfterDate ?? undefined,
+  };
+}
+
+export function EditQRCodeDrawer({ qr, open, onClose }: EditQRCodeDrawerProps) {
+  const [tags, setTags] = useState<string[]>((qr.link?.tags as string[]) || []);
+  const [tagInput, setTagInput] = useState("");
+  const [showTagDropdown, setShowTagDropdown] = useState(false);
+  const [isUtmParamsOpen, setIsUtmParamsOpen] = useState(false);
+  const [isOptionalSettingsOpen, setIsOptionalSettingsOpen] = useState(false);
+
+  const { data: userTags } = api.tag.list.useQuery(undefined, { enabled: open });
+  const userSubscription = api.subscriptions.get.useQuery(undefined, { enabled: open });
+  const { data: existingGeoRules } = api.geoRules.getByLinkId.useQuery(
+    { linkId: qr.link?.id ?? 0 },
+    { enabled: open && !!qr.link?.id }
+  );
+
+  const updateMutation = api.qrCode.update.useMutation({
+    onSuccess: async () => {
+      await revalidateRoute("/dashboard/qrcodes");
+      onClose();
+    },
+  });
+
+  const form = useForm<EditQRCodeFormValues>({
+    resolver: zodResolver(qrcodeUpdateInput),
+    defaultValues: getFormDefaults(qr, existingGeoRules),
+  });
+
+  // Reset form when switching QR codes or when geo rules finish loading.
+  // Use qr.id (stable primitive) instead of qr (object ref) to avoid
+  // resetting on every parent re-render and discarding unsaved edits.
+  useEffect(() => {
+    if (!open) return;
+    // Wait for geo rules to load before resetting (avoids a double reset)
+    if (qr.link?.id && existingGeoRules === undefined) return;
+    form.reset(getFormDefaults(qr, existingGeoRules));
+    setTags((qr.link?.tags as string[]) || []);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [qr.id, existingGeoRules, open]);
+
+  const handleTagKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === "Enter" && tagInput.trim() !== "") {
+      e.preventDefault();
+      addTag(tagInput.trim());
+    } else if (e.key === "ArrowDown" && userTags && userTags.length > 0) {
+      setShowTagDropdown(true);
+    }
+  };
+
+  const addTag = (tagToAdd: string) => {
+    if (!tags.includes(tagToAdd)) {
+      const newTags = [...tags, tagToAdd];
+      setTags(newTags);
+      form.setValue("tags", newTags);
+      setTagInput("");
+    }
+    setShowTagDropdown(false);
+  };
+
+  const removeTag = (tagToRemove: string) => {
+    const newTags = tags.filter((tag) => tag !== tagToRemove);
+    setTags(newTags);
+    form.setValue("tags", newTags);
+  };
+
+  const filteredTags = useMemo(
+    () =>
+      userTags
+        ? userTags
+            .filter(
+              (tag) =>
+                (tagInput === "" || tag.name.toLowerCase().includes(tagInput.toLowerCase())) &&
+                !tags.includes(tag.name),
+            )
+            .map((tag) => tag.name)
+        : [],
+    [userTags, tags, tagInput],
+  );
+
+  async function onSubmit(values: EditQRCodeFormValues) {
+    values.tags = tags;
+    toast.promise(updateMutation.mutateAsync(values), {
+      loading: "Updating QR code...",
+      success: "QR code updated successfully",
+      error: "Failed to update QR code",
+    });
+  }
+
+  const subscriptionStatus = userSubscription?.data?.subscriptions;
+  const isUltraUser = subscriptionStatus?.plan === "ultra";
+  const isProOrUltraUser = subscriptionStatus?.status === "active";
+
+  const scans = qr.visitCount ?? 0;
+
+  return (
+    <AnimatePresence>
+      {open && (
+        <>
+          {/* Backdrop */}
+          <motion.div
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            transition={{ duration: 0.2 }}
+            style={{ willChange: "opacity" }}
+            className="fixed inset-0 z-40 bg-black/20 backdrop-blur-[2px]"
+            onClick={onClose}
+          />
+
+          {/* Drawer Panel */}
+          <motion.div
+            initial={{ x: "100%" }}
+            animate={{ x: 0 }}
+            exit={{ x: "100%" }}
+            transition={{ type: "spring", damping: 30, stiffness: 300 }}
+            className="fixed right-0 top-0 z-50 flex h-full w-full max-w-xl flex-col border-l border-neutral-200 bg-white"
+          >
+            {/* Header */}
+            <div className="border-b border-neutral-200 px-6 py-5">
+              <div className="flex items-start justify-between">
+                <div>
+                  <h2 className="text-[14px] font-semibold text-neutral-900">Edit QR Code</h2>
+                  <p className="mt-0.5 flex items-center gap-1.5 text-[13px] text-neutral-500">
+                    <IconQrcode size={14} stroke={1.5} className="text-neutral-400" />
+                    {qr.title || "Untitled QR Code"}
+                  </p>
+                  <div className="mt-2 flex items-center gap-3 text-[12px] text-neutral-400">
+                    <span className="flex items-center gap-1">
+                      <IconClick size={14} stroke={1.5} className="text-blue-600" />
+                      {scans} scans
+                    </span>
+                    <span>
+                      Created{" "}
+                      {qr.createdAt ? format(new Date(qr.createdAt), "MMM d, yyyy") : "Unknown"}
+                    </span>
+                  </div>
+                </div>
+                <button
+                  onClick={onClose}
+                  aria-label="Close drawer"
+                  className="rounded-md p-1 text-neutral-400 transition-colors hover:bg-neutral-50 hover:text-neutral-600"
+                >
+                  <IconX size={18} stroke={1.5} />
+                </button>
+              </div>
+            </div>
+
+            {/* Form Content */}
+            <div className="flex-1 overflow-y-auto">
+              <Form {...form}>
+                <form className="space-y-4 p-6">
+                  {/* Basic Information */}
+                  <div className="space-y-4 rounded-lg border border-neutral-200 p-4">
+                    <FormField
+                      control={form.control}
+                      name="url"
+                      render={({ field }) => (
+                        <FormItem>
+                          <FormLabel className="text-[13px] font-medium text-neutral-700">Destination URL</FormLabel>
+                          <FormControl>
+                            <Input
+                              className="h-9 border-neutral-200 bg-white text-[13px] placeholder:text-neutral-400 focus-visible:ring-neutral-300"
+                              placeholder="https://site.com"
+                              {...field}
+                            />
+                          </FormControl>
+                          <FormDescription className="text-[12px] text-neutral-400">
+                            Change where this QR code redirects to
+                          </FormDescription>
+                          <FormMessage />
+                        </FormItem>
+                      )}
+                    />
+
+                    <FormField
+                      control={form.control}
+                      name="title"
+                      render={({ field }) => (
+                        <FormItem>
+                          <FormLabel className="text-[13px] font-medium text-neutral-700">QR Code Title</FormLabel>
+                          <FormControl>
+                            <Input
+                              className="h-9 border-neutral-200 bg-white text-[13px] placeholder:text-neutral-400 focus-visible:ring-neutral-300"
+                              placeholder="My QR Code"
+                              {...field}
+                            />
+                          </FormControl>
+                          <FormDescription className="text-[12px] text-neutral-400">
+                            A friendly name to identify your QR code (optional)
+                          </FormDescription>
+                          <FormMessage />
+                        </FormItem>
+                      )}
+                    />
+
+                    <FormField
+                      control={form.control}
+                      name="note"
+                      render={({ field }) => (
+                        <FormItem>
+                          <FormLabel className="text-[13px] font-medium text-neutral-700">Note</FormLabel>
+                          <FormControl>
+                            <Input
+                              className="h-9 border-neutral-200 bg-white text-[13px] placeholder:text-neutral-400 focus-visible:ring-neutral-300"
+                              placeholder="Add a note to your QR code"
+                              {...field}
+                            />
+                          </FormControl>
+                          <FormMessage />
+                        </FormItem>
+                      )}
+                    />
+
+                    {/* Tags */}
+                    <FormField
+                      control={form.control}
+                      name="tags"
+                      render={() => (
+                        <FormItem>
+                          <FormLabel className="text-[13px] font-medium text-neutral-700">Tags</FormLabel>
+                          <FormControl>
+                            <div className="relative">
+                              {tags.length > 0 && (
+                                <div className="mb-2 flex flex-wrap gap-1.5">
+                                  {tags.map((tag) => (
+                                    <div
+                                      key={tag}
+                                      className="inline-flex items-center gap-1 rounded-md bg-neutral-100 px-2 py-0.5 text-[12px] font-medium text-neutral-600"
+                                    >
+                                      <span>{tag}</span>
+                                      <button
+                                        type="button"
+                                        onClick={() => removeTag(tag)}
+                                        aria-label={`Remove tag ${tag}`}
+                                        className="text-neutral-400 transition-colors hover:text-neutral-600"
+                                      >
+                                        <IconX size={12} stroke={1.5} />
+                                      </button>
+                                    </div>
+                                  ))}
+                                </div>
+                              )}
+                              <div className="relative">
+                                <Input
+                                  className="h-9 border-neutral-200 bg-white text-[13px] placeholder:text-neutral-400 focus-visible:ring-neutral-300"
+                                  placeholder="Add tags (press Enter)"
+                                  value={tagInput}
+                                  onChange={(e) => {
+                                    setTagInput(e.target.value);
+                                    setShowTagDropdown(true);
+                                  }}
+                                  onKeyDown={handleTagKeyDown}
+                                  onBlur={() => {
+                                    setTimeout(() => setShowTagDropdown(false), 200);
+                                  }}
+                                  onFocus={() => setShowTagDropdown(true)}
+                                />
+
+                                {showTagDropdown && filteredTags.length > 0 && (
+                                  <div className="absolute z-10 mt-1 max-h-48 w-full overflow-auto rounded-md border border-neutral-200 bg-white shadow-md">
+                                    {filteredTags.map((tag) => (
+                                      <div
+                                        key={tag}
+                                        className="cursor-pointer px-3 py-2 text-[13px] text-neutral-600 transition-colors hover:bg-neutral-50 hover:text-neutral-900"
+                                        onMouseDown={(e) => {
+                                          e.preventDefault();
+                                          addTag(tag);
+                                        }}
+                                      >
+                                        {tag}
+                                      </div>
+                                    ))}
+                                  </div>
+                                )}
+                              </div>
+                            </div>
+                          </FormControl>
+                          <FormDescription className="text-[12px] text-neutral-400">
+                            Press Enter to add a tag, or select from existing tags.
+                          </FormDescription>
+                          <FormMessage />
+                        </FormItem>
+                      )}
+                    />
+                  </div>
+
+                  {/* UTM Parameters */}
+                  <SectionToggle
+                    title="UTM Parameters"
+                    description="Add UTM parameters for campaign tracking"
+                    isOpen={isUtmParamsOpen}
+                    onToggle={() => setIsUtmParamsOpen(!isUtmParamsOpen)}
+                    badge={!isUltraUser ? <PlanBadge plan="Ultra" /> : undefined}
+                  >
+                    {isUltraUser && (
+                      <div className="flex justify-end">
+                        <UtmTemplateSelector
+                          onSelect={(params) => {
+                            form.setValue("utmParams.utm_source", params.utm_source ?? undefined);
+                            form.setValue("utmParams.utm_medium", params.utm_medium ?? undefined);
+                            form.setValue("utmParams.utm_campaign", params.utm_campaign ?? undefined);
+                            form.setValue("utmParams.utm_term", params.utm_term ?? undefined);
+                            form.setValue("utmParams.utm_content", params.utm_content ?? undefined);
+                          }}
+                        />
+                      </div>
+                    )}
+                    <UtmParamsForm form={form} disabled={!isUltraUser} />
+                  </SectionToggle>
+
+                  {/* Geotargeting Rules */}
+                  <GeoRulesForm
+                    form={form}
+                    disabled={!isProOrUltraUser}
+                    maxRules={isUltraUser ? undefined : 3}
+                    isUnlimited={isUltraUser}
+                  />
+
+                  {/* Optional Settings */}
+                  <SectionToggle
+                    title="Optional Settings"
+                    description="Configure additional options for your QR code"
+                    isOpen={isOptionalSettingsOpen}
+                    onToggle={() => setIsOptionalSettingsOpen(!isOptionalSettingsOpen)}
+                  >
+                    <FormField
+                      control={form.control}
+                      name="disableLinkAfterClicks"
+                      render={({ field }) => (
+                        <FormItem>
+                          <FormLabel className="text-[13px] font-medium text-neutral-700">Disable after scans</FormLabel>
+                          <FormControl>
+                            <Input
+                              {...field}
+                              type="number"
+                              className="h-9 border-neutral-200 bg-white text-[13px] placeholder:text-neutral-400 focus-visible:ring-neutral-300"
+                            />
+                          </FormControl>
+                          <FormDescription className="text-[12px] text-neutral-400">
+                            Deactivate after a certain number of scans. Leave empty to never disable.
+                          </FormDescription>
+                          <FormMessage />
+                        </FormItem>
+                      )}
+                    />
+
+                    <FormField
+                      control={form.control}
+                      name="disableLinkAfterDate"
+                      render={({ field }) => (
+                        <FormItem>
+                          <FormLabel className="text-[13px] font-medium text-neutral-700">Disable after date</FormLabel>
+                          <FormControl>
+                            <Popover>
+                              <PopoverTrigger asChild>
+                                <Button
+                                  variant="outline"
+                                  className={cn(
+                                    "h-9 w-full justify-start border-neutral-200 text-left text-[13px] font-normal hover:bg-neutral-50",
+                                    !field.value && "text-neutral-400",
+                                  )}
+                                >
+                                  <IconCalendar size={14} stroke={1.5} className="mr-2 text-neutral-400" />
+                                  {field.value ? (
+                                    format(new Date(field.value), "PPP")
+                                  ) : (
+                                    <span>Pick a date</span>
+                                  )}
+                                </Button>
+                              </PopoverTrigger>
+                              <PopoverContent className="w-auto p-0">
+                                <Calendar
+                                  mode="single"
+                                  selected={field.value ? new Date(field.value) : undefined}
+                                  onSelect={(date) => field.onChange(date)}
+                                  initialFocus
+                                  disabled={(date) => date < new Date()}
+                                />
+                              </PopoverContent>
+                            </Popover>
+                          </FormControl>
+                          <FormDescription className="text-[12px] text-neutral-400">
+                            Deactivate the QR code after a certain date.
+                          </FormDescription>
+                          <FormMessage />
+                        </FormItem>
+                      )}
+                    />
+                  </SectionToggle>
+                </form>
+              </Form>
+            </div>
+
+            {/* Footer */}
+            <div className="border-t border-neutral-200 bg-neutral-50 px-6 py-4">
+              <div className="flex items-center justify-end gap-3">
+                <Button
+                  type="button"
+                  variant="outline"
+                  onClick={onClose}
+                  className="h-9 border-neutral-200 text-[13px] hover:bg-neutral-50"
+                >
+                  Cancel
+                </Button>
+                <Button
+                  type="button"
+                  onClick={form.handleSubmit(onSubmit)}
+                  disabled={updateMutation.isLoading}
+                  className="h-9 bg-blue-600 text-[13px] text-white hover:bg-blue-700"
+                >
+                  {updateMutation.isLoading ? "Saving..." : "Save Changes"}
+                </Button>
+              </div>
+            </div>
+          </motion.div>
+        </>
+      )}
+    </AnimatePresence>
+  );
+}

--- a/src/app/(main)/dashboard/qrcodes/_components/qrcode-actions.tsx
+++ b/src/app/(main)/dashboard/qrcodes/_components/qrcode-actions.tsx
@@ -1,0 +1,280 @@
+"use client";
+
+import {
+  IconDots,
+  IconDownload,
+  IconLink,
+  IconLinkOff,
+  IconPencil,
+  IconRefresh,
+  IconTrash,
+} from "@tabler/icons-react";
+import { useState } from "react";
+import { toast } from "sonner";
+
+import { POSTHOG_EVENTS, trackEvent } from "@/lib/analytics/events";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { api } from "@/trpc/react";
+
+import { revalidateRoute } from "../../revalidate-homepage";
+import { EditQRCodeDrawer } from "./edit-qrcode-drawer";
+
+import type { RouterOutputs } from "@/trpc/shared";
+
+type QRCodeActionsProps = {
+  qr: RouterOutputs["qrCode"]["list"][number];
+};
+
+export function QRCodeActions({ qr }: QRCodeActionsProps) {
+  const [hasOpenedDrawer, setHasOpenedDrawer] = useState(false);
+  const [openEditDrawer, setOpenEditDrawer] = useState(false);
+  const [resetStatsDialog, setResetStatsDialog] = useState(false);
+  const [deleteDialog, setDeleteDialog] = useState(false);
+
+  const isActive = !qr.link?.disabled;
+
+  const toggleStatusMutation = api.qrCode.toggleStatus.useMutation({
+    onSuccess: async () => {
+      await revalidateRoute("/dashboard/qrcodes");
+    },
+  });
+
+  const resetStatsMutation = api.qrCode.resetStatistics.useMutation({
+    onSuccess: async () => {
+      await revalidateRoute("/dashboard/qrcodes");
+      setResetStatsDialog(false);
+    },
+  });
+
+  const deleteMutation = api.qrCode.delete.useMutation({
+    onSuccess: async () => {
+      await revalidateRoute("/dashboard/qrcodes");
+      setDeleteDialog(false);
+    },
+  });
+
+  const handleOpenEditDrawer = () => {
+    setHasOpenedDrawer(true);
+    setOpenEditDrawer(true);
+  };
+
+  const handleDownload = () => {
+    if (!qr.qrCode) {
+      toast.error("QR code image is not available for download.");
+      return;
+    }
+    const a = document.createElement("a");
+    a.href = qr.qrCode;
+    a.download = qr.title ?? "qr-code";
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+    trackEvent(POSTHOG_EVENTS.QR_CODE_DOWNLOADED);
+  };
+
+  const handleToggleStatus = () => {
+    toast.promise(toggleStatusMutation.mutateAsync({ id: qr.id }), {
+      loading: "Updating...",
+      success: isActive ? "QR code deactivated" : "QR code activated",
+      error: "Failed to update",
+    });
+  };
+
+  return (
+    <>
+      <DropdownMenu modal={false}>
+        <DropdownMenuTrigger asChild>
+          <button
+            type="button"
+            className="flex h-7 w-7 items-center justify-center rounded-md text-neutral-400 transition-colors hover:bg-neutral-100 hover:text-neutral-600 focus:outline-none"
+          >
+            <IconDots size={16} stroke={1.5} />
+          </button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent
+          align="end"
+          className="w-52 border-neutral-200 p-1"
+          sideOffset={4}
+        >
+          <DropdownMenuLabel className="px-2 py-1.5 text-[11px] font-medium uppercase tracking-wider text-neutral-400">
+            Edit & Manage
+          </DropdownMenuLabel>
+          <DropdownMenuItem
+            onClick={handleOpenEditDrawer}
+            className="rounded-md px-2 py-1.5 text-[13px] text-neutral-600 focus:bg-neutral-50 focus:text-neutral-900"
+          >
+            <IconPencil
+              size={15}
+              stroke={1.5}
+              className="mr-2 text-neutral-400"
+            />
+            Edit QR code
+          </DropdownMenuItem>
+          <DropdownMenuItem
+            onClick={handleDownload}
+            className="rounded-md px-2 py-1.5 text-[13px] text-neutral-600 focus:bg-neutral-50 focus:text-neutral-900"
+          >
+            <IconDownload
+              size={15}
+              stroke={1.5}
+              className="mr-2 text-neutral-400"
+            />
+            Download
+          </DropdownMenuItem>
+
+          <DropdownMenuSeparator className="my-1 bg-neutral-100" />
+
+          <DropdownMenuLabel className="px-2 py-1.5 text-[11px] font-medium uppercase tracking-wider text-neutral-400">
+            Settings
+          </DropdownMenuLabel>
+          <DropdownMenuItem
+            onClick={handleToggleStatus}
+            className="rounded-md px-2 py-1.5 text-[13px] text-neutral-600 focus:bg-neutral-50 focus:text-neutral-900"
+          >
+            {isActive ? (
+              <>
+                <IconLinkOff
+                  size={15}
+                  stroke={1.5}
+                  className="mr-2 text-neutral-400"
+                />
+                Deactivate QR code
+              </>
+            ) : (
+              <>
+                <IconLink
+                  size={15}
+                  stroke={1.5}
+                  className="mr-2 text-neutral-400"
+                />
+                Activate QR code
+              </>
+            )}
+          </DropdownMenuItem>
+
+          <DropdownMenuSeparator className="my-1 bg-neutral-100" />
+
+          <DropdownMenuItem
+            onClick={() => setResetStatsDialog(true)}
+            className="rounded-md px-2 py-1.5 text-[13px] text-red-600 focus:bg-red-50 focus:text-red-600"
+          >
+            <IconRefresh size={15} stroke={1.5} className="mr-2" />
+            Reset statistics
+          </DropdownMenuItem>
+          <DropdownMenuItem
+            onClick={() => setDeleteDialog(true)}
+            className="rounded-md px-2 py-1.5 text-[13px] text-red-600 focus:bg-red-50 focus:text-red-600"
+          >
+            <IconTrash size={15} stroke={1.5} className="mr-2" />
+            Delete QR code
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
+
+      {hasOpenedDrawer && (
+        <EditQRCodeDrawer
+          qr={qr}
+          open={openEditDrawer}
+          onClose={() => setOpenEditDrawer(false)}
+        />
+      )}
+
+      {/* Reset Statistics Dialog */}
+      <AlertDialog open={resetStatsDialog} onOpenChange={setResetStatsDialog}>
+        <AlertDialogContent className="max-w-sm border-neutral-200">
+          <AlertDialogHeader>
+            <AlertDialogTitle className="text-[15px] font-semibold text-neutral-900">
+              Reset statistics?
+            </AlertDialogTitle>
+            <AlertDialogDescription className="text-[13px] text-neutral-500">
+              This will permanently delete all scan data for{" "}
+              <span className="font-medium text-neutral-700">
+                {qr.title || "this QR code"}
+              </span>
+              . This cannot be undone.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter className="gap-2">
+            <AlertDialogCancel className="h-9 border-neutral-200 text-[13px] hover:bg-neutral-50">
+              Cancel
+            </AlertDialogCancel>
+            <AlertDialogAction
+              onClick={(e) => {
+                e.preventDefault();
+                toast.promise(
+                  resetStatsMutation.mutateAsync({ id: qr.id }),
+                  {
+                    loading: "Resetting...",
+                    success: "Statistics reset",
+                    error: "Failed to reset",
+                  },
+                );
+              }}
+              disabled={resetStatsMutation.isLoading}
+              className="h-9 bg-red-600 text-[13px] text-white hover:bg-red-700 disabled:opacity-50"
+            >
+              {resetStatsMutation.isLoading ? "Resetting..." : "Reset"}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+
+      {/* Delete QR Code Dialog */}
+      <AlertDialog open={deleteDialog} onOpenChange={setDeleteDialog}>
+        <AlertDialogContent className="max-w-sm border-neutral-200">
+          <AlertDialogHeader>
+            <AlertDialogTitle className="text-[15px] font-semibold text-neutral-900">
+              Delete QR code?
+            </AlertDialogTitle>
+            <AlertDialogDescription className="text-[13px] text-neutral-500">
+              This will permanently delete{" "}
+              <span className="font-medium text-neutral-700">
+                {qr.title || "this QR code"}
+              </span>{" "}
+              and all its scan data. This cannot be undone.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter className="gap-2">
+            <AlertDialogCancel className="h-9 border-neutral-200 text-[13px] hover:bg-neutral-50">
+              Cancel
+            </AlertDialogCancel>
+            <AlertDialogAction
+              onClick={(e) => {
+                e.preventDefault();
+                toast.promise(
+                  deleteMutation.mutateAsync({ id: qr.id }),
+                  {
+                    loading: "Deleting...",
+                    success: "QR code deleted",
+                    error: "Failed to delete",
+                  },
+                );
+              }}
+              disabled={deleteMutation.isLoading}
+              className="h-9 bg-red-600 text-[13px] text-white hover:bg-red-700 disabled:opacity-50"
+            >
+              {deleteMutation.isLoading ? "Deleting..." : "Delete"}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </>
+  );
+}

--- a/src/app/(main)/dashboard/qrcodes/_components/qrcode-card-new.tsx
+++ b/src/app/(main)/dashboard/qrcodes/_components/qrcode-card-new.tsx
@@ -3,29 +3,13 @@
 import { motion } from "framer-motion";
 import {
   IconClick,
-  IconDownload,
   IconExternalLink,
-  IconTrash,
 } from "@tabler/icons-react";
 import { Link } from "next-view-transitions";
-import { useState } from "react";
-import { toast } from "sonner";
 
-import { POSTHOG_EVENTS, trackEvent } from "@/lib/analytics/events";
-import {
-  AlertDialog,
-  AlertDialogAction,
-  AlertDialogCancel,
-  AlertDialogContent,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogTitle,
-} from "@/components/ui/alert-dialog";
 import { daysSinceDate } from "@/lib/utils";
-import { api } from "@/trpc/react";
 
-import { revalidateRoute } from "../../revalidate-homepage";
+import { QRCodeActions } from "./qrcode-actions";
 
 import type { RouterOutputs } from "@/trpc/shared";
 
@@ -35,36 +19,8 @@ type QRCodeCardProps = {
 };
 
 export function QRCodeCard({ qr, index }: QRCodeCardProps) {
-  const [deleteDialog, setDeleteDialog] = useState(false);
-  const deleteQrMutation = api.qrCode.delete.useMutation({
-    onSuccess: async () => {
-      await revalidateRoute("/dashboard/qrcodes");
-    },
-  });
-
   const daysSinceCreation = daysSinceDate(new Date(qr.createdAt!));
   const scans = qr.visitCount ?? 0;
-
-  const handleDownload = () => {
-    const link = document.createElement("a");
-    link.href = qr.qrCode!;
-    link.download = qr.title ?? "qr-code";
-    link.click();
-    trackEvent(POSTHOG_EVENTS.QR_CODE_DOWNLOADED);
-  };
-
-  const handleDelete = async () => {
-    try {
-      await toast.promise(deleteQrMutation.mutateAsync({ id: qr.id }), {
-        loading: "Deleting QR Code",
-        success: "QR Code deleted successfully",
-        error: "Failed to delete QR Code",
-      });
-      setDeleteDialog(false);
-    } catch {
-      // Error is already handled by toast.promise
-    }
-  };
 
   return (
     <motion.div
@@ -136,58 +92,16 @@ export function QRCodeCard({ qr, index }: QRCodeCardProps) {
               <span className="font-medium">{scans}</span>
             </Link>
 
-            <div className="flex items-center gap-0.5 opacity-0 transition-opacity group-hover:opacity-100">
-              <button
-                type="button"
-                onClick={handleDownload}
-                className="flex h-7 w-7 items-center justify-center rounded-md text-neutral-400 transition-colors hover:bg-neutral-100 hover:text-neutral-600"
-              >
-                <IconDownload size={14} stroke={1.5} />
-              </button>
-              <button
-                type="button"
-                onClick={() => setDeleteDialog(true)}
-                className="flex h-7 w-7 items-center justify-center rounded-md text-neutral-400 transition-colors hover:bg-red-50 hover:text-red-600"
-              >
-                <IconTrash size={14} stroke={1.5} />
-              </button>
+            <div className="w-7">
+              {qr.link && (
+                <div className="opacity-0 transition-opacity group-hover:opacity-100">
+                  <QRCodeActions qr={qr} />
+                </div>
+              )}
             </div>
           </div>
         </div>
       </div>
-
-      {/* Delete Confirmation */}
-      <AlertDialog open={deleteDialog} onOpenChange={setDeleteDialog}>
-        <AlertDialogContent className="max-w-md rounded-xl">
-          <AlertDialogHeader>
-            <AlertDialogTitle className="text-[14px] font-semibold text-neutral-900">
-              Delete QR Code?
-            </AlertDialogTitle>
-            <AlertDialogDescription className="text-[12px] text-neutral-500">
-              This will permanently delete{" "}
-              <span className="font-medium text-neutral-700">
-                {qr.title || "this QR Code"}
-              </span>
-              . This action cannot be undone.
-            </AlertDialogDescription>
-          </AlertDialogHeader>
-          <AlertDialogFooter>
-            <AlertDialogCancel className="rounded-lg border-neutral-200 text-[13px]">
-              Cancel
-            </AlertDialogCancel>
-            <AlertDialogAction
-              onClick={(e) => {
-                e.preventDefault();
-                handleDelete();
-              }}
-              disabled={deleteQrMutation.isLoading}
-              className="rounded-lg bg-red-600 text-[13px] text-white hover:bg-red-700 disabled:opacity-50"
-            >
-              {deleteQrMutation.isLoading ? "Deleting..." : "Delete"}
-            </AlertDialogAction>
-          </AlertDialogFooter>
-        </AlertDialogContent>
-      </AlertDialog>
     </motion.div>
   );
 }

--- a/src/server/api/routers/link/link.input.ts
+++ b/src/server/api/routers/link/link.input.ts
@@ -68,7 +68,7 @@ export const listLinksSchema = z.object({
   search: z.string().optional(),
 });
 
-const geoRuleInputSchema = z
+export const geoRuleInputSchema = z
   .object({
     type: z.enum(["country", "continent"]),
     condition: z.enum(["in", "not_in"]),

--- a/src/server/api/routers/qrcode/qrcode.input.ts
+++ b/src/server/api/routers/qrcode/qrcode.input.ts
@@ -1,5 +1,7 @@
 import { z } from "zod";
 
+import { geoRuleInputSchema } from "../link/link.input";
+
 export const qrcodeInput = z.object({
   title: z.string().optional(),
   content: z.string().url("Please enter a valid URL"),
@@ -13,15 +15,29 @@ export const qrcodeSaveImageInput = z.object({
   qrCodeBase64: z.string(),
 });
 
-export const qrcodeLinkUpdate = z.object({
-  url: z.string(),
-});
-
-export const qrcodeUpdate = qrcodeLinkUpdate.extend({
+export const qrcodeUpdateInput = z.object({
   id: z.number(),
+  title: z.string().optional(),
+  url: z.string().url("Please enter a valid URL").optional(),
+  note: z.string().optional(),
+  tags: z.array(z.string()).optional(),
+  utmParams: z
+    .object({
+      utm_source: z.string().max(255).optional(),
+      utm_medium: z.string().max(255).optional(),
+      utm_campaign: z.string().max(255).optional(),
+      utm_term: z.string().max(255).optional(),
+      utm_content: z.string().max(255).optional(),
+    })
+    .optional(),
+  geoRules: z.array(geoRuleInputSchema).optional(),
+  disableLinkAfterClicks: z.number().optional(),
+  disableLinkAfterDate: z.date().optional(),
 });
 
-export const qrcodeDeleteInput = z.object({
+export type QRCodeUpdateInput = z.infer<typeof qrcodeUpdateInput>;
+
+export const qrcodeIdInput = z.object({
   id: z.number(),
 });
 

--- a/src/server/api/routers/qrcode/qrcode.procedure.ts
+++ b/src/server/api/routers/qrcode/qrcode.procedure.ts
@@ -6,17 +6,27 @@ export const qrCodeRouter = createTRPCRouter({
   create: workspaceProcedure.input(inputs.qrcodeInput).mutation(async ({ ctx, input }) => {
     return services.createQrCode(ctx, input);
   }),
-  get: workspaceProcedure.input(inputs.qrcodeDeleteInput).query(async ({ ctx, input }) => {
+  get: workspaceProcedure.input(inputs.qrcodeIdInput).query(async ({ ctx, input }) => {
     return services.getQrCode(ctx, input.id);
   }),
   list: workspaceProcedure.query(async ({ ctx }) => {
     return services.retrieveUserQrCodes(ctx);
   }),
-  delete: workspaceProcedure.input(inputs.qrcodeDeleteInput).mutation(async ({ ctx, input }) => {
+  delete: workspaceProcedure.input(inputs.qrcodeIdInput).mutation(async ({ ctx, input }) => {
     return services.deleteQrCode(ctx, input.id);
   }),
   saveImage: workspaceProcedure.input(inputs.qrcodeSaveImageInput).mutation(async ({ ctx, input }) => {
     return services.saveQrCodeImage(ctx, input);
+  }),
+
+  update: workspaceProcedure.input(inputs.qrcodeUpdateInput).mutation(async ({ ctx, input }) => {
+    return services.updateQrCode(ctx, input);
+  }),
+  resetStatistics: workspaceProcedure.input(inputs.qrcodeIdInput).mutation(async ({ ctx, input }) => {
+    return services.resetQrCodeStatistics(ctx, input.id);
+  }),
+  toggleStatus: workspaceProcedure.input(inputs.qrcodeIdInput).mutation(async ({ ctx, input }) => {
+    return services.toggleQrCodeStatus(ctx, input.id);
   }),
 
   // QR Preset procedures

--- a/src/server/api/routers/qrcode/qrcode.service.ts
+++ b/src/server/api/routers/qrcode/qrcode.service.ts
@@ -15,8 +15,10 @@ import {
   incrementWorkspaceLinkCount,
 } from "../link/utils";
 
+import { updateLink } from "../link/link.service";
+
 import type { WorkspaceTRPCContext } from "../../trpc";
-import type { QRCodeInput, QRPresetCreateInput, QRPresetUpdateInput } from "./qrcode.input";
+import type { QRCodeInput, QRCodeUpdateInput, QRPresetCreateInput, QRPresetUpdateInput } from "./qrcode.input";
 import type { z } from "zod";
 import type { qrcodeSaveImageInput } from "./qrcode.input";
 
@@ -192,6 +194,7 @@ export async function deleteQrCode(ctx: WorkspaceTRPCContext, id: number) {
       eq(qrcode.id, id),
       workspaceFilter(ctx.workspace, qrcode.userId, qrcode.teamId)
     ),
+    with: { link: true },
   });
 
   if (!qrCode) throw new Error("QR Code not found");
@@ -207,13 +210,8 @@ export async function deleteQrCode(ctx: WorkspaceTRPCContext, id: number) {
 
   // Collect cache key before the transaction so we can invalidate after it commits
   let cacheKey: string | undefined;
-  if (qrCode.linkId && qrCode.linkId > 0) {
-    const hiddenLink = await ctx.db.query.link.findFirst({
-      where: eq(link.id, qrCode.linkId),
-    });
-    if (hiddenLink?.alias) {
-      cacheKey = buildCacheKey(hiddenLink.domain, hiddenLink.alias);
-    }
+  if (qrCode.link?.alias) {
+    cacheKey = buildCacheKey(qrCode.link.domain, qrCode.link.alias);
   }
 
   // Delete QR code and its associated hidden link atomically
@@ -232,6 +230,88 @@ export async function deleteQrCode(ctx: WorkspaceTRPCContext, id: number) {
   // Invalidate cache after the transaction commits successfully
   if (cacheKey) {
     void deleteFromCache(cacheKey);
+  }
+
+  return true;
+}
+
+// ---------------------------------------------------------------------------
+// QR Code Update / Actions
+// ---------------------------------------------------------------------------
+
+/** Fetch a QR code by ID with workspace ownership check, joining the associated link. */
+async function fetchQrCodeWithLink(ctx: WorkspaceTRPCContext, id: number) {
+  const qrCode = await ctx.db.query.qrcode.findFirst({
+    where: and(
+      eq(qrcode.id, id),
+      workspaceFilter(ctx.workspace, qrcode.userId, qrcode.teamId),
+    ),
+    with: { link: true },
+  });
+
+  if (!qrCode) throw new TRPCError({ code: "NOT_FOUND", message: "QR Code not found" });
+  if (!qrCode.linkId || !qrCode.link) throw new TRPCError({ code: "BAD_REQUEST", message: "QR Code has no associated link" });
+
+  return qrCode as typeof qrCode & { linkId: number; link: NonNullable<typeof qrCode.link> };
+}
+
+export async function updateQrCode(ctx: WorkspaceTRPCContext, input: QRCodeUpdateInput) {
+  const qrCode = await fetchQrCodeWithLink(ctx, input.id);
+
+  // Phishing check on new destination URL
+  if (input.url) {
+    await assertUrlSafe(input.url);
+  }
+
+  // Sync QR-specific fields first so that if updateLink fails,
+  // the live redirect target (link.url) is still the old safe value.
+  const qrUpdates: Partial<Pick<typeof qrcode.$inferInsert, "title" | "content">> = {};
+  if (input.title !== undefined) qrUpdates.title = input.title;
+  if (input.url !== undefined) qrUpdates.content = input.url;
+
+  if (Object.keys(qrUpdates).length > 0) {
+    await ctx.db
+      .update(qrcode)
+      .set(qrUpdates)
+      .where(eq(qrcode.id, input.id));
+  }
+
+  // Delegate to updateLink for the complex work (cache, tags, geo rules, UTM, etc.)
+  const { id: _qrId, title, url, ...linkFields } = input;
+  await updateLink(ctx, {
+    id: qrCode.linkId,
+    url,
+    name: title,
+    ...linkFields,
+  });
+
+  return true;
+}
+
+export async function resetQrCodeStatistics(ctx: WorkspaceTRPCContext, id: number) {
+  const qrCode = await fetchQrCodeWithLink(ctx, id);
+
+  // Delete both visit tables to fully reset stats (matches deleteQrCode cleanup)
+  await Promise.all([
+    ctx.db.delete(linkVisit).where(eq(linkVisit.linkId, qrCode.linkId)),
+    ctx.db.delete(uniqueLinkVisit).where(eq(uniqueLinkVisit.linkId, qrCode.linkId)),
+  ]);
+
+  return true;
+}
+
+export async function toggleQrCodeStatus(ctx: WorkspaceTRPCContext, id: number) {
+  const qrCode = await fetchQrCodeWithLink(ctx, id);
+
+  // Inline instead of delegating to toggleLinkStatusService to avoid a redundant link re-fetch
+  await ctx.db
+    .update(link)
+    .set({ disabled: !qrCode.link.disabled })
+    .where(eq(link.id, qrCode.linkId));
+
+  // Invalidate cache so the status change takes effect immediately
+  if (qrCode.link.alias) {
+    await deleteFromCache(buildCacheKey(qrCode.link.domain, qrCode.link.alias));
   }
 
   return true;


### PR DESCRIPTION
## Summary

Add full management capabilities to QR codes: edit destination URL, toggle active/inactive status, reset scan statistics, and delete — all accessible via a new actions dropdown on each QR code card. QR codes are now truly dynamic (print once, change destination unlimited times).

## Changes

- Add three new tRPC procedures: `update`, `resetStatistics`, `toggleStatus` with proper workspace ownership checks
- Add QR code actions dropdown with edit, download, activate/deactivate, reset stats, and delete
- Add edit drawer for QR codes (destination URL, title, note, tags, UTM params, geotargeting, expiration settings)
- Extract `SectionToggle` and `PlanBadge` into a shared component (previously duplicated in 2 files, now used by 3)
- Export `geoRuleInputSchema` from link input for reuse in QR code input schema
- Fix `UtmTemplateSelector` dropdown `modal={false}` to prevent dismiss layer issues inside drawers

## Type of Change

- [x] feat: New feature
- [x] refactor: Code refactoring

## Testing

- Manual testing of all QR code actions (edit, download, toggle status, reset stats, delete)
- Verified cache invalidation on URL changes and status toggles
- Confirmed phishing check (`assertUrlSafe`) runs on URL updates
- Verified shared SectionToggle works correctly in all three consumers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Dynamic QR code management: edit destination URL, title, note, tags, UTM params, geotargeting, and scan/date limits.
  * QR code actions menu: Edit, Download, Activate/Deactivate, Reset statistics, Delete.

* **Refactor**
  * Shared UI improvements: unified collapsible section headers and plan badges across the dashboard.

* **Documentation**
  * Added release changelog entry describing dynamic QR code capabilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->