### PR TITLE
Classify macOS visitors as Desktop instead of Unknown

### DIFF
--- a/src/lib/core/analytics/index.ts
+++ b/src/lib/core/analytics/index.ts
@@ -2,6 +2,7 @@ import { UAParser } from "ua-parser-js";
 
 import { env } from "@/env.mjs";
 import { LOCAL_DEVELOPMENT_GEOLOCATION_DATA } from "@/lib/constants/app";
+import { resolveDeviceType } from "@/lib/utils/device-type";
 
 import type { RouterOutputs } from "@/trpc/shared";
 
@@ -36,29 +37,12 @@ const identifyRequestingDevice = async (headers: Headers) => {
 
   const result = await UAParser(userAgent, headers).withClientHints();
 
-  const deviceTypesMapping: Record<string, string> = {
-    iOS: "Mobile",
-    Android: "Mobile",
-    "Mac OS": "Desktop",
-    Windows: "Desktop",
-    Linux: "Desktop",
-    Ubuntu: "Desktop",
-    Debian: "Desktop",
-    Fedora: "Desktop",
-    "Chrome OS": "Desktop",
-    ChromeOS: "Desktop",
-    FreeBSD: "Desktop",
-    OpenBSD: "Desktop",
-  };
-
   const osName = result.os.name ?? "Unknown";
-  const deviceType =
-    result.device.type ?? deviceTypesMapping[osName] ?? "Unknown";
 
   return {
     browser: result.browser.name ?? "Unknown",
     os: osName,
-    device: deviceType,
+    device: resolveDeviceType(osName, result.device.type),
     model: result.device.model ?? "Unknown",
   };
 };

--- a/src/lib/utils/device-type.ts
+++ b/src/lib/utils/device-type.ts
@@ -1,0 +1,34 @@
+// Desktop/mobile classification for analytics. ua-parser-js only populates
+// `device.type` for non-desktop user agents (mobile/tablet/smarttv/etc.), so
+// we fall back to the OS name. Keys are matched case-insensitively so that
+// future ua-parser-js casing changes (e.g. "Mac OS" → "macOS" between v1 and
+// v2) don't silently degrade to "Unknown" again.
+
+const DESKTOP_OS_NAMES = new Set([
+  "macos",
+  "mac os",
+  "os x",
+  "windows",
+  "linux",
+  "ubuntu",
+  "debian",
+  "fedora",
+  "chrome os",
+  "chromeos",
+  "freebsd",
+  "openbsd",
+]);
+
+const MOBILE_OS_NAMES = new Set(["ios", "android"]);
+
+export function resolveDeviceType(
+  osName: string | undefined | null,
+  parserDeviceType: string | undefined | null,
+): string {
+  if (parserDeviceType) return parserDeviceType;
+  if (!osName) return "Unknown";
+  const key = osName.toLowerCase();
+  if (MOBILE_OS_NAMES.has(key)) return "Mobile";
+  if (DESKTOP_OS_NAMES.has(key)) return "Desktop";
+  return "Unknown";
+}

--- a/src/middlewares/record-click.ts
+++ b/src/middlewares/record-click.ts
@@ -4,6 +4,7 @@ import { UAParser } from "ua-parser-js";
 import { type Link, buildCacheKey, normalizeDomain, getFromCache, setInCache } from "@/lib/core/cache";
 import { getContinentName, getCountryFullName } from "@/lib/countries";
 import { runBackgroundTask } from "@/lib/utils/background";
+import { resolveDeviceType } from "@/lib/utils/device-type";
 import { hashIp } from "@/lib/utils/ip-hash";
 import { isBot } from "@/lib/utils/is-bot";
 import { db } from "@/server/db";
@@ -13,21 +14,6 @@ import { checkAndFireMilestones } from "@/server/lib/milestone-check";
 import { sendEventUsageEmail } from "@/server/lib/notifications/event-usage";
 
 const isLocalhost = process.env.NODE_ENV === "development";
-
-const OS_TO_DEVICE_TYPE: Record<string, string> = {
-  iOS: "Mobile",
-  Android: "Mobile",
-  "Mac OS": "Desktop",
-  Windows: "Desktop",
-  Linux: "Desktop",
-  Ubuntu: "Desktop",
-  Debian: "Desktop",
-  Fedora: "Desktop",
-  "Chrome OS": "Desktop",
-  ChromeOS: "Desktop",
-  FreeBSD: "Desktop",
-  OpenBSD: "Desktop",
-};
 
 /**
  * Cache-first link lookup. No side effects except populating the cache on miss.
@@ -109,7 +95,7 @@ export async function recordClick(
   const deviceDetails = {
     browser: parsedUserAgent.browser.name ?? "Unknown",
     os: osName,
-    device: parsedUserAgent.device.type ?? OS_TO_DEVICE_TYPE[osName] ?? "Unknown",
+    device: resolveDeviceType(osName, parsedUserAgent.device.type),
     model: parsedUserAgent.device.model ?? "Unknown",
   };
 


### PR DESCRIPTION
## Summary

After the ua-parser-js v1 → v2 bump in the previous PR, desktop Mac visitors were being bucketed as `device: Unknown` even though OS and browser resolved correctly. Root cause was a key-miss in the OS → device-type fallback map:

- v1 returned `"Mac OS"` (with space).
- v2 returns `"macOS"` (no space).
- The map only had `"Mac OS"`, so Mac visits fell through.

This PR fixes the map **and** prevents the same drift from happening again.

## What changed

- Extracted the OS → device-type fallback into a single `src/lib/utils/device-type.ts` helper. It was previously duplicated across `src/middlewares/record-click.ts` and `src/lib/core/analytics/index.ts`, which is how the v1/v2 naming drift slipped through.
- Added `"macOS"` to the set alongside `"Mac OS"` (and `"OS X"`) and made the comparison case-insensitive. Any future casing change upstream is absorbed automatically.
- Both analytics paths now import the shared helper.

## Why not use `userAgent()` from `next/server`

Checked at the source (`node_modules/next/dist/server/web/spec-extension/user-agent.js`). It would be a regression:

- Ships a vendored **ua-parser-js v1.0.35** (we're on v2.0.9). Switching loses the maintained bot/AI-crawler registry, most recent OS/device vocabulary, and re-introduces the exact `"Mac OS"` naming that caused this bug.
- Doesn't forward Client Hints. Our current code uses `UAParser(ua, headers).withClientHints()`, which recovers the real OS version and device model on modern Chrome. Next.js's helper passes only the UA string.
- Its `isBot` is a small static regex (~25 entries). Ours uses v2's maintained bot-detection submodule (curl, python-requests, Go-http-client, GPTBot, ClaudeBot, etc.).
- Its `device.type` for desktop is also `undefined` — it would not have solved the original problem.

Keeping the direct v2 + Client Hints + OS-fallback approach. The fallback just needed to learn the new naming.

## Verified against real UAs

| UA | Before | After |
| --- | --- | --- |
| Firefox / macOS | Unknown | Desktop |
| Chrome / macOS | Unknown | Desktop |
| Chrome / Windows 11 | Desktop | Desktop |
| Firefox / Ubuntu | Desktop | Desktop |
| Chromebook | Desktop | Desktop |
| iPhone Safari | mobile | mobile |
| Pixel 7 Chrome | mobile | mobile |

## Test plan

- [ ] Click a short link from Firefox on macOS. Confirm the new visit appears with `device: Desktop` in the analytics dashboard.
- [ ] Click from Chrome on macOS. Same check.
- [ ] Click from an iPhone and an Android phone. Confirm both show as mobile.
- [ ] Verify that existing rows with `device: Unknown` are unchanged — this fix only affects new clicks.

## Scope note

Existing `device: Unknown` rows stay as they are; this fix applies to new visits only. If you want those backfilled, that would be a separate data migration using the stored `os` column to retroactively reclassify.