### PR TITLE
perf(admin): analytics dashboard performance + chart redesign

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -2,6 +2,9 @@ import("./src/env.mjs");
 
 /** @type {import("next").NextConfig} */
 const config = {
+  experimental: {
+    optimizePackageImports: ["@tabler/icons-react"],
+  },
   logging: {
     fetches: {
       fullUrl: true,

--- a/src/app/(main)/dashboard/admin/_components/daily-activity-chart.tsx
+++ b/src/app/(main)/dashboard/admin/_components/daily-activity-chart.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useState } from "react";
 import {
   Bar,
   BarChart as RechartsBarChart,
@@ -36,6 +37,8 @@ const chartConfig = {
   },
 } satisfies ChartConfig;
 
+type MetricView = "links" | "users" | "clicks";
+
 type ActivityChartProps = {
   data: { date: string; links: number; users: number; clicks: number }[] | undefined;
   isLoading: boolean;
@@ -49,30 +52,56 @@ export function ActivityChart({
   granularity,
   onGranularityChange,
 }: ActivityChartProps) {
+  const [metricView, setMetricView] = useState<MetricView>("links");
+
+  const description =
+    metricView === "links"
+      ? "Links created over time"
+      : metricView === "users"
+        ? "New users over time"
+        : "Clicks over time";
   return (
     <Card className="overflow-hidden rounded-xl border-neutral-200 dark:border-border shadow-none">
-      <div className="flex items-center justify-between border-b border-neutral-100 dark:border-border/50 px-5 pb-4 pt-5">
+      <div className="flex flex-col gap-3 border-b border-neutral-100 dark:border-border/50 px-5 pb-4 pt-5 sm:flex-row sm:items-center sm:justify-between">
         <div className="space-y-0.5">
           <h2 className="text-[14px] font-semibold tracking-tight text-neutral-900 dark:text-foreground">
             Activity
           </h2>
           <p className="text-[12px] text-neutral-400 dark:text-neutral-500">
-            Links, users, and clicks over time
+            {description}
           </p>
         </div>
-        <Tabs
-          value={granularity}
-          onValueChange={(v) => onGranularityChange(v as "day" | "month")}
-        >
-          <TabsList className="h-7">
-            <TabsTrigger value="day" className="px-2.5 text-[11px]">
-              Daily
-            </TabsTrigger>
-            <TabsTrigger value="month" className="px-2.5 text-[11px]">
-              Monthly
-            </TabsTrigger>
-          </TabsList>
-        </Tabs>
+        <div className="flex items-center gap-2">
+          <Tabs
+            value={metricView}
+            onValueChange={(v) => setMetricView(v as MetricView)}
+          >
+            <TabsList className="h-7">
+              <TabsTrigger value="links" className="px-2.5 text-[11px]">
+                Links
+              </TabsTrigger>
+              <TabsTrigger value="users" className="px-2.5 text-[11px]">
+                Users
+              </TabsTrigger>
+              <TabsTrigger value="clicks" className="px-2.5 text-[11px]">
+                Clicks
+              </TabsTrigger>
+            </TabsList>
+          </Tabs>
+          <Tabs
+            value={granularity}
+            onValueChange={(v) => onGranularityChange(v as "day" | "month")}
+          >
+            <TabsList className="h-7">
+              <TabsTrigger value="day" className="px-2.5 text-[11px]">
+                Daily
+              </TabsTrigger>
+              <TabsTrigger value="month" className="px-2.5 text-[11px]">
+                Monthly
+              </TabsTrigger>
+            </TabsList>
+          </Tabs>
+        </div>
       </div>
 
       <div className="px-2 pb-5 pt-4 sm:px-5 sm:pt-5">
@@ -121,9 +150,11 @@ export function ActivityChart({
                   />
                 }
               />
-              <Bar dataKey="links" fill="var(--color-links)" radius={4} />
-              <Bar dataKey="users" fill="var(--color-users)" radius={4} />
-              <Bar dataKey="clicks" fill="var(--color-clicks)" radius={4} />
+              <Bar
+                dataKey={metricView}
+                fill={`var(--color-${metricView})`}
+                radius={4}
+              />
               <ChartLegend content={<ChartLegendContent />} />
             </RechartsBarChart>
           </ChartContainer>

--- a/src/app/(main)/dashboard/admin/page.tsx
+++ b/src/app/(main)/dashboard/admin/page.tsx
@@ -85,13 +85,19 @@ export default function AdminPage() {
     api.admin.getAnalytics.useQuery({ from, to });
 
   const { data: chartData, isLoading: chartLoading } =
-    api.admin.getActivityChart.useQuery({ from, to, granularity });
+    api.admin.getActivityChart.useQuery(
+      { from, to, granularity },
+      { keepPreviousData: true },
+    );
 
   const { data: peakData, isLoading: peakLoading } =
-    api.admin.getPeakPeriods.useQuery({ from, to });
+    api.admin.getPeakPeriods.useQuery({ from, to }, { keepPreviousData: true });
 
   const { data: monthlyData, isLoading: monthlyLoading } =
-    api.admin.getMonthlyBreakdown.useQuery({ from, to });
+    api.admin.getMonthlyBreakdown.useQuery(
+      { from, to },
+      { keepPreviousData: true },
+    );
 
   const { data: healthData, isLoading: healthLoading } =
     api.admin.getSystemHealth.useQuery();

--- a/src/server/api/routers/admin/admin.service.ts
+++ b/src/server/api/routers/admin/admin.service.ts
@@ -1,4 +1,4 @@
-import { and, between, count, desc, eq, like, or, sql } from "drizzle-orm";
+import { and, between, count, desc, eq, inArray, like, or, sql } from "drizzle-orm";
 
 import { buildCacheKey, deleteFromCache } from "@/lib/core/cache";
 import {
@@ -129,7 +129,7 @@ export async function getDailyStats(ctx: ProtectedTRPCContext) {
 }
 
 export async function getRecentUsers(ctx: ProtectedTRPCContext) {
-  return ctx.db
+  const recent = await ctx.db
     .select({
       id: user.id,
       name: user.name,
@@ -137,12 +137,21 @@ export async function getRecentUsers(ctx: ProtectedTRPCContext) {
       imageUrl: user.imageUrl,
       createdAt: user.createdAt,
       banned: user.banned,
-      linkCount:
-        sql<number>`(SELECT COUNT(*) FROM Link WHERE Link.userId = ${user.id})`,
     })
     .from(user)
     .orderBy(desc(user.createdAt))
     .limit(8);
+
+  if (recent.length === 0) return [];
+
+  const counts = await ctx.db
+    .select({ userId: link.userId, linkCount: count() })
+    .from(link)
+    .where(inArray(link.userId, recent.map((u) => u.id)))
+    .groupBy(link.userId);
+
+  const countsByUser = new Map(counts.map((c) => [c.userId, c.linkCount]));
+  return recent.map((u) => ({ ...u, linkCount: countsByUser.get(u.id) ?? 0 }));
 }
 
 export async function getRecentActivity(ctx: ProtectedTRPCContext) {
@@ -909,7 +918,6 @@ export async function getMonthlyBreakdown(
   const usersByMonth = new Map(monthlyUsers.map((u) => [u.month, u.count]));
   const clicksByMonth = new Map(monthlyClicks.map((c) => [c.month, c.count]));
 
-  // Fill all months in range
   const result: {
     month: string;
     links: number;

--- a/src/server/api/trpc.ts
+++ b/src/server/api/trpc.ts
@@ -55,17 +55,28 @@ export type ProtectedTRPCContext = Omit<TRPCContext, "auth"> & {
   isAdmin: boolean;
 };
 
+// Per-request memo so batched procedures share one ban/admin lookup.
+// Keyed on the ctx object — same request = same ctx = same cached promise.
+const currentUserCache = new WeakMap<
+  object,
+  Promise<{ banned: boolean | null; isAdmin: boolean | null } | undefined>
+>();
+
 // Protected procedure middleware
 export const protectedProcedure = t.procedure.use(async ({ ctx, next }) => {
   if (!ctx.auth.userId) {
     throw new TRPCError({ code: "UNAUTHORIZED" });
   }
 
-  // Single query for both ban check and admin status
-  const currentUser = await ctx.db.query.user.findFirst({
-    where: eq(user.id, ctx.auth.userId),
-    columns: { banned: true, isAdmin: true },
-  });
+  let cached = currentUserCache.get(ctx);
+  if (!cached) {
+    cached = ctx.db.query.user.findFirst({
+      where: eq(user.id, ctx.auth.userId),
+      columns: { banned: true, isAdmin: true },
+    });
+    currentUserCache.set(ctx, cached);
+  }
+  const currentUser = await cached;
 
   if (currentUser?.banned) {
     throw new TRPCError({

--- a/src/server/db/schema.ts
+++ b/src/server/db/schema.ts
@@ -167,6 +167,7 @@ export const user = mysqlTable(
   },
   (table) => ({
     deletedAtIdx: index("deletedAt_idx").on(table.deletedAt),
+    createdAtIdx: index("createdAt_idx").on(table.createdAt),
   }),
 );
 
@@ -293,6 +294,7 @@ export const linkVisit = mysqlTable(
     linkIdIdx: index("linkId_idx").on(table.linkId),
     geoRuleIdIdx: index("geoRuleId_idx").on(table.matchedGeoRuleId),
     linkCreatedAtIdx: index("linkId_createdAt_idx").on(table.linkId, table.createdAt),
+    createdAtIdx: index("createdAt_idx").on(table.createdAt),
   }),
 );
 

--- a/src/trpc/react.tsx
+++ b/src/trpc/react.tsx
@@ -12,7 +12,17 @@ import type { AppRouter } from "@/server/api/root";
 export const api = createTRPCReact<AppRouter>();
 
 export function TRPCReactProvider(props: { children: React.ReactNode }) {
-  const [queryClient] = useState(() => new QueryClient());
+  const [queryClient] = useState(
+    () =>
+      new QueryClient({
+        defaultOptions: {
+          queries: {
+            staleTime: 60_000,
+            refetchOnWindowFocus: false,
+          },
+        },
+      }),
+  );
 
   const [trpcClient] = useState(() =>
     api.createClient({


### PR DESCRIPTION
## Summary

Cuts admin analytics dashboard load time and fixes the activity chart's incommensurable-metric scale problem. Also ships a one-line bundle optimization for `@tabler/icons-react` that benefits the entire app.

## Changes

### Server-side performance

- **N+1 fix in `getRecentUsers`**: replaced the correlated `SELECT COUNT(*) FROM Link WHERE userId = ...` subquery (fired once per user) with a single batched `WHERE userId IN (...) GROUP BY userId` query after fetching the recent users.
- **Shared auth lookup across batched procedures**: `protectedProcedure` was running a separate `user.findFirst` per procedure call. With 7 admin queries in one HTTP batch, that meant 7 duplicate lookups. Now memoized per-request via a module-scoped `WeakMap<ctx, Promise>`, so one lookup serves the whole batch. Public procedures are untouched since the memo lives inside `protectedProcedure` only.
- **New indexes**: `User.createdAt` and `LinkVisit.createdAt`. These are the hot paths for every date-range aggregate on the admin dashboard (`getAnalytics`, `getActivityChart`, `getPeakPeriods`, `getMonthlyBreakdown`). The `LinkVisit` index in particular converts full table scans into index range scans on the click queries.

> **Operational note**: the raw SQL to add these indexes manually is:
>
> ```sql
> CREATE INDEX createdAt_idx ON User (createdAt);
> CREATE INDEX createdAt_idx ON LinkVisit (createdAt);
> ```
>
> `LinkVisit` is the largest table in the app, so expect the index build to take real wall-clock time. InnoDB runs `ALGORITHM=INPLACE, LOCK=NONE` by default so concurrent reads/writes continue, but run it during a quiet window and watch replication lag if there are replicas. Recommend applying the indexes to the DB **before** deploying this PR so the code arrives to a database that's already fast.

### Client-side caching

- `QueryClient` now ships with `staleTime: 60_000` and `refetchOnWindowFocus: false`. Remounting any page within 60s reuses the cached result instead of re-firing every query. Window focus no longer triggers refetches.
- `keepPreviousData: true` added to `getActivityChart`, `getPeakPeriods`, and `getMonthlyBreakdown`. Switching the Daily/Monthly toggle or changing the date range now keeps the current chart visible until the new data arrives instead of flashing a spinner. Stat cards deliberately still fall back to their loading placeholder to avoid briefly showing stale totals under their current-period labels.

### Chart redesign

- The "Activity" chart previously plotted links, users, and clicks on one shared linear y-axis. Clicks dominated so severely that links and users bars were effectively invisible. Splitting clicks off into its own tab only moved the problem down a level: links then dominated users by ~500x on daily and ~40x on monthly, making users still invisible.
- Replaced the layout with **three per-metric tabs** (Links, Users, Clicks). Each tab renders a single `<Bar>` series with its own auto-scaled y-axis, so every view is legible regardless of metric magnitude. The Daily/Monthly granularity toggle keeps working alongside.

### Build

- Added `experimental.optimizePackageImports: ["@tabler/icons-react"]` to `next.config.js`. 90 files import icons from this barrel; without the config, tree-shaking frequently fails on re-export-only index files and the full icon set ends up bundled. Next.js now rewrites those imports into deep paths at build time. Next 15's default list already covers `lucide-react`, `date-fns`, and `@radix-ui/*`, so only tabler needed explicit opt-in.

## Type of Change

- [x] perf: Performance improvement
- [x] feat: New feature (chart metric tabs)

## Testing

- `bunx tsc --noEmit` clean on every commit.
- Verified the chart switches cleanly between Links/Users/Clicks tabs and between Daily/Monthly granularity with no spinner flash.
- Confirmed via network payload inspection (captured `getActivityChart` response with 2,294 daily rows across All Time) that all date strings are well-formed and totals line up with the stat cards.
- Schema indexes are declarative only; they must be applied to prod via the SQL in the Operational note above.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Daily activity chart now supports filtering by individual metrics—view links, users, or clicks separately instead of combined data.

* **Performance Improvements**
  * Optimized package imports for faster load times.
  * Enhanced dashboard analytics caching to reduce unnecessary queries.
  * Improved database query performance with new indexes.
  * Optimized query client configuration for better responsiveness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->