### PR TITLE
feat(admin): enhance dashboard with date range analytics and new widgets

### DIFF
--- a/src/app/(main)/dashboard/admin/_components/daily-activity-chart.tsx
+++ b/src/app/(main)/dashboard/admin/_components/daily-activity-chart.tsx
@@ -16,7 +16,8 @@ import {
   ChartTooltip,
   ChartTooltipContent,
 } from "@/components/ui/chart";
-import { formatChartDate } from "@/lib/utils";
+import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { formatChartDate, formatChartMonth } from "@/lib/utils";
 
 import type { ChartConfig } from "@/components/ui/chart";
 
@@ -29,62 +30,100 @@ const chartConfig = {
     label: "New Users",
     color: "#10b981",
   },
+  clicks: {
+    label: "Clicks",
+    color: "#f59e0b",
+  },
 } satisfies ChartConfig;
 
-type DailyActivityChartProps = {
-  data: { date: string; links: number; users: number }[];
+type ActivityChartProps = {
+  data: { date: string; links: number; users: number; clicks: number }[] | undefined;
+  isLoading: boolean;
+  granularity: "day" | "month";
+  onGranularityChange: (g: "day" | "month") => void;
 };
 
-export function DailyActivityChart({ data }: DailyActivityChartProps) {
+export function ActivityChart({
+  data,
+  isLoading,
+  granularity,
+  onGranularityChange,
+}: ActivityChartProps) {
   return (
     <Card className="overflow-hidden rounded-xl border-neutral-200 shadow-none">
-      <div className="border-b border-neutral-100 px-5 pb-4 pt-5">
+      <div className="flex items-center justify-between border-b border-neutral-100 px-5 pb-4 pt-5">
         <div className="space-y-0.5">
           <h2 className="text-[14px] font-semibold tracking-tight text-neutral-900">
-            Daily Activity
+            Activity
           </h2>
           <p className="text-[12px] text-neutral-400">
-            Links created and new user signups over the last 14 days
+            Links, users, and clicks over time
           </p>
         </div>
+        <Tabs
+          value={granularity}
+          onValueChange={(v) => onGranularityChange(v as "day" | "month")}
+        >
+          <TabsList className="h-7">
+            <TabsTrigger value="day" className="px-2.5 text-[11px]">
+              Daily
+            </TabsTrigger>
+            <TabsTrigger value="month" className="px-2.5 text-[11px]">
+              Monthly
+            </TabsTrigger>
+          </TabsList>
+        </Tabs>
       </div>
 
       <div className="px-2 pb-5 pt-4 sm:px-5 sm:pt-5">
-        <ChartContainer
-          config={chartConfig}
-          className="aspect-auto h-64 w-full"
-        >
-          <RechartsBarChart data={data}>
-            <CartesianGrid vertical={false} />
-            <XAxis
-              dataKey="date"
-              tickLine={false}
-              axisLine={false}
-              tickMargin={8}
-              minTickGap={32}
-              tickFormatter={formatChartDate}
-            />
-            <YAxis
-              tickLine={false}
-              axisLine={false}
-              tickMargin={4}
-              width={32}
-              allowDecimals={false}
-            />
-            <ChartTooltip
-              cursor={false}
-              content={
-                <ChartTooltipContent
-                  labelFormatter={(value) => formatChartDate(String(value))}
-                  indicator="dashed"
-                />
-              }
-            />
-            <Bar dataKey="links" fill="var(--color-links)" radius={4} />
-            <Bar dataKey="users" fill="var(--color-users)" radius={4} />
-            <ChartLegend content={<ChartLegendContent />} />
-          </RechartsBarChart>
-        </ChartContainer>
+        {isLoading || !data ? (
+          <div className="flex h-64 items-center justify-center">
+            <div className="h-5 w-5 animate-spin rounded-full border-2 border-neutral-200 border-t-neutral-400" />
+          </div>
+        ) : (
+          <ChartContainer
+            config={chartConfig}
+            className="aspect-auto h-64 w-full"
+          >
+            <RechartsBarChart data={data}>
+              <CartesianGrid vertical={false} />
+              <XAxis
+                dataKey="date"
+                tickLine={false}
+                axisLine={false}
+                tickMargin={8}
+                minTickGap={32}
+                tickFormatter={
+                  granularity === "month" ? formatChartMonth : formatChartDate
+                }
+              />
+              <YAxis
+                tickLine={false}
+                axisLine={false}
+                tickMargin={4}
+                width={32}
+                allowDecimals={false}
+              />
+              <ChartTooltip
+                cursor={false}
+                content={
+                  <ChartTooltipContent
+                    labelFormatter={(value) =>
+                      granularity === "month"
+                        ? formatChartMonth(String(value))
+                        : formatChartDate(String(value))
+                    }
+                    indicator="dashed"
+                  />
+                }
+              />
+              <Bar dataKey="links" fill="var(--color-links)" radius={4} />
+              <Bar dataKey="users" fill="var(--color-users)" radius={4} />
+              <Bar dataKey="clicks" fill="var(--color-clicks)" radius={4} />
+              <ChartLegend content={<ChartLegendContent />} />
+            </RechartsBarChart>
+          </ChartContainer>
+        )}
       </div>
     </Card>
   );

--- a/src/app/(main)/dashboard/admin/_components/daily-activity-chart.tsx
+++ b/src/app/(main)/dashboard/admin/_components/daily-activity-chart.tsx
@@ -76,9 +76,13 @@ export function ActivityChart({
       </div>
 
       <div className="px-2 pb-5 pt-4 sm:px-5 sm:pt-5">
-        {isLoading || !data ? (
+        {isLoading ? (
           <div className="flex h-64 items-center justify-center">
             <div className="h-5 w-5 animate-spin rounded-full border-2 border-neutral-200 border-t-neutral-400" />
+          </div>
+        ) : !data ? (
+          <div className="flex h-64 items-center justify-center">
+            <p className="text-[13px] text-neutral-400">No data available</p>
           </div>
         ) : (
           <ChartContainer

--- a/src/app/(main)/dashboard/admin/_components/date-range-picker.tsx
+++ b/src/app/(main)/dashboard/admin/_components/date-range-picker.tsx
@@ -1,0 +1,151 @@
+"use client";
+
+import { IconCalendar } from "@tabler/icons-react";
+import { format } from "date-fns";
+import { useState } from "react";
+
+import { Button } from "@/components/ui/button";
+import { Calendar } from "@/components/ui/calendar";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import { cn } from "@/lib/utils";
+
+import type { DateRange } from "react-day-picker";
+
+type Preset = {
+  label: string;
+  getValue: () => { from: Date; to: Date };
+};
+
+const presets: Preset[] = [
+  {
+    label: "7d",
+    getValue: () => {
+      const to = new Date();
+      to.setHours(23, 59, 59, 999);
+      const from = new Date();
+      from.setDate(from.getDate() - 6);
+      from.setHours(0, 0, 0, 0);
+      return { from, to };
+    },
+  },
+  {
+    label: "30d",
+    getValue: () => {
+      const to = new Date();
+      to.setHours(23, 59, 59, 999);
+      const from = new Date();
+      from.setDate(from.getDate() - 29);
+      from.setHours(0, 0, 0, 0);
+      return { from, to };
+    },
+  },
+  {
+    label: "90d",
+    getValue: () => {
+      const to = new Date();
+      to.setHours(23, 59, 59, 999);
+      const from = new Date();
+      from.setDate(from.getDate() - 89);
+      from.setHours(0, 0, 0, 0);
+      return { from, to };
+    },
+  },
+  {
+    label: "1 Year",
+    getValue: () => {
+      const to = new Date();
+      to.setHours(23, 59, 59, 999);
+      const from = new Date();
+      from.setFullYear(from.getFullYear() - 1);
+      from.setHours(0, 0, 0, 0);
+      return { from, to };
+    },
+  },
+  {
+    label: "All Time",
+    getValue: () => {
+      const to = new Date();
+      to.setHours(23, 59, 59, 999);
+      const from = new Date(2020, 0, 1);
+      from.setHours(0, 0, 0, 0);
+      return { from, to };
+    },
+  },
+];
+
+type DateRangePickerProps = {
+  from: Date;
+  to: Date;
+  onChange: (range: { from: Date; to: Date }) => void;
+};
+
+export function DateRangePicker({ from, to, onChange }: DateRangePickerProps) {
+  const [open, setOpen] = useState(false);
+
+  const handleSelect = (range: DateRange | undefined) => {
+    if (range?.from && range?.to) {
+      const newFrom = new Date(range.from);
+      newFrom.setHours(0, 0, 0, 0);
+      const newTo = new Date(range.to);
+      newTo.setHours(23, 59, 59, 999);
+      onChange({ from: newFrom, to: newTo });
+    } else if (range?.from) {
+      const newFrom = new Date(range.from);
+      newFrom.setHours(0, 0, 0, 0);
+      onChange({ from: newFrom, to });
+    }
+  };
+
+  const handlePreset = (preset: Preset) => {
+    onChange(preset.getValue());
+    setOpen(false);
+  };
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <Button
+          variant="outline"
+          size="sm"
+          className={cn(
+            "h-8 gap-1.5 rounded-lg border-neutral-200 px-3 text-[12px] font-medium text-neutral-600",
+          )}
+        >
+          <IconCalendar size={14} stroke={1.5} />
+          <span>
+            {format(from, "MMM d, yyyy")} – {format(to, "MMM d, yyyy")}
+          </span>
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent
+        className="w-auto p-0"
+        align="end"
+        sideOffset={8}
+      >
+        <div className="flex gap-1.5 border-b border-neutral-100 px-3 py-2.5">
+          {presets.map((preset) => (
+            <button
+              key={preset.label}
+              onClick={() => handlePreset(preset)}
+              className="rounded-md px-2.5 py-1 text-[11px] font-medium text-neutral-500 transition-colors hover:bg-neutral-100 hover:text-neutral-700"
+            >
+              {preset.label}
+            </button>
+          ))}
+        </div>
+        <Calendar
+          mode="range"
+          selected={{ from, to }}
+          onSelect={handleSelect}
+          numberOfMonths={2}
+          defaultMonth={new Date(from.getFullYear(), from.getMonth())}
+          disabled={{ after: new Date() }}
+        />
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/src/app/(main)/dashboard/admin/_components/date-range-picker.tsx
+++ b/src/app/(main)/dashboard/admin/_components/date-range-picker.tsx
@@ -86,17 +86,18 @@ type DateRangePickerProps = {
 export function DateRangePicker({ from, to, onChange }: DateRangePickerProps) {
   const [open, setOpen] = useState(false);
 
+  const [draft, setDraft] = useState<Date | null>(null);
+
   const handleSelect = (range: DateRange | undefined) => {
     if (range?.from && range?.to) {
       const newFrom = new Date(range.from);
       newFrom.setHours(0, 0, 0, 0);
       const newTo = new Date(range.to);
       newTo.setHours(23, 59, 59, 999);
+      setDraft(null);
       onChange({ from: newFrom, to: newTo });
     } else if (range?.from) {
-      const newFrom = new Date(range.from);
-      newFrom.setHours(0, 0, 0, 0);
-      onChange({ from: newFrom, to });
+      setDraft(range.from);
     }
   };
 
@@ -139,7 +140,7 @@ export function DateRangePicker({ from, to, onChange }: DateRangePickerProps) {
         </div>
         <Calendar
           mode="range"
-          selected={{ from, to }}
+          selected={draft ? { from: draft, to: undefined } : { from, to }}
           onSelect={handleSelect}
           numberOfMonths={2}
           defaultMonth={new Date(from.getFullYear(), from.getMonth())}

--- a/src/app/(main)/dashboard/admin/_components/monthly-breakdown-card.tsx
+++ b/src/app/(main)/dashboard/admin/_components/monthly-breakdown-card.tsx
@@ -1,0 +1,141 @@
+"use client";
+
+import { IconChevronDown, IconChevronUp, IconTable } from "@tabler/icons-react";
+import { useMemo, useState } from "react";
+
+import { Card } from "@/components/ui/card";
+import { formatChartMonth } from "@/lib/utils";
+
+type MonthlyRow = {
+  month: string;
+  links: number;
+  users: number;
+  clicks: number;
+};
+
+type SortKey = "month" | "links" | "users" | "clicks";
+type SortDir = "asc" | "desc";
+
+function SortIcon({ active, dir }: { active: boolean; dir: SortDir }) {
+  if (!active) {
+    return (
+      <IconChevronDown size={12} stroke={1.5} className="text-neutral-300" />
+    );
+  }
+  return dir === "asc" ? (
+    <IconChevronUp size={12} stroke={2} className="text-neutral-700" />
+  ) : (
+    <IconChevronDown size={12} stroke={2} className="text-neutral-700" />
+  );
+}
+
+type MonthlyBreakdownCardProps = {
+  data: MonthlyRow[] | undefined;
+  isLoading: boolean;
+};
+
+export function MonthlyBreakdownCard({
+  data,
+  isLoading,
+}: MonthlyBreakdownCardProps) {
+  const [sortKey, setSortKey] = useState<SortKey>("month");
+  const [sortDir, setSortDir] = useState<SortDir>("desc");
+
+  const sorted = useMemo(() => {
+    if (!data) return [];
+    return [...data].sort((a, b) => {
+      const av = a[sortKey];
+      const bv = b[sortKey];
+      if (typeof av === "string" && typeof bv === "string") {
+        return sortDir === "asc"
+          ? av.localeCompare(bv)
+          : bv.localeCompare(av);
+      }
+      return sortDir === "asc"
+        ? (av as number) - (bv as number)
+        : (bv as number) - (av as number);
+    });
+  }, [data, sortKey, sortDir]);
+
+  const toggleSort = (key: SortKey) => {
+    if (sortKey === key) {
+      setSortDir((d) => (d === "asc" ? "desc" : "asc"));
+    } else {
+      setSortKey(key);
+      setSortDir("desc");
+    }
+  };
+
+  const columns: { key: SortKey; label: string; align: string }[] = [
+    { key: "month", label: "Month", align: "text-left" },
+    { key: "links", label: "Links", align: "text-right" },
+    { key: "users", label: "Users", align: "text-right" },
+    { key: "clicks", label: "Clicks", align: "text-right" },
+  ];
+
+  return (
+    <Card className="rounded-xl border-neutral-200 shadow-none">
+      <div className="flex items-center gap-2 border-b border-neutral-100 px-5 py-4">
+        <IconTable size={15} stroke={1.5} className="text-neutral-400" />
+        <p className="text-[14px] font-semibold tracking-tight text-neutral-900">
+          Monthly Breakdown
+        </p>
+      </div>
+
+      {isLoading ? (
+        <div className="flex items-center justify-center px-5 py-12">
+          <div className="h-5 w-5 animate-spin rounded-full border-2 border-neutral-200 border-t-neutral-400" />
+        </div>
+      ) : sorted.length === 0 ? (
+        <div className="flex items-center justify-center px-5 py-12">
+          <p className="text-[13px] text-neutral-400">No data for this period</p>
+        </div>
+      ) : (
+        <div className="overflow-x-auto">
+          <table className="w-full">
+            <thead>
+              <tr className="border-b border-neutral-100">
+                {columns.map((col) => (
+                  <th
+                    key={col.key}
+                    className={`cursor-pointer px-5 py-2.5 text-[11px] font-medium uppercase tracking-wider text-neutral-400 transition-colors hover:text-neutral-600 ${col.align}`}
+                    onClick={() => toggleSort(col.key)}
+                  >
+                    <span className="inline-flex items-center gap-1">
+                      {col.label}
+                      <SortIcon
+                        active={sortKey === col.key}
+                        dir={sortDir}
+                      />
+                    </span>
+                  </th>
+                ))}
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-neutral-50">
+              {sorted.map((row) => (
+                <tr
+                  key={row.month}
+                  className="transition-colors hover:bg-neutral-50/50"
+                >
+                  <td className="px-5 py-2.5 text-[13px] font-medium text-neutral-700">
+                    {formatChartMonth(row.month)}
+                  </td>
+                  <td className="px-5 py-2.5 text-right text-[13px] tabular-nums text-neutral-600">
+                    {row.links.toLocaleString()}
+                  </td>
+                  <td className="px-5 py-2.5 text-right text-[13px] tabular-nums text-neutral-600">
+                    {row.users.toLocaleString()}
+                  </td>
+                  <td className="px-5 py-2.5 text-right text-[13px] tabular-nums text-neutral-600">
+                    {row.clicks.toLocaleString()}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </Card>
+  );
+}

--- a/src/app/(main)/dashboard/admin/_components/monthly-breakdown-card.tsx
+++ b/src/app/(main)/dashboard/admin/_components/monthly-breakdown-card.tsx
@@ -98,16 +98,26 @@ export function MonthlyBreakdownCard({
                 {columns.map((col) => (
                   <th
                     key={col.key}
-                    className={`cursor-pointer px-5 py-2.5 text-[11px] font-medium uppercase tracking-wider text-neutral-400 transition-colors hover:text-neutral-600 ${col.align}`}
-                    onClick={() => toggleSort(col.key)}
+                    className={`px-5 py-2.5 ${col.align}`}
+                    aria-sort={
+                      sortKey === col.key
+                        ? sortDir === "asc"
+                          ? "ascending"
+                          : "descending"
+                        : "none"
+                    }
                   >
-                    <span className="inline-flex items-center gap-1">
+                    <button
+                      type="button"
+                      onClick={() => toggleSort(col.key)}
+                      className="inline-flex cursor-pointer items-center gap-1 text-[11px] font-medium uppercase tracking-wider text-neutral-400 transition-colors hover:text-neutral-600"
+                    >
                       {col.label}
                       <SortIcon
                         active={sortKey === col.key}
                         dir={sortDir}
                       />
-                    </span>
+                    </button>
                   </th>
                 ))}
               </tr>

--- a/src/app/(main)/dashboard/admin/_components/peak-periods-card.tsx
+++ b/src/app/(main)/dashboard/admin/_components/peak-periods-card.tsx
@@ -1,0 +1,121 @@
+"use client";
+
+import { Card } from "@/components/ui/card";
+import { formatChartDate, formatChartMonth } from "@/lib/utils";
+
+type PeakPeriod = { date?: string; month?: string; count: number };
+
+type PeakData = {
+  peakLinkDay: PeakPeriod | null;
+  peakUserDay: PeakPeriod | null;
+  peakClickDay: PeakPeriod | null;
+  peakLinkMonth: PeakPeriod | null;
+  peakUserMonth: PeakPeriod | null;
+};
+
+function PeakRow({
+  label,
+  value,
+  detail,
+}: {
+  label: string;
+  value: string;
+  detail: string;
+}) {
+  return (
+    <div className="flex items-center justify-between px-5 py-3">
+      <span className="text-[13px] text-neutral-600">{label}</span>
+      <div className="flex items-center gap-2">
+        <span className="text-[11px] text-neutral-400">{detail}</span>
+        <span className="min-w-[2rem] text-right text-[13px] font-semibold tabular-nums text-neutral-900">
+          {value}
+        </span>
+      </div>
+    </div>
+  );
+}
+
+type PeakPeriodsCardProps = {
+  data: PeakData | undefined;
+  isLoading: boolean;
+};
+
+export function PeakPeriodsCard({ data, isLoading }: PeakPeriodsCardProps) {
+  if (isLoading || !data) {
+    return (
+      <Card className="rounded-xl border-neutral-200 shadow-none">
+        <div className="border-b border-neutral-100 px-5 py-4">
+          <p className="text-[14px] font-semibold tracking-tight text-neutral-900">
+            Peak Periods
+          </p>
+        </div>
+        <div className="flex items-center justify-center px-5 py-12">
+          <div className="h-5 w-5 animate-spin rounded-full border-2 border-neutral-200 border-t-neutral-400" />
+        </div>
+      </Card>
+    );
+  }
+
+  const hasAnyData =
+    data.peakLinkDay?.date ||
+    data.peakUserDay?.date ||
+    data.peakClickDay?.date ||
+    data.peakLinkMonth?.month ||
+    data.peakUserMonth?.month;
+
+  return (
+    <Card className="rounded-xl border-neutral-200 shadow-none">
+      <div className="border-b border-neutral-100 px-5 py-4">
+        <p className="text-[14px] font-semibold tracking-tight text-neutral-900">
+          Peak Periods
+        </p>
+        <p className="mt-0.5 text-[12px] text-neutral-400">
+          Busiest days and months in range
+        </p>
+      </div>
+      {!hasAnyData ? (
+        <div className="flex items-center justify-center px-5 py-12">
+          <p className="text-[13px] text-neutral-400">No data for this period</p>
+        </div>
+      ) : (
+        <div className="divide-y divide-neutral-100">
+          {data.peakLinkDay?.date && (
+            <PeakRow
+              label="Most links (day)"
+              value={data.peakLinkDay.count.toLocaleString()}
+              detail={formatChartDate(data.peakLinkDay.date)}
+            />
+          )}
+          {data.peakUserDay?.date && (
+            <PeakRow
+              label="Most signups (day)"
+              value={data.peakUserDay.count.toLocaleString()}
+              detail={formatChartDate(data.peakUserDay.date)}
+            />
+          )}
+          {data.peakClickDay?.date && (
+            <PeakRow
+              label="Most clicks (day)"
+              value={data.peakClickDay.count.toLocaleString()}
+              detail={formatChartDate(data.peakClickDay.date)}
+            />
+          )}
+          {data.peakLinkMonth?.month && (
+            <PeakRow
+              label="Most links (month)"
+              value={data.peakLinkMonth.count.toLocaleString()}
+              detail={formatChartMonth(data.peakLinkMonth.month)}
+            />
+          )}
+          {data.peakUserMonth?.month && (
+            <PeakRow
+              label="Most signups (month)"
+              value={data.peakUserMonth.count.toLocaleString()}
+              detail={formatChartMonth(data.peakUserMonth.month)}
+            />
+          )}
+        </div>
+      )}
+    </Card>
+  );
+}

--- a/src/app/(main)/dashboard/admin/_components/peak-periods-card.tsx
+++ b/src/app/(main)/dashboard/admin/_components/peak-periods-card.tsx
@@ -41,7 +41,7 @@ type PeakPeriodsCardProps = {
 };
 
 export function PeakPeriodsCard({ data, isLoading }: PeakPeriodsCardProps) {
-  if (isLoading || !data) {
+  if (isLoading) {
     return (
       <Card className="rounded-xl border-neutral-200 shadow-none">
         <div className="border-b border-neutral-100 px-5 py-4">
@@ -51,6 +51,21 @@ export function PeakPeriodsCard({ data, isLoading }: PeakPeriodsCardProps) {
         </div>
         <div className="flex items-center justify-center px-5 py-12">
           <div className="h-5 w-5 animate-spin rounded-full border-2 border-neutral-200 border-t-neutral-400" />
+        </div>
+      </Card>
+    );
+  }
+
+  if (!data) {
+    return (
+      <Card className="rounded-xl border-neutral-200 shadow-none">
+        <div className="border-b border-neutral-100 px-5 py-4">
+          <p className="text-[14px] font-semibold tracking-tight text-neutral-900">
+            Peak Periods
+          </p>
+        </div>
+        <div className="flex items-center justify-center px-5 py-12">
+          <p className="text-[13px] text-neutral-400">Failed to load data</p>
         </div>
       </Card>
     );

--- a/src/app/(main)/dashboard/admin/_components/system-health-card.tsx
+++ b/src/app/(main)/dashboard/admin/_components/system-health-card.tsx
@@ -58,7 +58,7 @@ type SystemHealthCardProps = {
 };
 
 export function SystemHealthCard({ data, isLoading }: SystemHealthCardProps) {
-  if (isLoading || !data) {
+  if (isLoading) {
     return (
       <Card className="rounded-xl border-neutral-200 shadow-none">
         <div className="border-b border-neutral-100 px-5 py-4">
@@ -68,6 +68,21 @@ export function SystemHealthCard({ data, isLoading }: SystemHealthCardProps) {
         </div>
         <div className="flex items-center justify-center px-5 py-12">
           <div className="h-5 w-5 animate-spin rounded-full border-2 border-neutral-200 border-t-neutral-400" />
+        </div>
+      </Card>
+    );
+  }
+
+  if (!data) {
+    return (
+      <Card className="rounded-xl border-neutral-200 shadow-none">
+        <div className="border-b border-neutral-100 px-5 py-4">
+          <p className="text-[14px] font-semibold tracking-tight text-neutral-900">
+            System Health
+          </p>
+        </div>
+        <div className="flex items-center justify-center px-5 py-12">
+          <p className="text-[13px] text-neutral-400">Failed to load data</p>
         </div>
       </Card>
     );

--- a/src/app/(main)/dashboard/admin/_components/system-health-card.tsx
+++ b/src/app/(main)/dashboard/admin/_components/system-health-card.tsx
@@ -1,0 +1,127 @@
+"use client";
+
+import { Card } from "@/components/ui/card";
+
+type HealthData = {
+  totalLinks: number;
+  totalUsers: number;
+  blockedLinks: number;
+  bannedUsers: number;
+  blockedPercent: number;
+  banRate: number;
+  pendingFlagged: number;
+  openFeedback: number;
+  blockedDomains: number;
+};
+
+type Status = "green" | "amber" | "red" | "neutral";
+
+const dotColor: Record<Status, string> = {
+  green: "bg-emerald-500",
+  amber: "bg-amber-500",
+  red: "bg-red-500",
+  neutral: "bg-neutral-300",
+};
+
+function StatusRow({
+  label,
+  value,
+  detail,
+  status,
+}: {
+  label: string;
+  value: string;
+  detail?: string;
+  status: Status;
+}) {
+  return (
+    <div className="flex items-center justify-between px-5 py-3">
+      <div className="flex items-center gap-2.5">
+        <span className={`h-1.5 w-1.5 shrink-0 rounded-full ${dotColor[status]}`} />
+        <span className="text-[13px] text-neutral-600">{label}</span>
+      </div>
+      <div className="flex items-center gap-2">
+        {detail && (
+          <span className="text-[11px] text-neutral-400">{detail}</span>
+        )}
+        <span className="min-w-[2rem] text-right text-[13px] font-semibold tabular-nums text-neutral-900">
+          {value}
+        </span>
+      </div>
+    </div>
+  );
+}
+
+type SystemHealthCardProps = {
+  data: HealthData | undefined;
+  isLoading: boolean;
+};
+
+export function SystemHealthCard({ data, isLoading }: SystemHealthCardProps) {
+  if (isLoading || !data) {
+    return (
+      <Card className="rounded-xl border-neutral-200 shadow-none">
+        <div className="border-b border-neutral-100 px-5 py-4">
+          <p className="text-[14px] font-semibold tracking-tight text-neutral-900">
+            System Health
+          </p>
+        </div>
+        <div className="flex items-center justify-center px-5 py-12">
+          <div className="h-5 w-5 animate-spin rounded-full border-2 border-neutral-200 border-t-neutral-400" />
+        </div>
+      </Card>
+    );
+  }
+
+  const pctStatus = (v: number): Status =>
+    v > 5 ? "red" : v > 2 ? "amber" : "green";
+
+  return (
+    <Card className="rounded-xl border-neutral-200 shadow-none">
+      <div className="border-b border-neutral-100 px-5 py-4">
+        <p className="text-[14px] font-semibold tracking-tight text-neutral-900">
+          System Health
+        </p>
+        <p className="mt-0.5 text-[12px] text-neutral-400">
+          {data.totalLinks.toLocaleString()} links &middot;{" "}
+          {data.totalUsers.toLocaleString()} users
+        </p>
+      </div>
+      <div className="divide-y divide-neutral-100">
+        <StatusRow
+          label="Blocked links"
+          value={`${data.blockedPercent}%`}
+          detail={`${data.blockedLinks.toLocaleString()} of ${data.totalLinks.toLocaleString()}`}
+          status={pctStatus(data.blockedPercent)}
+        />
+        <StatusRow
+          label="Ban rate"
+          value={`${data.banRate}%`}
+          detail={`${data.bannedUsers.toLocaleString()} of ${data.totalUsers.toLocaleString()}`}
+          status={pctStatus(data.banRate)}
+        />
+        <StatusRow
+          label="Pending flagged"
+          value={data.pendingFlagged.toLocaleString()}
+          status={
+            data.pendingFlagged > 10
+              ? "red"
+              : data.pendingFlagged > 0
+                ? "amber"
+                : "green"
+          }
+        />
+        <StatusRow
+          label="Open feedback"
+          value={data.openFeedback.toLocaleString()}
+          status={data.openFeedback > 20 ? "amber" : "neutral"}
+        />
+        <StatusRow
+          label="Blocked domains"
+          value={data.blockedDomains.toLocaleString()}
+          status="neutral"
+        />
+      </div>
+    </Card>
+  );
+}

--- a/src/app/(main)/dashboard/admin/_components/top-links-card.tsx
+++ b/src/app/(main)/dashboard/admin/_components/top-links-card.tsx
@@ -1,0 +1,70 @@
+"use client";
+
+import { IconClick } from "@tabler/icons-react";
+
+import { Card } from "@/components/ui/card";
+import { api } from "@/trpc/react";
+
+type TopLinksCardProps = {
+  from: Date;
+  to: Date;
+};
+
+export function TopLinksCard({ from, to }: TopLinksCardProps) {
+  const { data, isLoading } = api.admin.getTopLinks.useQuery({
+    from,
+    to,
+    limit: 10,
+  });
+
+  return (
+    <Card className="flex flex-col rounded-xl border-neutral-200 shadow-none">
+      <div className="flex items-center justify-between border-b border-neutral-100 px-5 py-4">
+        <div className="flex items-center gap-2">
+          <IconClick size={15} stroke={1.5} className="text-blue-500" />
+          <p className="text-[14px] font-semibold tracking-tight text-neutral-900">
+            Most Clicked Links
+          </p>
+        </div>
+      </div>
+
+      {isLoading ? (
+        <div className="flex flex-1 items-center justify-center px-5 py-12">
+          <div className="h-5 w-5 animate-spin rounded-full border-2 border-neutral-200 border-t-neutral-400" />
+        </div>
+      ) : !data || data.length === 0 ? (
+        <div className="flex flex-1 items-center justify-center px-5 py-12">
+          <p className="text-[13px] text-neutral-400">No click data for this period</p>
+        </div>
+      ) : (
+        <div className="divide-y divide-neutral-100">
+          {data.map((l, i) => (
+            <div
+              key={l.id}
+              className="flex items-center gap-3 px-5 py-2.5"
+            >
+              <span className="w-5 shrink-0 text-center text-[11px] font-semibold tabular-nums text-neutral-300">
+                {i + 1}
+              </span>
+              <div className="min-w-0 flex-1">
+                <p className="truncate text-[13px] font-medium text-neutral-700">
+                  <span className="text-neutral-400">{l.domain}/</span>
+                  {l.alias}
+                </p>
+                <p className="truncate text-[11px] text-neutral-400">
+                  {l.url}
+                </p>
+              </div>
+              <div className="shrink-0 text-right">
+                <p className="text-[12px] font-semibold tabular-nums text-neutral-700">
+                  {l.clicks.toLocaleString()}
+                </p>
+                <p className="text-[10px] text-neutral-400">clicks</p>
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </Card>
+  );
+}

--- a/src/app/(main)/dashboard/admin/_components/top-users-card.tsx
+++ b/src/app/(main)/dashboard/admin/_components/top-users-card.tsx
@@ -1,0 +1,107 @@
+"use client";
+
+import { IconTrophy } from "@tabler/icons-react";
+import { useState } from "react";
+
+import { Card } from "@/components/ui/card";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { api } from "@/trpc/react";
+
+type TopUsersCardProps = {
+  from: Date;
+  to: Date;
+};
+
+export function TopUsersCard({ from, to }: TopUsersCardProps) {
+  const [sortBy, setSortBy] = useState<"links" | "clicks">("links");
+
+  const { data, isLoading } = api.admin.getTopUsers.useQuery({
+    from,
+    to,
+    sortBy,
+    limit: 10,
+  });
+
+  return (
+    <Card className="flex flex-col rounded-xl border-neutral-200 shadow-none">
+      <div className="flex items-center justify-between border-b border-neutral-100 px-5 py-4">
+        <div className="flex items-center gap-2">
+          <IconTrophy size={15} stroke={1.5} className="text-amber-500" />
+          <p className="text-[14px] font-semibold tracking-tight text-neutral-900">
+            Top Users
+          </p>
+        </div>
+        <Select
+          value={sortBy}
+          onValueChange={(v) => setSortBy(v as "links" | "clicks")}
+        >
+          <SelectTrigger className="h-7 w-[110px] rounded-lg text-[11px]">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="links">By Links</SelectItem>
+            <SelectItem value="clicks">By Clicks</SelectItem>
+          </SelectContent>
+        </Select>
+      </div>
+
+      {isLoading ? (
+        <div className="flex flex-1 items-center justify-center px-5 py-12">
+          <div className="h-5 w-5 animate-spin rounded-full border-2 border-neutral-200 border-t-neutral-400" />
+        </div>
+      ) : !data || data.length === 0 ? (
+        <div className="flex flex-1 items-center justify-center px-5 py-12">
+          <p className="text-[13px] text-neutral-400">No data for this period</p>
+        </div>
+      ) : (
+        <div className="divide-y divide-neutral-100">
+          {data.map((u, i) => (
+            <div
+              key={u.id}
+              className="flex items-center gap-3 px-5 py-2.5"
+            >
+              <span className="w-5 shrink-0 text-center text-[11px] font-semibold tabular-nums text-neutral-300">
+                {i + 1}
+              </span>
+              {u.imageUrl ? (
+                <img
+                  src={u.imageUrl}
+                  alt=""
+                  className="h-7 w-7 shrink-0 rounded-full bg-neutral-100 object-cover"
+                />
+              ) : (
+                <div className="flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-neutral-100 text-[11px] font-medium text-neutral-500">
+                  {(u.name ?? u.email ?? "?").charAt(0).toUpperCase()}
+                </div>
+              )}
+              <div className="min-w-0 flex-1">
+                <p className="truncate text-[13px] font-medium text-neutral-700">
+                  {u.name ?? "Unnamed"}
+                </p>
+                <p className="truncate text-[11px] text-neutral-400">
+                  {u.email}
+                </p>
+              </div>
+              <div className="shrink-0 text-right">
+                <p className="text-[12px] font-semibold tabular-nums text-neutral-700">
+                  {sortBy === "clicks"
+                    ? u.clickCount.toLocaleString()
+                    : u.linkCount.toLocaleString()}
+                </p>
+                <p className="text-[10px] text-neutral-400">
+                  {sortBy === "clicks" ? "clicks" : "links"}
+                </p>
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </Card>
+  );
+}

--- a/src/app/(main)/dashboard/admin/page.tsx
+++ b/src/app/(main)/dashboard/admin/page.tsx
@@ -96,8 +96,10 @@ export default function AdminPage() {
   const { data: healthData, isLoading: healthLoading } =
     api.admin.getSystemHealth.useQuery();
 
-  const { data: activity } = api.admin.getRecentActivity.useQuery();
-  const { data: recentUsers } = api.admin.getRecentUsers.useQuery();
+  const { data: activity, isLoading: activityLoading } =
+    api.admin.getRecentActivity.useQuery();
+  const { data: recentUsers, isLoading: recentUsersLoading } =
+    api.admin.getRecentUsers.useQuery();
 
   return (
     <div>
@@ -179,7 +181,11 @@ export default function AdminPage() {
               View all
             </Link>
           </div>
-          {!recentUsers || recentUsers.length === 0 ? (
+          {recentUsersLoading ? (
+            <div className="flex flex-1 items-center justify-center px-5 py-12">
+              <div className="h-5 w-5 animate-spin rounded-full border-2 border-neutral-200 border-t-neutral-400" />
+            </div>
+          ) : !recentUsers || recentUsers.length === 0 ? (
             <div className="flex flex-1 items-center justify-center px-5 py-12">
               <p className="text-[13px] text-neutral-400">No users yet</p>
             </div>
@@ -238,7 +244,11 @@ export default function AdminPage() {
               View all
             </Link>
           </div>
-          {!activity || activity.recentLinks.length === 0 ? (
+          {activityLoading ? (
+            <div className="flex flex-1 items-center justify-center px-5 py-12">
+              <div className="h-5 w-5 animate-spin rounded-full border-2 border-neutral-200 border-t-neutral-400" />
+            </div>
+          ) : !activity || activity.recentLinks.length === 0 ? (
             <div className="flex flex-1 items-center justify-center px-5 py-12">
               <p className="text-[13px] text-neutral-400">
                 No links created yet
@@ -289,7 +299,11 @@ export default function AdminPage() {
               View all
             </Link>
           </div>
-          {!activity || activity.recentBlocked.length === 0 ? (
+          {activityLoading ? (
+            <div className="flex flex-1 items-center justify-center px-5 py-12">
+              <div className="h-5 w-5 animate-spin rounded-full border-2 border-neutral-200 border-t-neutral-400" />
+            </div>
+          ) : !activity || activity.recentBlocked.length === 0 ? (
             <div className="flex flex-1 items-center justify-center px-5 py-12">
               <p className="text-[13px] text-neutral-400">No blocked links</p>
             </div>

--- a/src/app/(main)/dashboard/admin/page.tsx
+++ b/src/app/(main)/dashboard/admin/page.tsx
@@ -1,19 +1,31 @@
+"use client";
+
 import {
-  IconBan,
-  IconLink,
-  IconTrendingUp,
-  IconUserPlus,
-  IconUsers,
+  IconArrowDownRight,
+  IconArrowUpRight,
 } from "@tabler/icons-react";
 import { Link } from "next-view-transitions";
+import { useState } from "react";
 
-import { QuickInfoCard } from "@/app/(main)/dashboard/analytics/[alias]/_components/quick-info-card";
 import { Card } from "@/components/ui/card";
-import { api } from "@/trpc/server";
+import { api } from "@/trpc/react";
 
-import { DailyActivityChart } from "./_components/daily-activity-chart";
+import { ActivityChart } from "./_components/daily-activity-chart";
+import { DateRangePicker } from "./_components/date-range-picker";
+import { MonthlyBreakdownCard } from "./_components/monthly-breakdown-card";
+import { PeakPeriodsCard } from "./_components/peak-periods-card";
+import { SystemHealthCard } from "./_components/system-health-card";
+import { TopLinksCard } from "./_components/top-links-card";
+import { TopUsersCard } from "./_components/top-users-card";
 
-export const dynamic = "force-dynamic";
+function getDefault30d() {
+  const to = new Date();
+  to.setHours(23, 59, 59, 999);
+  const from = new Date();
+  from.setDate(from.getDate() - 29);
+  from.setHours(0, 0, 0, 0);
+  return { from, to };
+}
 
 function timeAgo(date: Date | null): string {
   if (!date) return "";
@@ -28,66 +40,128 @@ function timeAgo(date: Date | null): string {
   return date.toLocaleDateString();
 }
 
-export default async function AdminPage() {
-  const [stats, activity, dailyStats, recentUsers] = await Promise.all([
-    api.admin.getStats.query(),
-    api.admin.getRecentActivity.query(),
-    api.admin.getDailyStats.query(),
-    api.admin.getRecentUsers.query(),
-  ]);
+function StatCard({
+  title,
+  value,
+  growth,
+}: {
+  title: string;
+  value: string;
+  growth?: number | null;
+}) {
+  return (
+    <Card className="rounded-xl border-neutral-200 p-5 shadow-none">
+      <p className="text-[11px] font-medium uppercase tracking-wider text-neutral-400">
+        {title}
+      </p>
+      <p className="mt-1 text-2xl font-semibold tabular-nums tracking-tight text-neutral-900">
+        {value}
+      </p>
+      {growth !== undefined && growth !== null && (
+        <span
+          className={`mt-1 inline-flex items-center gap-0.5 text-[11px] font-medium ${
+            growth >= 0 ? "text-emerald-600" : "text-red-500"
+          }`}
+        >
+          {growth >= 0 ? (
+            <IconArrowUpRight size={12} stroke={2} />
+          ) : (
+            <IconArrowDownRight size={12} stroke={2} />
+          )}
+          {Math.abs(growth)}% vs prev period
+        </span>
+      )}
+    </Card>
+  );
+}
+
+export default function AdminPage() {
+  const [dateRange, setDateRange] = useState(getDefault30d);
+  const [granularity, setGranularity] = useState<"day" | "month">("day");
+
+  const { from, to } = dateRange;
+
+  const { data: analytics, isLoading: analyticsLoading } =
+    api.admin.getAnalytics.useQuery({ from, to });
+
+  const { data: chartData, isLoading: chartLoading } =
+    api.admin.getActivityChart.useQuery({ from, to, granularity });
+
+  const { data: peakData, isLoading: peakLoading } =
+    api.admin.getPeakPeriods.useQuery({ from, to });
+
+  const { data: monthlyData, isLoading: monthlyLoading } =
+    api.admin.getMonthlyBreakdown.useQuery({ from, to });
+
+  const { data: healthData, isLoading: healthLoading } =
+    api.admin.getSystemHealth.useQuery();
+
+  const { data: activity } = api.admin.getRecentActivity.useQuery();
+  const { data: recentUsers } = api.admin.getRecentUsers.useQuery();
 
   return (
     <div>
       {/* Header */}
-      <div className="mb-8">
-        <h1 className="text-xl font-semibold tracking-tight text-neutral-900">
-          Admin Dashboard
-        </h1>
-        <p className="mt-1 text-[13px] text-neutral-400">
-          Platform overview and moderation tools
-        </p>
+      <div className="mb-8 flex items-start justify-between">
+        <div>
+          <h1 className="text-xl font-semibold tracking-tight text-neutral-900">
+            Admin Dashboard
+          </h1>
+          <p className="mt-1 text-[13px] text-neutral-400">
+            Platform overview and moderation tools
+          </p>
+        </div>
+        <DateRangePicker from={from} to={to} onChange={setDateRange} />
       </div>
 
       {/* Stats */}
-      <div className="grid grid-cols-2 gap-4 sm:grid-cols-3 lg:grid-cols-5">
-        <QuickInfoCard
-          title="Total Links"
-          value={stats.totalLinks.toLocaleString()}
-          icon={<IconLink size={16} stroke={1.5} className="text-blue-600" />}
+      <div className="grid grid-cols-2 gap-4 lg:grid-cols-4">
+        <StatCard
+          title="Links"
+          value={analyticsLoading ? "..." : (analytics?.links.toLocaleString() ?? "0")}
+          growth={analytics?.linksGrowth ?? null}
         />
-        <QuickInfoCard
-          title="Total Users"
-          value={stats.totalUsers.toLocaleString()}
-          icon={<IconUsers size={16} stroke={1.5} className="text-blue-600" />}
+        <StatCard
+          title="Users"
+          value={analyticsLoading ? "..." : (analytics?.users.toLocaleString() ?? "0")}
+          growth={analytics?.usersGrowth ?? null}
         />
-        <QuickInfoCard
-          title="Links Today"
-          value={stats.linksToday.toLocaleString()}
-          icon={
-            <IconTrendingUp
-              size={16}
-              stroke={1.5}
-              className="text-blue-600"
-            />
-          }
+        <StatCard
+          title="Clicks"
+          value={analyticsLoading ? "..." : (analytics?.clicks.toLocaleString() ?? "0")}
+          growth={analytics?.clicksGrowth ?? null}
         />
-        <QuickInfoCard
-          title="Users Today"
-          value={stats.usersToday.toLocaleString()}
-          icon={
-            <IconUserPlus size={16} stroke={1.5} className="text-blue-600" />
-          }
-        />
-        <QuickInfoCard
-          title="Blocked Links"
-          value={stats.blockedLinks.toLocaleString()}
-          icon={<IconBan size={16} stroke={1.5} className="text-blue-600" />}
+        <StatCard
+          title="Avg Links/User"
+          value={analyticsLoading ? "..." : (analytics?.avgLinksPerUser?.toString() ?? "0")}
         />
       </div>
 
-      {/* Daily activity chart */}
+      {/* Activity chart */}
       <div className="mt-8">
-        <DailyActivityChart data={dailyStats} />
+        <ActivityChart
+          data={chartData}
+          isLoading={chartLoading}
+          granularity={granularity}
+          onGranularityChange={setGranularity}
+        />
+      </div>
+
+      {/* Peak Periods + System Health */}
+      <div className="mt-4 grid grid-cols-1 gap-4 lg:grid-cols-2">
+        <PeakPeriodsCard data={peakData} isLoading={peakLoading} />
+        <SystemHealthCard data={healthData} isLoading={healthLoading} />
+      </div>
+
+      {/* Top Users + Top Links */}
+      <div className="mt-4 grid grid-cols-1 gap-4 lg:grid-cols-2">
+        <TopUsersCard from={from} to={to} />
+        <TopLinksCard from={from} to={to} />
+      </div>
+
+      {/* Monthly Breakdown */}
+      <div className="mt-4">
+        <MonthlyBreakdownCard data={monthlyData} isLoading={monthlyLoading} />
       </div>
 
       {/* New users + Recent links */}
@@ -105,7 +179,7 @@ export default async function AdminPage() {
               View all
             </Link>
           </div>
-          {recentUsers.length === 0 ? (
+          {!recentUsers || recentUsers.length === 0 ? (
             <div className="flex flex-1 items-center justify-center px-5 py-12">
               <p className="text-[13px] text-neutral-400">No users yet</p>
             </div>
@@ -164,7 +238,7 @@ export default async function AdminPage() {
               View all
             </Link>
           </div>
-          {activity.recentLinks.length === 0 ? (
+          {!activity || activity.recentLinks.length === 0 ? (
             <div className="flex flex-1 items-center justify-center px-5 py-12">
               <p className="text-[13px] text-neutral-400">
                 No links created yet
@@ -215,7 +289,7 @@ export default async function AdminPage() {
               View all
             </Link>
           </div>
-          {activity.recentBlocked.length === 0 ? (
+          {!activity || activity.recentBlocked.length === 0 ? (
             <div className="flex flex-1 items-center justify-center px-5 py-12">
               <p className="text-[13px] text-neutral-400">No blocked links</p>
             </div>

--- a/src/lib/utils/index.ts
+++ b/src/lib/utils/index.ts
@@ -145,3 +145,13 @@ export function formatChartDate(dateString: string): string {
     timeZone: "UTC",
   });
 }
+
+/**
+ * Formats a "YYYY-MM" month string into a human-readable label.
+ * Used by chart and table components for month display.
+ */
+export function formatChartMonth(monthStr: string): string {
+  const [year, month] = monthStr.split("-").map(Number);
+  const d = new Date(year!, month! - 1);
+  return d.toLocaleDateString("en-US", { month: "short", year: "numeric" });
+}

--- a/src/server/api/routers/admin/admin.input.ts
+++ b/src/server/api/routers/admin/admin.input.ts
@@ -69,3 +69,35 @@ export const resolveFlaggedLinkSchema = z.object({
 });
 
 export type ResolveFlaggedLinkInput = z.infer<typeof resolveFlaggedLinkSchema>;
+
+// --- Analytics inputs ---
+
+export const dateRangeSchema = z.object({
+  from: z.date(),
+  to: z.date(),
+});
+
+export const getAnalyticsSchema = dateRangeSchema;
+export type GetAnalyticsInput = z.infer<typeof getAnalyticsSchema>;
+
+export const getActivityChartSchema = dateRangeSchema.extend({
+  granularity: z.enum(["day", "month"]).default("day"),
+});
+export type GetActivityChartInput = z.infer<typeof getActivityChartSchema>;
+
+export const getTopUsersSchema = dateRangeSchema.extend({
+  sortBy: z.enum(["links", "clicks"]).default("links"),
+  limit: z.number().int().positive().max(100).default(20),
+});
+export type GetTopUsersInput = z.infer<typeof getTopUsersSchema>;
+
+export const getTopLinksSchema = dateRangeSchema.extend({
+  limit: z.number().int().positive().max(100).default(20),
+});
+export type GetTopLinksInput = z.infer<typeof getTopLinksSchema>;
+
+export const getPeakPeriodsSchema = dateRangeSchema;
+export type GetPeakPeriodsInput = z.infer<typeof getPeakPeriodsSchema>;
+
+export const getMonthlyBreakdownSchema = dateRangeSchema;
+export type GetMonthlyBreakdownInput = z.infer<typeof getMonthlyBreakdownSchema>;

--- a/src/server/api/routers/admin/admin.input.ts
+++ b/src/server/api/routers/admin/admin.input.ts
@@ -72,10 +72,15 @@ export type ResolveFlaggedLinkInput = z.infer<typeof resolveFlaggedLinkSchema>;
 
 // --- Analytics inputs ---
 
-export const dateRangeSchema = z.object({
-  from: z.date(),
-  to: z.date(),
-});
+export const dateRangeSchema = z
+  .object({
+    from: z.date(),
+    to: z.date(),
+  })
+  .refine((d) => d.from <= d.to, {
+    message: "from must be before or equal to to",
+    path: ["from"],
+  });
 
 export const getAnalyticsSchema = dateRangeSchema;
 export type GetAnalyticsInput = z.infer<typeof getAnalyticsSchema>;

--- a/src/server/api/routers/admin/admin.procedure.ts
+++ b/src/server/api/routers/admin/admin.procedure.ts
@@ -61,4 +61,33 @@ export const adminRouter = createTRPCRouter({
   resolveFlaggedLink: adminProcedure
     .input(inputs.resolveFlaggedLinkSchema)
     .mutation(({ ctx, input }) => services.resolveFlaggedLink(ctx, input)),
+
+  // Analytics
+  getAnalytics: adminProcedure
+    .input(inputs.getAnalyticsSchema)
+    .query(({ ctx, input }) => services.getAnalytics(ctx, input)),
+
+  getActivityChart: adminProcedure
+    .input(inputs.getActivityChartSchema)
+    .query(({ ctx, input }) => services.getActivityChart(ctx, input)),
+
+  getTopUsers: adminProcedure
+    .input(inputs.getTopUsersSchema)
+    .query(({ ctx, input }) => services.getTopUsers(ctx, input)),
+
+  getTopLinks: adminProcedure
+    .input(inputs.getTopLinksSchema)
+    .query(({ ctx, input }) => services.getTopLinks(ctx, input)),
+
+  getPeakPeriods: adminProcedure
+    .input(inputs.getPeakPeriodsSchema)
+    .query(({ ctx, input }) => services.getPeakPeriods(ctx, input)),
+
+  getMonthlyBreakdown: adminProcedure
+    .input(inputs.getMonthlyBreakdownSchema)
+    .query(({ ctx, input }) => services.getMonthlyBreakdown(ctx, input)),
+
+  getSystemHealth: adminProcedure.query(({ ctx }) =>
+    services.getSystemHealth(ctx),
+  ),
 });

--- a/src/server/api/routers/admin/admin.service.ts
+++ b/src/server/api/routers/admin/admin.service.ts
@@ -1,10 +1,12 @@
-import { and, count, desc, eq, like, or, sql } from "drizzle-orm";
+import { and, between, count, desc, eq, like, or, sql } from "drizzle-orm";
 
 import { buildCacheKey, deleteFromCache } from "@/lib/core/cache";
 import {
   blockedDomain,
+  feedback,
   flaggedLink,
   link,
+  linkVisit,
   user,
 } from "@/server/db/schema";
 
@@ -16,7 +18,13 @@ import type {
   AddBlockedDomainInput,
   BanUserInput,
   BlockLinkInput,
+  GetActivityChartInput,
+  GetAnalyticsInput,
   GetFlaggedLinksInput,
+  GetMonthlyBreakdownInput,
+  GetPeakPeriodsInput,
+  GetTopLinksInput,
+  GetTopUsersInput,
   RemoveBlockedDomainInput,
   ResolveFlaggedLinkInput,
   SearchLinksInput,
@@ -533,4 +541,427 @@ export async function resolveFlaggedLink(
       reason: flagged.reason ?? "Flagged and blocked by admin",
     });
   }
+}
+
+// ---------------------------------------------------------------------------
+// Analytics
+// ---------------------------------------------------------------------------
+
+/** Compute the previous period of the same length for comparison */
+function getPreviousPeriod(from: Date, to: Date) {
+  const durationMs = to.getTime() - from.getTime();
+  const prevTo = new Date(from.getTime() - 1); // 1ms before current "from"
+  prevTo.setHours(23, 59, 59, 999);
+  const prevFrom = new Date(prevTo.getTime() - durationMs);
+  prevFrom.setHours(0, 0, 0, 0);
+  return { prevFrom, prevTo };
+}
+
+/** Compute percentage change, returning null when the previous value is 0 */
+function pctChange(current: number, previous: number): number | null {
+  if (previous === 0) return current > 0 ? 100 : null;
+  return Math.round(((current - previous) / previous) * 100);
+}
+
+async function countClicks(
+  ctx: ProtectedTRPCContext,
+  from: Date,
+  to: Date,
+): Promise<number> {
+  const result = await ctx.db
+    .select({ total: count() })
+    .from(linkVisit)
+    .where(between(linkVisit.createdAt, from, to));
+  return result[0]?.total ?? 0;
+}
+
+export async function getAnalytics(
+  ctx: ProtectedTRPCContext,
+  input: GetAnalyticsInput,
+) {
+  const { from, to } = input;
+  const { prevFrom, prevTo } = getPreviousPeriod(from, to);
+
+  const [
+    linksInRange,
+    usersInRange,
+    clicksInRange,
+    linksPrev,
+    usersPrev,
+    clicksPrev,
+  ] = await Promise.all([
+    ctx.db
+      .select({ total: count() })
+      .from(link)
+      .where(between(link.createdAt, from, to)),
+    ctx.db
+      .select({ total: count() })
+      .from(user)
+      .where(between(user.createdAt, from, to)),
+    countClicks(ctx, from, to),
+    ctx.db
+      .select({ total: count() })
+      .from(link)
+      .where(between(link.createdAt, prevFrom, prevTo)),
+    ctx.db
+      .select({ total: count() })
+      .from(user)
+      .where(between(user.createdAt, prevFrom, prevTo)),
+    countClicks(ctx, prevFrom, prevTo),
+  ]);
+
+  const currentLinks = linksInRange[0]?.total ?? 0;
+  const currentUsers = usersInRange[0]?.total ?? 0;
+  const previousLinks = linksPrev[0]?.total ?? 0;
+  const previousUsers = usersPrev[0]?.total ?? 0;
+
+  return {
+    links: currentLinks,
+    users: currentUsers,
+    clicks: clicksInRange,
+    linksGrowth: pctChange(currentLinks, previousLinks),
+    usersGrowth: pctChange(currentUsers, previousUsers),
+    clicksGrowth: pctChange(clicksInRange, clicksPrev),
+    avgLinksPerUser:
+      currentUsers > 0
+        ? Math.round((currentLinks / currentUsers) * 10) / 10
+        : 0,
+  };
+}
+
+export async function getActivityChart(
+  ctx: ProtectedTRPCContext,
+  input: GetActivityChartInput,
+) {
+  const { from, to, granularity } = input;
+
+  const dateExpr =
+    granularity === "month"
+      ? sql<string>`DATE_FORMAT(${link.createdAt}, '%Y-%m')`
+      : sql<string>`DATE(${link.createdAt})`;
+
+  const userDateExpr =
+    granularity === "month"
+      ? sql<string>`DATE_FORMAT(${user.createdAt}, '%Y-%m')`
+      : sql<string>`DATE(${user.createdAt})`;
+
+  const clickDateExpr =
+    granularity === "month"
+      ? sql<string>`DATE_FORMAT(${linkVisit.createdAt}, '%Y-%m')`
+      : sql<string>`DATE(${linkVisit.createdAt})`;
+
+  const [dailyLinks, dailyUsers, dailyClicks] = await Promise.all([
+    ctx.db
+      .select({ date: dateExpr, count: count() })
+      .from(link)
+      .where(between(link.createdAt, from, to))
+      .groupBy(dateExpr)
+      .orderBy(dateExpr),
+    ctx.db
+      .select({ date: userDateExpr, count: count() })
+      .from(user)
+      .where(between(user.createdAt, from, to))
+      .groupBy(userDateExpr)
+      .orderBy(userDateExpr),
+    ctx.db
+      .select({ date: clickDateExpr, count: count() })
+      .from(linkVisit)
+      .where(between(linkVisit.createdAt, from, to))
+      .groupBy(clickDateExpr)
+      .orderBy(clickDateExpr),
+  ]);
+
+  const linksByDate = new Map(
+    dailyLinks.map((l) => [String(l.date).split("T")[0], l.count]),
+  );
+  const usersByDate = new Map(
+    dailyUsers.map((u) => [String(u.date).split("T")[0], u.count]),
+  );
+  const clicksByDate = new Map(
+    dailyClicks.map((c) => [String(c.date).split("T")[0], c.count]),
+  );
+
+  // Fill in all periods
+  const result: {
+    date: string;
+    links: number;
+    users: number;
+    clicks: number;
+  }[] = [];
+
+  if (granularity === "month") {
+    const cursor = new Date(from);
+    cursor.setDate(1);
+    const endMonth = to.getFullYear() * 12 + to.getMonth();
+    while (cursor.getFullYear() * 12 + cursor.getMonth() <= endMonth) {
+      const key = `${cursor.getFullYear()}-${String(cursor.getMonth() + 1).padStart(2, "0")}`;
+      result.push({
+        date: key,
+        links: linksByDate.get(key) ?? 0,
+        users: usersByDate.get(key) ?? 0,
+        clicks: clicksByDate.get(key) ?? 0,
+      });
+      cursor.setMonth(cursor.getMonth() + 1);
+    }
+  } else {
+    const cursor = new Date(from);
+    cursor.setHours(0, 0, 0, 0);
+    while (cursor <= to) {
+      const key = cursor.toISOString().split("T")[0]!;
+      result.push({
+        date: key,
+        links: linksByDate.get(key) ?? 0,
+        users: usersByDate.get(key) ?? 0,
+        clicks: clicksByDate.get(key) ?? 0,
+      });
+      cursor.setDate(cursor.getDate() + 1);
+    }
+  }
+
+  return result;
+}
+
+export async function getTopUsers(
+  ctx: ProtectedTRPCContext,
+  input: GetTopUsersInput,
+) {
+  const { from, to, sortBy, limit: lim } = input;
+
+  const orderExpr =
+    sortBy === "clicks"
+      ? sql`COUNT(${linkVisit.id}) DESC`
+      : sql`COUNT(DISTINCT ${link.id}) DESC`;
+
+  return ctx.db
+    .select({
+      id: user.id,
+      name: user.name,
+      email: user.email,
+      imageUrl: user.imageUrl,
+      createdAt: user.createdAt,
+      linkCount: sql<number>`COUNT(DISTINCT ${link.id})`,
+      clickCount: sql<number>`COUNT(${linkVisit.id})`,
+    })
+    .from(user)
+    .innerJoin(link, eq(link.userId, user.id))
+    .leftJoin(linkVisit, eq(linkVisit.linkId, link.id))
+    .where(between(link.createdAt, from, to))
+    .groupBy(user.id)
+    .orderBy(orderExpr)
+    .limit(lim);
+}
+
+export async function getTopLinks(
+  ctx: ProtectedTRPCContext,
+  input: GetTopLinksInput,
+) {
+  const { from, to, limit: lim } = input;
+
+  return ctx.db
+    .select({
+      id: link.id,
+      url: link.url,
+      alias: link.alias,
+      domain: link.domain,
+      createdAt: link.createdAt,
+      userEmail: user.email,
+      clicks: count(linkVisit.id),
+    })
+    .from(linkVisit)
+    .innerJoin(link, eq(linkVisit.linkId, link.id))
+    .leftJoin(user, eq(link.userId, user.id))
+    .where(between(linkVisit.createdAt, from, to))
+    .groupBy(link.id)
+    .orderBy(sql`COUNT(${linkVisit.id}) DESC`)
+    .limit(lim);
+}
+
+export async function getPeakPeriods(
+  ctx: ProtectedTRPCContext,
+  input: GetPeakPeriodsInput,
+) {
+  const { from, to } = input;
+
+  const [peakLinkDay, peakUserDay, peakClickDay, peakLinkMonth, peakUserMonth] =
+    await Promise.all([
+      ctx.db
+        .select({
+          date: sql<string>`DATE(${link.createdAt})`,
+          count: count(),
+        })
+        .from(link)
+        .where(between(link.createdAt, from, to))
+        .groupBy(sql`DATE(${link.createdAt})`)
+        .orderBy(sql`COUNT(*) DESC`)
+        .limit(1),
+      ctx.db
+        .select({
+          date: sql<string>`DATE(${user.createdAt})`,
+          count: count(),
+        })
+        .from(user)
+        .where(between(user.createdAt, from, to))
+        .groupBy(sql`DATE(${user.createdAt})`)
+        .orderBy(sql`COUNT(*) DESC`)
+        .limit(1),
+      ctx.db
+        .select({
+          date: sql<string>`DATE(${linkVisit.createdAt})`,
+          count: count(),
+        })
+        .from(linkVisit)
+        .where(between(linkVisit.createdAt, from, to))
+        .groupBy(sql`DATE(${linkVisit.createdAt})`)
+        .orderBy(sql`COUNT(*) DESC`)
+        .limit(1),
+      ctx.db
+        .select({
+          month: sql<string>`DATE_FORMAT(${link.createdAt}, '%Y-%m')`,
+          count: count(),
+        })
+        .from(link)
+        .where(between(link.createdAt, from, to))
+        .groupBy(sql`DATE_FORMAT(${link.createdAt}, '%Y-%m')`)
+        .orderBy(sql`COUNT(*) DESC`)
+        .limit(1),
+      ctx.db
+        .select({
+          month: sql<string>`DATE_FORMAT(${user.createdAt}, '%Y-%m')`,
+          count: count(),
+        })
+        .from(user)
+        .where(between(user.createdAt, from, to))
+        .groupBy(sql`DATE_FORMAT(${user.createdAt}, '%Y-%m')`)
+        .orderBy(sql`COUNT(*) DESC`)
+        .limit(1),
+    ]);
+
+  return {
+    peakLinkDay: peakLinkDay[0]
+      ? { date: String(peakLinkDay[0].date).split("T")[0], count: peakLinkDay[0].count }
+      : null,
+    peakUserDay: peakUserDay[0]
+      ? { date: String(peakUserDay[0].date).split("T")[0], count: peakUserDay[0].count }
+      : null,
+    peakClickDay: peakClickDay[0]
+      ? { date: String(peakClickDay[0].date).split("T")[0], count: peakClickDay[0].count }
+      : null,
+    peakLinkMonth: peakLinkMonth[0] ?? null,
+    peakUserMonth: peakUserMonth[0] ?? null,
+  };
+}
+
+export async function getMonthlyBreakdown(
+  ctx: ProtectedTRPCContext,
+  input: GetMonthlyBreakdownInput,
+) {
+  const { from, to } = input;
+
+  const [monthlyLinks, monthlyUsers, monthlyClicks] = await Promise.all([
+    ctx.db
+      .select({
+        month: sql<string>`DATE_FORMAT(${link.createdAt}, '%Y-%m')`,
+        count: count(),
+      })
+      .from(link)
+      .where(between(link.createdAt, from, to))
+      .groupBy(sql`DATE_FORMAT(${link.createdAt}, '%Y-%m')`)
+      .orderBy(sql`DATE_FORMAT(${link.createdAt}, '%Y-%m')`),
+    ctx.db
+      .select({
+        month: sql<string>`DATE_FORMAT(${user.createdAt}, '%Y-%m')`,
+        count: count(),
+      })
+      .from(user)
+      .where(between(user.createdAt, from, to))
+      .groupBy(sql`DATE_FORMAT(${user.createdAt}, '%Y-%m')`)
+      .orderBy(sql`DATE_FORMAT(${user.createdAt}, '%Y-%m')`),
+    ctx.db
+      .select({
+        month: sql<string>`DATE_FORMAT(${linkVisit.createdAt}, '%Y-%m')`,
+        count: count(),
+      })
+      .from(linkVisit)
+      .where(between(linkVisit.createdAt, from, to))
+      .groupBy(sql`DATE_FORMAT(${linkVisit.createdAt}, '%Y-%m')`)
+      .orderBy(sql`DATE_FORMAT(${linkVisit.createdAt}, '%Y-%m')`),
+  ]);
+
+  const linksByMonth = new Map(monthlyLinks.map((l) => [l.month, l.count]));
+  const usersByMonth = new Map(monthlyUsers.map((u) => [u.month, u.count]));
+  const clicksByMonth = new Map(monthlyClicks.map((c) => [c.month, c.count]));
+
+  // Fill all months in range
+  const result: {
+    month: string;
+    links: number;
+    users: number;
+    clicks: number;
+  }[] = [];
+  const cursor = new Date(from);
+  cursor.setDate(1);
+  const endMonth = to.getFullYear() * 12 + to.getMonth();
+  while (cursor.getFullYear() * 12 + cursor.getMonth() <= endMonth) {
+    const key = `${cursor.getFullYear()}-${String(cursor.getMonth() + 1).padStart(2, "0")}`;
+    result.push({
+      month: key,
+      links: linksByMonth.get(key) ?? 0,
+      users: usersByMonth.get(key) ?? 0,
+      clicks: clicksByMonth.get(key) ?? 0,
+    });
+    cursor.setMonth(cursor.getMonth() + 1);
+  }
+
+  return result;
+}
+
+export async function getSystemHealth(ctx: ProtectedTRPCContext) {
+  const [
+    linkStatsResult,
+    userStatsResult,
+    pendingFlaggedResult,
+    openFeedbackResult,
+    blockedDomainsResult,
+  ] = await Promise.all([
+    ctx.db
+      .select({
+        total: count(),
+        blocked: sql<number>`SUM(${link.blocked} = true)`,
+      })
+      .from(link),
+    ctx.db
+      .select({
+        total: count(),
+        banned: sql<number>`SUM(${user.banned} = true)`,
+      })
+      .from(user),
+    ctx.db
+      .select({ count: count() })
+      .from(flaggedLink)
+      .where(eq(flaggedLink.status, "pending")),
+    ctx.db
+      .select({ count: count() })
+      .from(feedback)
+      .where(eq(feedback.status, "open")),
+    ctx.db.select({ count: count() }).from(blockedDomain),
+  ]);
+
+  const totalLinks = linkStatsResult[0]?.total ?? 0;
+  const blockedLinks = linkStatsResult[0]?.blocked ?? 0;
+  const totalUsers = userStatsResult[0]?.total ?? 0;
+  const bannedUsers = userStatsResult[0]?.banned ?? 0;
+
+  return {
+    totalLinks,
+    totalUsers,
+    blockedLinks,
+    bannedUsers,
+    blockedPercent:
+      totalLinks > 0 ? Math.round((blockedLinks / totalLinks) * 100 * 10) / 10 : 0,
+    banRate:
+      totalUsers > 0 ? Math.round((bannedUsers / totalUsers) * 100 * 10) / 10 : 0,
+    pendingFlagged: pendingFlaggedResult[0]?.count ?? 0,
+    openFeedback: openFeedbackResult[0]?.count ?? 0,
+    blockedDomains: blockedDomainsResult[0]?.count ?? 0,
+  };
 }

--- a/src/server/api/routers/admin/admin.service.ts
+++ b/src/server/api/routers/admin/admin.service.ts
@@ -727,11 +727,29 @@ export async function getTopUsers(
 ) {
   const { from, to, sortBy, limit: lim } = input;
 
-  const orderExpr =
-    sortBy === "clicks"
-      ? sql`COUNT(${linkVisit.id}) DESC`
-      : sql`COUNT(DISTINCT ${link.id}) DESC`;
+  if (sortBy === "clicks") {
+    // When ranking by clicks, filter on linkVisit.createdAt so clicks
+    // are scoped to the selected window (not all-time).
+    return ctx.db
+      .select({
+        id: user.id,
+        name: user.name,
+        email: user.email,
+        imageUrl: user.imageUrl,
+        createdAt: user.createdAt,
+        linkCount: sql<number>`COUNT(DISTINCT ${link.id})`,
+        clickCount: sql<number>`COUNT(${linkVisit.id})`,
+      })
+      .from(user)
+      .innerJoin(link, eq(link.userId, user.id))
+      .innerJoin(linkVisit, eq(linkVisit.linkId, link.id))
+      .where(between(linkVisit.createdAt, from, to))
+      .groupBy(user.id)
+      .orderBy(sql`COUNT(${linkVisit.id}) DESC`)
+      .limit(lim);
+  }
 
+  // When ranking by links, filter on link.createdAt.
   return ctx.db
     .select({
       id: user.id,
@@ -740,14 +758,14 @@ export async function getTopUsers(
       imageUrl: user.imageUrl,
       createdAt: user.createdAt,
       linkCount: sql<number>`COUNT(DISTINCT ${link.id})`,
-      clickCount: sql<number>`COUNT(${linkVisit.id})`,
+      clickCount: sql<number>`SUM(CASE WHEN ${linkVisit.createdAt} BETWEEN ${from} AND ${to} THEN 1 ELSE 0 END)`,
     })
     .from(user)
     .innerJoin(link, eq(link.userId, user.id))
     .leftJoin(linkVisit, eq(linkVisit.linkId, link.id))
     .where(between(link.createdAt, from, to))
     .groupBy(user.id)
-    .orderBy(orderExpr)
+    .orderBy(sql`COUNT(DISTINCT ${link.id}) DESC`)
     .limit(lim);
 }
 


### PR DESCRIPTION
## Summary

Enhance the existing admin dashboard with date range filtering, period-over-period growth comparisons, and additional analytics widgets.

## Changes

- Add 7 new tRPC admin endpoints for analytics (getAnalytics, getActivityChart, getTopUsers, getTopLinks, getPeakPeriods, getMonthlyBreakdown, getSystemHealth)
- Add date range picker with presets (7d, 30d, 90d, 1 year, all time) that filters all analytics
- Add period-over-period growth indicators to stat cards (links, users, clicks, avg links/user)
- Extend activity chart with clicks series and day/month granularity toggle
- Add peak periods card showing busiest days and months in the selected range
- Add system health card with status indicators (blocked links %, ban rate, pending flagged, open feedback)
- Add top users leaderboard sortable by links or clicks
- Add most clicked links card
- Add monthly breakdown table with client-side column sorting
- Extract shared `formatChartMonth` utility to deduplicate month formatting across components
- Use drizzle-orm `between()` for all date range queries instead of raw SQL

## Type of Change

- [x] feat: New feature

## Testing

Verified type-checking passes with `tsc --noEmit`. Manually tested in development.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Date range picker for flexible period selection
  * Activity chart with Daily/Monthly toggle and clicks series
  * System Health card with key metrics and status indicators
  * Peak Periods and Monthly Breakdown cards for trend insights
  * Top Links and Top Users cards with sortable, date-range-filtered rankings
  * Loading spinners and friendly "no data" messages across dashboard sections
<!-- end of auto-generated comment: release notes by coderabbit.ai -->