### PR TITLE
feat(admin): user base analytics on users page

### DIFF
--- a/orca.yaml
+++ b/orca.yaml
@@ -1,0 +1,11 @@
+scripts:
+  setup: |
+    set -e
+    MAIN_WORKTREE=$(git worktree list --porcelain | awk '/^worktree / {print $2; exit}')
+    if [ -n "$MAIN_WORKTREE" ] && [ -f "$MAIN_WORKTREE/.env" ]; then
+      cp "$MAIN_WORKTREE/.env" .env
+      echo "Copied .env from $MAIN_WORKTREE"
+    else
+      echo "Warning: no .env found at main worktree ($MAIN_WORKTREE)"
+    fi
+    bun install

--- a/src/app/(main)/dashboard/admin/_components/stat-card.tsx
+++ b/src/app/(main)/dashboard/admin/_components/stat-card.tsx
@@ -1,0 +1,46 @@
+import { IconArrowDownRight, IconArrowUpRight } from "@tabler/icons-react";
+
+import { Card } from "@/components/ui/card";
+
+type StatCardProps = {
+  title: string;
+  value: string;
+  growth?: number | null;
+  hint?: string;
+};
+
+export function StatCard({ title, value, growth, hint }: StatCardProps) {
+  return (
+    <Card className="rounded-xl border-neutral-200 dark:border-border p-5 shadow-none">
+      <p className="text-[11px] font-medium uppercase tracking-wider text-neutral-400 dark:text-neutral-500">
+        {title}
+      </p>
+      <p className="mt-1 text-2xl font-semibold tabular-nums tracking-tight text-neutral-900 dark:text-foreground">
+        {value}
+      </p>
+      <div className="mt-1 flex items-center gap-2">
+        {growth !== undefined && growth !== null && (
+          <span
+            className={`inline-flex items-center gap-0.5 text-[11px] font-medium ${
+              growth >= 0
+                ? "text-emerald-600 dark:text-emerald-400"
+                : "text-red-500 dark:text-red-400"
+            }`}
+          >
+            {growth >= 0 ? (
+              <IconArrowUpRight size={12} stroke={2} />
+            ) : (
+              <IconArrowDownRight size={12} stroke={2} />
+            )}
+            {Math.abs(growth)}% vs prev period
+          </span>
+        )}
+        {hint && (
+          <span className="text-[11px] text-neutral-400 dark:text-neutral-500">
+            {hint}
+          </span>
+        )}
+      </div>
+    </Card>
+  );
+}

--- a/src/app/(main)/dashboard/admin/page.tsx
+++ b/src/app/(main)/dashboard/admin/page.tsx
@@ -1,19 +1,17 @@
 "use client";
 
-import {
-  IconArrowDownRight,
-  IconArrowUpRight,
-} from "@tabler/icons-react";
 import { Link } from "next-view-transitions";
 import { useState } from "react";
 
 import { Card } from "@/components/ui/card";
+import { timeAgo } from "@/lib/utils";
 import { api } from "@/trpc/react";
 
 import { ActivityChart } from "./_components/daily-activity-chart";
 import { DateRangePicker } from "./_components/date-range-picker";
 import { MonthlyBreakdownCard } from "./_components/monthly-breakdown-card";
 import { PeakPeriodsCard } from "./_components/peak-periods-card";
+import { StatCard } from "./_components/stat-card";
 import { SystemHealthCard } from "./_components/system-health-card";
 import { TopLinksCard } from "./_components/top-links-card";
 import { TopUsersCard } from "./_components/top-users-card";
@@ -25,54 +23,6 @@ function getDefault30d() {
   from.setDate(from.getDate() - 29);
   from.setHours(0, 0, 0, 0);
   return { from, to };
-}
-
-function timeAgo(date: Date | null): string {
-  if (!date) return "";
-  const seconds = Math.floor((Date.now() - date.getTime()) / 1000);
-  if (seconds < 60) return "just now";
-  const minutes = Math.floor(seconds / 60);
-  if (minutes < 60) return `${minutes}m ago`;
-  const hours = Math.floor(minutes / 60);
-  if (hours < 24) return `${hours}h ago`;
-  const days = Math.floor(hours / 24);
-  if (days < 30) return `${days}d ago`;
-  return date.toLocaleDateString();
-}
-
-function StatCard({
-  title,
-  value,
-  growth,
-}: {
-  title: string;
-  value: string;
-  growth?: number | null;
-}) {
-  return (
-    <Card className="rounded-xl border-neutral-200 dark:border-border p-5 shadow-none">
-      <p className="text-[11px] font-medium uppercase tracking-wider text-neutral-400 dark:text-neutral-500">
-        {title}
-      </p>
-      <p className="mt-1 text-2xl font-semibold tabular-nums tracking-tight text-neutral-900 dark:text-foreground">
-        {value}
-      </p>
-      {growth !== undefined && growth !== null && (
-        <span
-          className={`mt-1 inline-flex items-center gap-0.5 text-[11px] font-medium ${
-            growth >= 0 ? "text-emerald-600 dark:text-emerald-400" : "text-red-500 dark:text-red-400"
-          }`}
-        >
-          {growth >= 0 ? (
-            <IconArrowUpRight size={12} stroke={2} />
-          ) : (
-            <IconArrowDownRight size={12} stroke={2} />
-          )}
-          {Math.abs(growth)}% vs prev period
-        </span>
-      )}
-    </Card>
-  );
 }
 
 export default function AdminPage() {

--- a/src/app/(main)/dashboard/admin/users/_components/recent-subscriptions-card.tsx
+++ b/src/app/(main)/dashboard/admin/users/_components/recent-subscriptions-card.tsx
@@ -1,0 +1,91 @@
+"use client";
+
+import { Card } from "@/components/ui/card";
+import { type PaidPlan } from "@/lib/constants/plan-pricing";
+import { timeAgo } from "@/lib/utils";
+import type { RouterOutputs } from "@/trpc/shared";
+
+type Subscription = RouterOutputs["admin"]["getRecentSubscriptions"][number];
+
+const PLAN_BADGE: Record<PaidPlan, string> = {
+  pro: "bg-blue-50 text-blue-700 dark:bg-blue-500/10 dark:text-blue-400",
+  ultra: "bg-violet-50 text-violet-700 dark:bg-violet-500/10 dark:text-violet-400",
+};
+
+function planBadgeClass(plan: Subscription["plan"]): string | null {
+  if (plan === "pro" || plan === "ultra") return PLAN_BADGE[plan];
+  return null;
+}
+
+export function RecentSubscriptionsCard({
+  data,
+  isLoading,
+}: {
+  data: Subscription[] | undefined;
+  isLoading: boolean;
+}) {
+  return (
+    <Card className="flex flex-col rounded-xl border-neutral-200 dark:border-border shadow-none">
+      <div className="border-b border-neutral-100 dark:border-border/50 px-5 py-4">
+        <p className="text-[14px] font-semibold tracking-tight text-neutral-900 dark:text-foreground">
+          Recent Subscriptions
+        </p>
+        <p className="mt-0.5 text-[12px] text-neutral-400 dark:text-neutral-500">
+          Latest paid sign-ups
+        </p>
+      </div>
+      {isLoading ? (
+        <div className="flex flex-1 items-center justify-center px-5 py-12">
+          <div className="h-5 w-5 animate-spin rounded-full border-2 border-neutral-200 dark:border-border border-t-neutral-400 dark:border-t-neutral-500" />
+        </div>
+      ) : !data || data.length === 0 ? (
+        <div className="flex flex-1 items-center justify-center px-5 py-12">
+          <p className="text-[13px] text-neutral-400 dark:text-neutral-500">
+            No paid subscriptions yet
+          </p>
+        </div>
+      ) : (
+        <div className="divide-y divide-neutral-100 dark:divide-border/50">
+          {data.map((s) => {
+            const badgeClass = planBadgeClass(s.plan);
+            return (
+              <div key={s.id} className="flex items-center gap-3 px-5 py-3">
+                {s.userImage ? (
+                  <img
+                    src={s.userImage}
+                    alt=""
+                    className="h-7 w-7 shrink-0 rounded-full bg-neutral-100 dark:bg-muted object-cover"
+                  />
+                ) : (
+                  <div className="flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-neutral-100 dark:bg-muted text-[11px] font-medium text-neutral-500 dark:text-neutral-400">
+                    {(s.userName ?? s.userEmail ?? "?").charAt(0).toUpperCase()}
+                  </div>
+                )}
+                <div className="min-w-0 flex-1">
+                  <p className="truncate text-[13px] font-medium text-neutral-700 dark:text-neutral-300">
+                    {s.userName ?? "Unnamed"}
+                  </p>
+                  <p className="truncate text-[11px] text-neutral-400 dark:text-neutral-500">
+                    {s.userEmail}
+                  </p>
+                </div>
+                <div className="flex shrink-0 items-center gap-2">
+                  {badgeClass && (
+                    <span
+                      className={`rounded-full px-2 py-0.5 text-[11px] font-medium capitalize ${badgeClass}`}
+                    >
+                      {s.plan}
+                    </span>
+                  )}
+                  <p className="w-16 text-right text-[11px] text-neutral-400 dark:text-neutral-500">
+                    {timeAgo(s.createdAt)}
+                  </p>
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </Card>
+  );
+}

--- a/src/app/(main)/dashboard/admin/users/_components/subscription-growth-chart.tsx
+++ b/src/app/(main)/dashboard/admin/users/_components/subscription-growth-chart.tsx
@@ -1,0 +1,117 @@
+"use client";
+
+import {
+  Bar,
+  BarChart as RechartsBarChart,
+  CartesianGrid,
+  XAxis,
+  YAxis,
+} from "recharts";
+
+import { Card } from "@/components/ui/card";
+import {
+  ChartContainer,
+  ChartLegend,
+  ChartLegendContent,
+  ChartTooltip,
+  ChartTooltipContent,
+} from "@/components/ui/chart";
+import { formatChartMonth } from "@/lib/utils";
+
+import type { ChartConfig } from "@/components/ui/chart";
+
+const chartConfig = {
+  pro: {
+    label: "Pro",
+    color: "#3b82f6",
+  },
+  ultra: {
+    label: "Ultra",
+    color: "#8b5cf6",
+  },
+} satisfies ChartConfig;
+
+type SubscriptionGrowthChartProps = {
+  data: { date: string; pro: number; ultra: number }[] | undefined;
+  isLoading: boolean;
+};
+
+export function SubscriptionGrowthChart({
+  data,
+  isLoading,
+}: SubscriptionGrowthChartProps) {
+  return (
+    <Card className="overflow-hidden rounded-xl border-neutral-200 dark:border-border shadow-none">
+      <div className="flex flex-col gap-3 border-b border-neutral-100 dark:border-border/50 px-5 pb-4 pt-5 sm:flex-row sm:items-center sm:justify-between">
+        <div className="space-y-0.5">
+          <h2 className="text-[14px] font-semibold tracking-tight text-neutral-900 dark:text-foreground">
+            Subscription Growth
+          </h2>
+          <p className="text-[12px] text-neutral-400 dark:text-neutral-500">
+            New paid subscriptions by plan, monthly
+          </p>
+        </div>
+      </div>
+
+      <div className="px-2 pb-5 pt-4 sm:px-5 sm:pt-5">
+        {isLoading ? (
+          <div className="flex h-64 items-center justify-center">
+            <div className="h-5 w-5 animate-spin rounded-full border-2 border-neutral-200 dark:border-border border-t-neutral-400 dark:border-t-neutral-500" />
+          </div>
+        ) : !data ? (
+          <div className="flex h-64 items-center justify-center">
+            <p className="text-[13px] text-neutral-400 dark:text-neutral-500">
+              No data available
+            </p>
+          </div>
+        ) : (
+          <ChartContainer
+            config={chartConfig}
+            className="aspect-auto h-64 w-full"
+          >
+            <RechartsBarChart data={data}>
+              <CartesianGrid vertical={false} />
+              <XAxis
+                dataKey="date"
+                tickLine={false}
+                axisLine={false}
+                tickMargin={8}
+                minTickGap={32}
+                tickFormatter={formatChartMonth}
+              />
+              <YAxis
+                tickLine={false}
+                axisLine={false}
+                tickMargin={4}
+                width={32}
+                allowDecimals={false}
+              />
+              <ChartTooltip
+                cursor={false}
+                content={
+                  <ChartTooltipContent
+                    labelFormatter={(value) => formatChartMonth(String(value))}
+                    indicator="dashed"
+                  />
+                }
+              />
+              <Bar
+                dataKey="pro"
+                stackId="plans"
+                fill="var(--color-pro)"
+                radius={[0, 0, 0, 0]}
+              />
+              <Bar
+                dataKey="ultra"
+                stackId="plans"
+                fill="var(--color-ultra)"
+                radius={[4, 4, 0, 0]}
+              />
+              <ChartLegend content={<ChartLegendContent />} />
+            </RechartsBarChart>
+          </ChartContainer>
+        )}
+      </div>
+    </Card>
+  );
+}

--- a/src/app/(main)/dashboard/admin/users/_components/tier-breakdown-card.tsx
+++ b/src/app/(main)/dashboard/admin/users/_components/tier-breakdown-card.tsx
@@ -1,0 +1,76 @@
+"use client";
+
+import { Card } from "@/components/ui/card";
+import { formatPrice } from "@/lib/utils";
+import type { RouterOutputs } from "@/trpc/shared";
+
+type TierBreakdown = RouterOutputs["admin"]["getUserBaseSummary"]["tiers"];
+
+const TIER_META = [
+  { key: "free", label: "Free", color: "bg-neutral-300 dark:bg-neutral-600" },
+  { key: "pro", label: "Pro", color: "bg-blue-500" },
+  { key: "ultra", label: "Ultra", color: "bg-violet-500" },
+] as const satisfies readonly { key: keyof TierBreakdown; label: string; color: string }[];
+
+export function TierBreakdownCard({
+  data,
+  isLoading,
+}: {
+  data: TierBreakdown | undefined;
+  isLoading: boolean;
+}) {
+  return (
+    <Card className="flex flex-col rounded-xl border-neutral-200 dark:border-border shadow-none">
+      <div className="border-b border-neutral-100 dark:border-border/50 px-5 py-4">
+        <p className="text-[14px] font-semibold tracking-tight text-neutral-900 dark:text-foreground">
+          Plan Breakdown
+        </p>
+        <p className="mt-0.5 text-[12px] text-neutral-400 dark:text-neutral-500">
+          Distribution across tiers (current)
+        </p>
+      </div>
+      {isLoading || !data ? (
+        <div className="flex flex-1 items-center justify-center px-5 py-12">
+          <div className="h-5 w-5 animate-spin rounded-full border-2 border-neutral-200 dark:border-border border-t-neutral-400 dark:border-t-neutral-500" />
+        </div>
+      ) : (
+        <div className="divide-y divide-neutral-100 dark:divide-border/50">
+          {TIER_META.map((meta) => {
+            const tier = data[meta.key];
+            return (
+              <div key={meta.key} className="px-5 py-3.5">
+                <div className="flex items-center justify-between">
+                  <div className="flex items-center gap-2">
+                    <span className={`h-2 w-2 rounded-full ${meta.color}`} />
+                    <p className="text-[13px] font-medium text-neutral-700 dark:text-neutral-300">
+                      {meta.label}
+                    </p>
+                  </div>
+                  <div className="flex items-baseline gap-3">
+                    <p className="text-[13px] font-semibold tabular-nums text-neutral-800 dark:text-neutral-200">
+                      {tier.count.toLocaleString()}
+                    </p>
+                    <p className="w-12 text-right text-[11px] tabular-nums text-neutral-400 dark:text-neutral-500">
+                      {tier.share}%
+                    </p>
+                    <p className="w-16 text-right text-[11px] tabular-nums text-neutral-400 dark:text-neutral-500">
+                      {tier.mrr > 0
+                        ? `${formatPrice(tier.mrr, { notation: "standard", maximumFractionDigits: 0 })}/mo`
+                        : "—"}
+                    </p>
+                  </div>
+                </div>
+                <div className="mt-2 h-1.5 overflow-hidden rounded-full bg-neutral-100 dark:bg-muted">
+                  <div
+                    className={`h-full ${meta.color}`}
+                    style={{ width: `${Math.min(tier.share, 100)}%` }}
+                  />
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </Card>
+  );
+}

--- a/src/app/(main)/dashboard/admin/users/_components/user-base-stats.tsx
+++ b/src/app/(main)/dashboard/admin/users/_components/user-base-stats.tsx
@@ -1,0 +1,43 @@
+"use client";
+
+import { formatPrice } from "@/lib/utils";
+import type { RouterOutputs } from "@/trpc/shared";
+
+import { StatCard } from "../../_components/stat-card";
+
+type Summary = RouterOutputs["admin"]["getUserBaseSummary"];
+
+export function UserBaseStats({
+  data,
+  isLoading,
+}: {
+  data: Summary | undefined;
+  isLoading: boolean;
+}) {
+  const placeholder = isLoading ? "..." : "0";
+
+  return (
+    <div className="grid grid-cols-2 gap-4 lg:grid-cols-4">
+      <StatCard
+        title="Total Users"
+        value={data ? data.totalUsers.toLocaleString() : placeholder}
+      />
+      <StatCard
+        title="Paid Users"
+        value={data ? data.paidUsers.toLocaleString() : placeholder}
+        growth={data?.paidGrowth ?? null}
+        hint={data ? `${data.paidPercent}% of users` : undefined}
+      />
+      <StatCard
+        title="MRR"
+        value={data ? formatPrice(data.mrr, { notation: "standard", maximumFractionDigits: 0 }) : placeholder}
+        hint={data ? "estimated" : undefined}
+      />
+      <StatCard
+        title="New Paid (in range)"
+        value={data ? data.newPaid.toLocaleString() : placeholder}
+        growth={data?.newPaidGrowth ?? null}
+      />
+    </div>
+  );
+}

--- a/src/app/(main)/dashboard/admin/users/page.tsx
+++ b/src/app/(main)/dashboard/admin/users/page.tsx
@@ -18,6 +18,12 @@ import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
 import { api } from "@/trpc/react";
 
+import { DateRangePicker } from "../_components/date-range-picker";
+import { RecentSubscriptionsCard } from "./_components/recent-subscriptions-card";
+import { SubscriptionGrowthChart } from "./_components/subscription-growth-chart";
+import { TierBreakdownCard } from "./_components/tier-breakdown-card";
+import { UserBaseStats } from "./_components/user-base-stats";
+
 type UserToBan = {
   id: string;
   name: string | null;
@@ -25,12 +31,40 @@ type UserToBan = {
   linkCount: number;
 } | null;
 
+function getDefault30d() {
+  const to = new Date();
+  to.setHours(23, 59, 59, 999);
+  const from = new Date();
+  from.setDate(from.getDate() - 29);
+  from.setHours(0, 0, 0, 0);
+  return { from, to };
+}
+
 export default function AdminUsersPage() {
+  const [dateRange, setDateRange] = useState(getDefault30d);
+
   const [query, setQuery] = useState("");
   const [searchQuery, setSearchQuery] = useState("");
   const [page, setPage] = useState(1);
   const [userToBan, setUserToBan] = useState<UserToBan>(null);
   const [banReason, setBanReason] = useState("");
+
+  const { from, to } = dateRange;
+
+  const { data: summary, isLoading: summaryLoading } =
+    api.admin.getUserBaseSummary.useQuery(
+      { from, to },
+      { keepPreviousData: true },
+    );
+
+  const { data: timeline, isLoading: timelineLoading } =
+    api.admin.getSubscriptionTimeline.useQuery(
+      { from, to },
+      { keepPreviousData: true },
+    );
+
+  const { data: recentSubs, isLoading: recentSubsLoading } =
+    api.admin.getRecentSubscriptions.useQuery({ limit: 10 });
 
   const { data, refetch, isLoading } = api.admin.searchUsers.useQuery(
     { query: searchQuery, page, pageSize: 20 },
@@ -70,12 +104,40 @@ export default function AdminUsersPage() {
 
   return (
     <div>
-      <div className="mb-8">
-        <h1 className="text-xl font-semibold tracking-tight text-neutral-900 dark:text-foreground">
-          Manage Users
-        </h1>
-        <p className="mt-1 text-[13px] text-neutral-400 dark:text-neutral-500">
-          Search users and manage account bans
+      <div className="mb-8 flex items-start justify-between gap-4">
+        <div>
+          <h1 className="text-xl font-semibold tracking-tight text-neutral-900 dark:text-foreground">
+            Users
+          </h1>
+          <p className="mt-1 text-[13px] text-neutral-400 dark:text-neutral-500">
+            User base overview and account management
+          </p>
+        </div>
+        <DateRangePicker from={from} to={to} onChange={setDateRange} />
+      </div>
+
+      <UserBaseStats data={summary} isLoading={summaryLoading} />
+
+      <div className="mt-4">
+        <SubscriptionGrowthChart data={timeline} isLoading={timelineLoading} />
+      </div>
+
+      <div className="mt-4 grid grid-cols-1 gap-4 lg:grid-cols-2">
+        <TierBreakdownCard data={summary?.tiers} isLoading={summaryLoading} />
+        <RecentSubscriptionsCard
+          data={recentSubs}
+          isLoading={recentSubsLoading}
+        />
+      </div>
+
+      <div className="mt-10 mb-4 border-t border-neutral-200 dark:border-border/50" />
+
+      <div className="mb-6">
+        <h2 className="text-[15px] font-semibold tracking-tight text-neutral-900 dark:text-foreground">
+          Find a user
+        </h2>
+        <p className="mt-1 text-[12px] text-neutral-400 dark:text-neutral-500">
+          Search by email or name to manage bans
         </p>
       </div>
 
@@ -97,7 +159,6 @@ export default function AdminUsersPage() {
         </Button>
       </form>
 
-      {/* Empty state before search */}
       {!searchQuery && (
         <div className="rounded-lg border border-dashed border-neutral-300 dark:border-border bg-neutral-50/50 dark:bg-accent/50 px-4 py-12 text-center">
           <IconSearch size={32} stroke={1.5} className="mx-auto mb-3 text-neutral-300 dark:text-neutral-600" />
@@ -246,7 +307,6 @@ export default function AdminUsersPage() {
         </>
       )}
 
-      {/* Ban dialog */}
       <Dialog open={!!userToBan} onOpenChange={(open) => { if (!open) { setUserToBan(null); setBanReason(""); } }}>
         <DialogContent>
           <DialogHeader>

--- a/src/lib/constants/plan-pricing.ts
+++ b/src/lib/constants/plan-pricing.ts
@@ -1,0 +1,8 @@
+export const PLAN_PRICES_USD = {
+  free: 0,
+  pro: 5,
+  ultra: 15,
+} as const;
+
+export type PaidPlan = "pro" | "ultra";
+export const PAID_PLANS: PaidPlan[] = ["pro", "ultra"];

--- a/src/lib/utils/index.ts
+++ b/src/lib/utils/index.ts
@@ -1,5 +1,6 @@
 import type { ClassValue } from "clsx";
 import { clsx } from "clsx";
+import { formatDistanceToNow } from "date-fns";
 import { toast } from "sonner";
 import { twMerge } from "tailwind-merge";
 
@@ -154,4 +155,9 @@ export function formatChartMonth(monthStr: string): string {
   const [year, month] = monthStr.split("-").map(Number);
   const d = new Date(year!, month! - 1);
   return d.toLocaleDateString("en-US", { month: "short", year: "numeric" });
+}
+
+export function timeAgo(date: Date | string | null): string {
+  if (!date) return "";
+  return formatDistanceToNow(new Date(date), { addSuffix: true });
 }

--- a/src/server/api/routers/admin/admin.input.ts
+++ b/src/server/api/routers/admin/admin.input.ts
@@ -106,3 +106,18 @@ export type GetPeakPeriodsInput = z.infer<typeof getPeakPeriodsSchema>;
 
 export const getMonthlyBreakdownSchema = dateRangeSchema;
 export type GetMonthlyBreakdownInput = z.infer<typeof getMonthlyBreakdownSchema>;
+
+export const getUserBaseSummarySchema = dateRangeSchema;
+export type GetUserBaseSummaryInput = z.infer<typeof getUserBaseSummarySchema>;
+
+export const getSubscriptionTimelineSchema = dateRangeSchema;
+export type GetSubscriptionTimelineInput = z.infer<
+  typeof getSubscriptionTimelineSchema
+>;
+
+export const getRecentSubscriptionsSchema = z.object({
+  limit: z.number().int().positive().max(50).default(10),
+});
+export type GetRecentSubscriptionsInput = z.infer<
+  typeof getRecentSubscriptionsSchema
+>;

--- a/src/server/api/routers/admin/admin.procedure.ts
+++ b/src/server/api/routers/admin/admin.procedure.ts
@@ -90,4 +90,16 @@ export const adminRouter = createTRPCRouter({
   getSystemHealth: adminProcedure.query(({ ctx }) =>
     services.getSystemHealth(ctx),
   ),
+
+  getUserBaseSummary: adminProcedure
+    .input(inputs.getUserBaseSummarySchema)
+    .query(({ ctx, input }) => services.getUserBaseSummary(ctx, input)),
+
+  getSubscriptionTimeline: adminProcedure
+    .input(inputs.getSubscriptionTimelineSchema)
+    .query(({ ctx, input }) => services.getSubscriptionTimeline(ctx, input)),
+
+  getRecentSubscriptions: adminProcedure
+    .input(inputs.getRecentSubscriptionsSchema)
+    .query(({ ctx, input }) => services.getRecentSubscriptions(ctx, input)),
 });

--- a/src/server/api/routers/admin/admin.service.ts
+++ b/src/server/api/routers/admin/admin.service.ts
@@ -1,12 +1,14 @@
 import { and, between, count, desc, eq, inArray, like, or, sql } from "drizzle-orm";
 
 import { buildCacheKey, deleteFromCache } from "@/lib/core/cache";
+import { PAID_PLANS, PLAN_PRICES_USD, type PaidPlan } from "@/lib/constants/plan-pricing";
 import {
   blockedDomain,
   feedback,
   flaggedLink,
   link,
   linkVisit,
+  subscription,
   user,
 } from "@/server/db/schema";
 
@@ -23,8 +25,11 @@ import type {
   GetFlaggedLinksInput,
   GetMonthlyBreakdownInput,
   GetPeakPeriodsInput,
+  GetRecentSubscriptionsInput,
+  GetSubscriptionTimelineInput,
   GetTopLinksInput,
   GetTopUsersInput,
+  GetUserBaseSummaryInput,
   RemoveBlockedDomainInput,
   ResolveFlaggedLinkInput,
   SearchLinksInput,
@@ -990,4 +995,205 @@ export async function getSystemHealth(ctx: ProtectedTRPCContext) {
     openFeedback: openFeedbackResult[0]?.count ?? 0,
     blockedDomains: blockedDomainsResult[0]?.count ?? 0,
   };
+}
+
+// ---------------------------------------------------------------------------
+// User-base analytics (subscriptions)
+// ---------------------------------------------------------------------------
+
+/**
+ * The webhook flips `subscription.plan` to "free" on cancel/expire, so
+ * `plan IN ('pro','ultra')` already means "currently paying". There is no
+ * historical event log, so churn-over-time is not derivable.
+ */
+
+function sharePct(part: number, total: number): number {
+  if (total <= 0) return 0;
+  return Math.round((part / total) * 1000) / 10;
+}
+
+export async function getUserBaseSummary(
+  ctx: ProtectedTRPCContext,
+  input: GetUserBaseSummaryInput,
+) {
+  const { from, to } = input;
+  const { prevFrom, prevTo } = getPreviousPeriod(from, to);
+
+  const [
+    totalUsersResult,
+    newUsersInRange,
+    newUsersPrev,
+    tierBreakdown,
+    paidPrevResult,
+    newPaidInRange,
+    newPaidPrev,
+  ] = await Promise.all([
+    ctx.db.select({ total: count() }).from(user),
+    ctx.db
+      .select({ total: count() })
+      .from(user)
+      .where(between(user.createdAt, from, to)),
+    ctx.db
+      .select({ total: count() })
+      .from(user)
+      .where(between(user.createdAt, prevFrom, prevTo)),
+    ctx.db
+      .select({ plan: subscription.plan, total: count() })
+      .from(subscription)
+      .where(inArray(subscription.plan, PAID_PLANS))
+      .groupBy(subscription.plan),
+    // Best-effort "paid at prevTo": rows that existed by prevTo and are still paid today.
+    ctx.db
+      .select({ total: count() })
+      .from(subscription)
+      .where(
+        and(
+          inArray(subscription.plan, PAID_PLANS),
+          sql`${subscription.createdAt} <= ${prevTo}`,
+        ),
+      ),
+    ctx.db
+      .select({ total: count() })
+      .from(subscription)
+      .where(
+        and(
+          inArray(subscription.plan, PAID_PLANS),
+          between(subscription.createdAt, from, to),
+        ),
+      ),
+    ctx.db
+      .select({ total: count() })
+      .from(subscription)
+      .where(
+        and(
+          inArray(subscription.plan, PAID_PLANS),
+          between(subscription.createdAt, prevFrom, prevTo),
+        ),
+      ),
+  ]);
+
+  const totalUsers = totalUsersResult[0]?.total ?? 0;
+
+  const tierMap = new Map<PaidPlan, number>();
+  for (const row of tierBreakdown) {
+    if (row.plan && (PAID_PLANS as string[]).includes(row.plan)) {
+      tierMap.set(row.plan as PaidPlan, row.total);
+    }
+  }
+  const proCount = tierMap.get("pro") ?? 0;
+  const ultraCount = tierMap.get("ultra") ?? 0;
+  const paidUsers = proCount + ultraCount;
+  const freeUsers = totalUsers - paidUsers;
+
+  const mrr =
+    proCount * PLAN_PRICES_USD.pro + ultraCount * PLAN_PRICES_USD.ultra;
+
+  return {
+    totalUsers,
+    freeUsers,
+    paidUsers,
+    paidPercent: sharePct(paidUsers, totalUsers),
+    mrr,
+    newUsers: newUsersInRange[0]?.total ?? 0,
+    newUsersGrowth: pctChange(
+      newUsersInRange[0]?.total ?? 0,
+      newUsersPrev[0]?.total ?? 0,
+    ),
+    newPaid: newPaidInRange[0]?.total ?? 0,
+    newPaidGrowth: pctChange(
+      newPaidInRange[0]?.total ?? 0,
+      newPaidPrev[0]?.total ?? 0,
+    ),
+    paidGrowth: pctChange(paidUsers, paidPrevResult[0]?.total ?? 0),
+    tiers: {
+      free: {
+        count: freeUsers,
+        share: sharePct(freeUsers, totalUsers),
+        mrr: 0,
+      },
+      pro: {
+        count: proCount,
+        share: sharePct(proCount, totalUsers),
+        mrr: proCount * PLAN_PRICES_USD.pro,
+      },
+      ultra: {
+        count: ultraCount,
+        share: sharePct(ultraCount, totalUsers),
+        mrr: ultraCount * PLAN_PRICES_USD.ultra,
+      },
+    },
+  };
+}
+
+export async function getSubscriptionTimeline(
+  ctx: ProtectedTRPCContext,
+  input: GetSubscriptionTimelineInput,
+) {
+  const { from, to } = input;
+
+  const dateExpr = sql<string>`DATE_FORMAT(${subscription.createdAt}, '%Y-%m')`;
+
+  const rows = await ctx.db
+    .select({
+      date: dateExpr,
+      plan: subscription.plan,
+      total: count(),
+    })
+    .from(subscription)
+    .where(
+      and(
+        inArray(subscription.plan, PAID_PLANS),
+        between(subscription.createdAt, from, to),
+      ),
+    )
+    .groupBy(dateExpr, subscription.plan)
+    .orderBy(dateExpr);
+
+  const byDate = new Map<string, { pro: number; ultra: number }>();
+  for (const row of rows) {
+    const key = String(row.date);
+    const entry = byDate.get(key) ?? { pro: 0, ultra: 0 };
+    if (row.plan === "pro") entry.pro = row.total;
+    else if (row.plan === "ultra") entry.ultra = row.total;
+    byDate.set(key, entry);
+  }
+
+  const result: { date: string; pro: number; ultra: number }[] = [];
+  const cursor = new Date(from);
+  cursor.setDate(1);
+  const endMonth = to.getFullYear() * 12 + to.getMonth();
+  while (cursor.getFullYear() * 12 + cursor.getMonth() <= endMonth) {
+    const key = `${cursor.getFullYear()}-${String(cursor.getMonth() + 1).padStart(2, "0")}`;
+    const entry = byDate.get(key) ?? { pro: 0, ultra: 0 };
+    result.push({ date: key, pro: entry.pro, ultra: entry.ultra });
+    cursor.setMonth(cursor.getMonth() + 1);
+  }
+
+  return result;
+}
+
+export async function getRecentSubscriptions(
+  ctx: ProtectedTRPCContext,
+  input: GetRecentSubscriptionsInput,
+) {
+  const rows = await ctx.db
+    .select({
+      id: subscription.id,
+      userId: subscription.userId,
+      plan: subscription.plan,
+      status: subscription.status,
+      createdAt: subscription.createdAt,
+      renewsAt: subscription.renewsAt,
+      endsAt: subscription.endsAt,
+      userName: user.name,
+      userEmail: user.email,
+      userImage: user.imageUrl,
+    })
+    .from(subscription)
+    .innerJoin(user, eq(subscription.userId, user.id))
+    .where(inArray(subscription.plan, PAID_PLANS))
+    .orderBy(desc(subscription.createdAt))
+    .limit(input.limit);
+
+  return rows;
 }


### PR DESCRIPTION
## Summary

Adds a founder-facing overview to the admin users page: total/paid user counts, MRR, plan-tier breakdown, monthly subscription growth chart, and recent paid sign-ups. The existing search and ban flow is preserved below the overview.

## Changes

- New tRPC procedures: `admin.getUserBaseSummary`, `admin.getSubscriptionTimeline`, `admin.getRecentSubscriptions`.
- Shared `PLAN_PRICES_USD` / `PAID_PLANS` constants in `src/lib/constants/plan-pricing.ts` (Pro $5, Ultra $15) used to compute MRR. Pricing card not refactored to consume them - out of scope.
- New components under `dashboard/admin/users/_components/`: stat row, plan-tier breakdown card, monthly subscription growth chart, recent paid sign-ups list.
- `StatCard` extracted to `dashboard/admin/_components/stat-card.tsx`; `admin/page.tsx` updated to consume it.
- `timeAgo` moved to `lib/utils/index.ts` as a thin null-safe wrapper around `date-fns` `formatDistanceToNow`.
- Adds `orca.yaml` so new worktrees copy the root `.env` from the main worktree and run `bun install` (unrelated; bundled for convenience).

## Notes / follow-ups

- **No index on `subscription.createdAt` or `(plan, createdAt)`.** Every new query is a full scan. Fine at current table size (1:1 with users); should be added before this scales.
- **`paidGrowth` is an approximation.** Without a subscription event log, "paid users at end of previous period" is computed as "rows existing by prevTo and still paid today" - anyone who churned in between is excluded from both sides, so the number trends optimistic.
- **MRR is understated by design of the existing webhook**, which flips `plan` to `free` immediately on cancellation rather than at `endsAt`. Pre-existing behavior; not changed here.
- Subscription growth chart is monthly-only by deliberate choice - daily buckets are too sparse to be meaningful for a small subscriber base.

## Testing

- `bun run typecheck` passes.
- `bun run lint` is blocked by an unrelated interactive ESLint config prompt in this project.
- Not yet smoke-tested in a browser - recommend a manual click-through before merging.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added comprehensive admin analytics dashboard for the Users section, including date range filtering, user base statistics (total users, paid users, MRR), subscription growth trends for Pro and Ultra plans, plan tier distribution breakdown, and recent paid subscription activity.

* **Chores**
  * Updated setup script to improve environment configuration handling and dependency installation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->