### PR TITLE
feat(analytics): add verified clicks

### DIFF
--- a/content/changelogs/2026-04-17-verified-clicks.md
+++ b/content/changelogs/2026-04-17-verified-clicks.md
@@ -1,0 +1,47 @@
+---
+date: 2026-04-17T12:00:00
+version: 2.3.0
+title: Verified Clicks
+shortDesc: See how many of your clicks came from real visitors, not automated traffic
+category: feature
+---
+
+Not every click on a short link is a person. Link scanners, security tools, preview crawlers, and other automated systems all follow links — and they all count toward your total. Verified Clicks separates the real visitors from the noise, so when you report "500 clicks" you can back it up with "and 320 of them were real people who actually opened the page."
+
+## What's new?
+
+### A "Verified Visits" number in your analytics
+
+Open the analytics page for any link with Verified Clicks turned on and you'll see a new card alongside Total Visits: **Verified Visits**. It shows how many of your clicks came from a real visitor opening the page — the rest is automated traffic, prefetch requests, and other noise you probably don't want to count.
+
+The gap between the two numbers is itself useful. A campaign sitting at 90% verified is healthy engagement. A campaign at 20% verified is telling you something about where those clicks are coming from.
+
+### A simple toggle per link
+
+When you create or edit a link, you'll find a new **Verified Clicks** section. Flip the switch and the feature is active immediately — no extra setup, no snippet to paste, no change to the short URL.
+
+You can turn it on for new links, or go back and enable it on links you've already shared. Existing click history stays intact; the verified count starts tracking from the moment you turn it on.
+
+### Works across your links — including password-protected ones
+
+Verified Clicks works with all your link types:
+
+- **Regular short links** — the standard redirect flow
+- **Cloaked links** — where your branded URL stays visible
+- **Password-protected links** — the verified count picks up after the visitor unlocks the link
+
+## Why it matters
+
+- **Trustworthy reporting** — Share numbers with clients, teams, or stakeholders knowing they reflect real engagement, not inflated crawler traffic
+- **Campaign confidence** — Spot when a link is getting a lot of clicks but little actual attention
+- **Cleaner comparisons** — When two campaigns have the same total clicks but very different verified counts, you know which one actually connected with people
+
+## How it works
+
+When someone clicks your link, we quietly check whether the click came from a real browser actually loading the page. If it did, we count it as verified. If it was an automated system that never really opened the page, it still shows up in your total count but doesn't count as verified.
+
+You don't see anything different as the link owner — the short URL still works exactly the same way, and visitors are taken to the destination as usual.
+
+## Who can use this?
+
+Verified Clicks is available on the **Pro** and **Ultra** plans. Enable it on any link from the [new link page](/dashboard/link/new) or by editing an existing link from your dashboard.

--- a/drizzle/0058_violet_timeslip.sql
+++ b/drizzle/0058_violet_timeslip.sql
@@ -1,0 +1,4 @@
+ALTER TABLE `Link` ADD `verifiedClicksEnabled` boolean DEFAULT false;--> statement-breakpoint
+ALTER TABLE `LinkVisit` ADD `visitId` char(36);--> statement-breakpoint
+ALTER TABLE `LinkVisit` ADD `verifiedAt` timestamp;--> statement-breakpoint
+ALTER TABLE `LinkVisit` ADD CONSTRAINT `visitId_idx` UNIQUE(`visitId`);

--- a/drizzle/meta/0058_snapshot.json
+++ b/drizzle/meta/0058_snapshot.json
@@ -1,0 +1,2702 @@
+{
+  "version": "5",
+  "dialect": "mysql",
+  "id": "7809a703-2fc5-4494-886f-d0f5070716d8",
+  "prevId": "5531bf2e-b107-4adc-883b-8148f1640e79",
+  "tables": {
+    "AccountTransfer": {
+      "name": "AccountTransfer",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "fromUserId": {
+          "name": "fromUserId",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "toEmail": {
+          "name": "toEmail",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "toUserId": {
+          "name": "toUserId",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "enum('pending','accepted','cancelled','expired','declined')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "linksCount": {
+          "name": "linksCount",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "customDomainsCount": {
+          "name": "customDomainsCount",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "qrCodesCount": {
+          "name": "qrCodesCount",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "foldersCount": {
+          "name": "foldersCount",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "tagsCount": {
+          "name": "tagsCount",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "utmTemplatesCount": {
+          "name": "utmTemplatesCount",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "qrPresetsCount": {
+          "name": "qrPresetsCount",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "acceptedAt": {
+          "name": "acceptedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "fromUser_idx": {
+          "name": "fromUser_idx",
+          "columns": [
+            "fromUserId"
+          ],
+          "isUnique": false
+        },
+        "toEmail_idx": {
+          "name": "toEmail_idx",
+          "columns": [
+            "toEmail"
+          ],
+          "isUnique": false
+        },
+        "status_idx": {
+          "name": "status_idx",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "AccountTransfer_id": {
+          "name": "AccountTransfer_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "AccountTransfer_token_unique": {
+          "name": "AccountTransfer_token_unique",
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "checkConstraint": {}
+    },
+    "BlockedDomain": {
+      "name": "BlockedDomain",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "domain": {
+          "name": "domain",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "createdByUserId": {
+          "name": "createdByUserId",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "BlockedDomain_id": {
+          "name": "BlockedDomain_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "BlockedDomain_domain_unique": {
+          "name": "BlockedDomain_domain_unique",
+          "columns": [
+            "domain"
+          ]
+        }
+      },
+      "checkConstraint": {}
+    },
+    "CustomDomain": {
+      "name": "CustomDomain",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "domain": {
+          "name": "domain",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "teamId": {
+          "name": "teamId",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "status": {
+          "name": "status",
+          "type": "enum('pending','active','invalid')",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "verificationDetails": {
+          "name": "verificationDetails",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "lastReminderSentAt": {
+          "name": "lastReminderSentAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "teamIdForUnique": {
+          "name": "teamIdForUnique",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "generated": {
+            "as": "COALESCE(`teamId`, 0)",
+            "type": "stored"
+          }
+        }
+      },
+      "indexes": {
+        "userId_idx": {
+          "name": "userId_idx",
+          "columns": [
+            "userId"
+          ],
+          "isUnique": false
+        },
+        "teamId_idx": {
+          "name": "teamId_idx",
+          "columns": [
+            "teamId"
+          ],
+          "isUnique": false
+        },
+        "status_createdAt_idx": {
+          "name": "status_createdAt_idx",
+          "columns": [
+            "status",
+            "createdAt"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "CustomDomain_id": {
+          "name": "CustomDomain_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "domain_workspace_unique": {
+          "name": "domain_workspace_unique",
+          "columns": [
+            "domain",
+            "userId",
+            "teamIdForUnique"
+          ]
+        }
+      },
+      "checkConstraint": {}
+    },
+    "Feedback": {
+      "name": "Feedback",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "feedbackType": {
+          "name": "feedbackType",
+          "type": "enum('bug','feature','question')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "imageUrls": {
+          "name": "imageUrls",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "('[]')"
+        },
+        "feedbackStatus": {
+          "name": "feedbackStatus",
+          "type": "enum('open','resolved','dismissed')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'open'"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "userId_idx": {
+          "name": "userId_idx",
+          "columns": [
+            "userId"
+          ],
+          "isUnique": false
+        },
+        "status_idx": {
+          "name": "status_idx",
+          "columns": [
+            "feedbackStatus"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "Feedback_id": {
+          "name": "Feedback_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "FlaggedLink": {
+      "name": "FlaggedLink",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "linkId": {
+          "name": "linkId",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "flagStatus": {
+          "name": "flagStatus",
+          "type": "enum('pending','blocked','dismissed')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "flaggedAt": {
+          "name": "flaggedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "resolvedAt": {
+          "name": "resolvedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "resolvedByUserId": {
+          "name": "resolvedByUserId",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "linkId_idx": {
+          "name": "linkId_idx",
+          "columns": [
+            "linkId"
+          ],
+          "isUnique": false
+        },
+        "status_idx": {
+          "name": "status_idx",
+          "columns": [
+            "flagStatus"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "FlaggedLink_id": {
+          "name": "FlaggedLink_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "Folder": {
+      "name": "Folder",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "teamId": {
+          "name": "teamId",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "isRestricted": {
+          "name": "isRestricted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "onUpdate": true
+        }
+      },
+      "indexes": {
+        "userId_idx": {
+          "name": "userId_idx",
+          "columns": [
+            "userId"
+          ],
+          "isUnique": false
+        },
+        "teamId_idx": {
+          "name": "teamId_idx",
+          "columns": [
+            "teamId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "Folder_id": {
+          "name": "Folder_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "FolderPermission": {
+      "name": "FolderPermission",
+      "columns": {
+        "folderId": {
+          "name": "folderId",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "userId_idx": {
+          "name": "userId_idx",
+          "columns": [
+            "userId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "FolderPermission_folderId_userId_pk": {
+          "name": "FolderPermission_folderId_userId_pk",
+          "columns": [
+            "folderId",
+            "userId"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "GeoRule": {
+      "name": "GeoRule",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "linkId": {
+          "name": "linkId",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "enum('country','continent')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "condition": {
+          "name": "condition",
+          "type": "enum('in','not_in')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'in'"
+        },
+        "values": {
+          "name": "values",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "action": {
+          "name": "action",
+          "type": "enum('redirect','block')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "destination": {
+          "name": "destination",
+          "type": "varchar(2048)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "blockMessage": {
+          "name": "blockMessage",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "priority": {
+          "name": "priority",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "linkId_idx": {
+          "name": "linkId_idx",
+          "columns": [
+            "linkId"
+          ],
+          "isUnique": false
+        },
+        "priority_idx": {
+          "name": "priority_idx",
+          "columns": [
+            "linkId",
+            "priority"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "GeoRule_id": {
+          "name": "GeoRule_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "Link": {
+      "name": "Link",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "alias": {
+          "name": "alias",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "domain": {
+          "name": "domain",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'ishortn.ink'"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "disableLinkAfterClicks": {
+          "name": "disableLinkAfterClicks",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "disableLinkAfterDate": {
+          "name": "disableLinkAfterDate",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "disabled": {
+          "name": "disabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "publicStats": {
+          "name": "publicStats",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "teamId": {
+          "name": "teamId",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdByUserId": {
+          "name": "createdByUserId",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "passwordHash": {
+          "name": "passwordHash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "note": {
+          "name": "note",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "utmParams": {
+          "name": "utmParams",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "('[]')"
+        },
+        "archived": {
+          "name": "archived",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "folderId": {
+          "name": "folderId",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cloaking": {
+          "name": "cloaking",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "verifiedClicksEnabled": {
+          "name": "verifiedClicksEnabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "isQrCode": {
+          "name": "isQrCode",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "blocked": {
+          "name": "blocked",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "blockedAt": {
+          "name": "blockedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "blockedReason": {
+          "name": "blockedReason",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "userId_idx": {
+          "name": "userId_idx",
+          "columns": [
+            "userId"
+          ],
+          "isUnique": false
+        },
+        "teamId_idx": {
+          "name": "teamId_idx",
+          "columns": [
+            "teamId"
+          ],
+          "isUnique": false
+        },
+        "aliasDomain_idx": {
+          "name": "aliasDomain_idx",
+          "columns": [
+            "alias",
+            "domain"
+          ],
+          "isUnique": false
+        },
+        "folderId_idx": {
+          "name": "folderId_idx",
+          "columns": [
+            "folderId"
+          ],
+          "isUnique": false
+        },
+        "createdAt_idx": {
+          "name": "createdAt_idx",
+          "columns": [
+            "createdAt"
+          ],
+          "isUnique": false
+        },
+        "blocked_blockedAt_idx": {
+          "name": "blocked_blockedAt_idx",
+          "columns": [
+            "blocked",
+            "blockedAt"
+          ],
+          "isUnique": false
+        },
+        "domain_idx": {
+          "name": "domain_idx",
+          "columns": [
+            "domain"
+          ],
+          "isUnique": false
+        },
+        "listing_idx": {
+          "name": "listing_idx",
+          "columns": [
+            "userId",
+            "teamId",
+            "isQrCode",
+            "archived"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "Link_id": {
+          "name": "Link_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "unique_alias_domain": {
+          "name": "unique_alias_domain",
+          "columns": [
+            "alias",
+            "domain"
+          ]
+        }
+      },
+      "checkConstraint": {}
+    },
+    "LinkMilestone": {
+      "name": "LinkMilestone",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "linkId": {
+          "name": "linkId",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "threshold": {
+          "name": "threshold",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "notifiedAt": {
+          "name": "notifiedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "linkId_idx": {
+          "name": "linkId_idx",
+          "columns": [
+            "linkId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "LinkMilestone_id": {
+          "name": "LinkMilestone_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "link_threshold_unique": {
+          "name": "link_threshold_unique",
+          "columns": [
+            "linkId",
+            "threshold"
+          ]
+        }
+      },
+      "checkConstraint": {}
+    },
+    "LinkTag": {
+      "name": "LinkTag",
+      "columns": {
+        "linkId": {
+          "name": "linkId",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tagId": {
+          "name": "tagId",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "tagId_idx": {
+          "name": "tagId_idx",
+          "columns": [
+            "tagId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "LinkTag_linkId_tagId_pk": {
+          "name": "LinkTag_linkId_tagId_pk",
+          "columns": [
+            "linkId",
+            "tagId"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "LinkVisit": {
+      "name": "LinkVisit",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "linkId": {
+          "name": "linkId",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "device": {
+          "name": "device",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "browser": {
+          "name": "browser",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "os": {
+          "name": "os",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "referer": {
+          "name": "referer",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "country": {
+          "name": "country",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "city": {
+          "name": "city",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "continent": {
+          "name": "continent",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'N/A'"
+        },
+        "matchedGeoRuleId": {
+          "name": "matchedGeoRuleId",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "visitId": {
+          "name": "visitId",
+          "type": "char(36)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "verifiedAt": {
+          "name": "verifiedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "linkId_idx": {
+          "name": "linkId_idx",
+          "columns": [
+            "linkId"
+          ],
+          "isUnique": false
+        },
+        "geoRuleId_idx": {
+          "name": "geoRuleId_idx",
+          "columns": [
+            "matchedGeoRuleId"
+          ],
+          "isUnique": false
+        },
+        "linkId_createdAt_idx": {
+          "name": "linkId_createdAt_idx",
+          "columns": [
+            "linkId",
+            "createdAt"
+          ],
+          "isUnique": false
+        },
+        "createdAt_idx": {
+          "name": "createdAt_idx",
+          "columns": [
+            "createdAt"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "LinkVisit_id": {
+          "name": "LinkVisit_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "visitId_idx": {
+          "name": "visitId_idx",
+          "columns": [
+            "visitId"
+          ]
+        }
+      },
+      "checkConstraint": {}
+    },
+    "LinkVisitDailySummary": {
+      "name": "LinkVisitDailySummary",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "linkId": {
+          "name": "linkId",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "clicks": {
+          "name": "clicks",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "uniqueClicks": {
+          "name": "uniqueClicks",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "LinkVisitDailySummary_id": {
+          "name": "LinkVisitDailySummary_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "link_date_unique": {
+          "name": "link_date_unique",
+          "columns": [
+            "linkId",
+            "date"
+          ]
+        }
+      },
+      "checkConstraint": {}
+    },
+    "QrPreset": {
+      "name": "QrPreset",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "teamId": {
+          "name": "teamId",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pixelStyle": {
+          "name": "pixelStyle",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'rounded'"
+        },
+        "markerShape": {
+          "name": "markerShape",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'square'"
+        },
+        "markerInnerShape": {
+          "name": "markerInnerShape",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'auto'"
+        },
+        "darkColor": {
+          "name": "darkColor",
+          "type": "varchar(9)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'#000000'"
+        },
+        "lightColor": {
+          "name": "lightColor",
+          "type": "varchar(9)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'#ffffff'"
+        },
+        "effect": {
+          "name": "effect",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'none'"
+        },
+        "effectRadius": {
+          "name": "effectRadius",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 12
+        },
+        "marginNoise": {
+          "name": "marginNoise",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "marginNoiseRate": {
+          "name": "marginNoiseRate",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'0.5'"
+        },
+        "logoImage": {
+          "name": "logoImage",
+          "type": "longtext",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "logoSize": {
+          "name": "logoSize",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 25
+        },
+        "logoMargin": {
+          "name": "logoMargin",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 4
+        },
+        "logoBorderRadius": {
+          "name": "logoBorderRadius",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 8
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "onUpdate": true
+        }
+      },
+      "indexes": {
+        "userId_idx": {
+          "name": "userId_idx",
+          "columns": [
+            "userId"
+          ],
+          "isUnique": false
+        },
+        "teamId_idx": {
+          "name": "teamId_idx",
+          "columns": [
+            "teamId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "QrPreset_id": {
+          "name": "QrPreset_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "QrCode": {
+      "name": "QrCode",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "qrCode": {
+          "name": "qrCode",
+          "type": "longtext",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "teamId": {
+          "name": "teamId",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "linkId": {
+          "name": "linkId",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "contentType": {
+          "name": "contentType",
+          "type": "enum('link','text')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "patternStyle": {
+          "name": "patternStyle",
+          "type": "enum('square','diamond','star','fluid','rounded','tile','stripe','fluid-line','stripe-column')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "cornerStyle": {
+          "name": "cornerStyle",
+          "type": "enum('circle','circle-diamond','square','square-diamond','rounded-circle','rounded','circle-star')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "color": {
+          "name": "color",
+          "type": "varchar(7)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "userId_idx": {
+          "name": "userId_idx",
+          "columns": [
+            "userId"
+          ],
+          "isUnique": false
+        },
+        "teamId_idx": {
+          "name": "teamId_idx",
+          "columns": [
+            "teamId"
+          ],
+          "isUnique": false
+        },
+        "linkId_idx": {
+          "name": "linkId_idx",
+          "columns": [
+            "linkId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "QrCode_id": {
+          "name": "QrCode_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "SiteSettings": {
+      "name": "SiteSettings",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "teamId": {
+          "name": "teamId",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "defaultDomain": {
+          "name": "defaultDomain",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'ishortn.ink'"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "onUpdate": true
+        }
+      },
+      "indexes": {
+        "userId_idx": {
+          "name": "userId_idx",
+          "columns": [
+            "userId"
+          ],
+          "isUnique": false
+        },
+        "teamId_idx": {
+          "name": "teamId_idx",
+          "columns": [
+            "teamId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "SiteSettings_id": {
+          "name": "SiteSettings_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "Subscription": {
+      "name": "Subscription",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "orderId": {
+          "name": "orderId",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "subscriptionId": {
+          "name": "subscriptionId",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "customerId": {
+          "name": "customerId",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "renewsAt": {
+          "name": "renewsAt",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "endsAt": {
+          "name": "endsAt",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "plan": {
+          "name": "plan",
+          "type": "enum('free','pro','ultra')",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'free'"
+        },
+        "variantId": {
+          "name": "variantId",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "productId": {
+          "name": "productId",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "cardBrand": {
+          "name": "cardBrand",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "cardLastFour": {
+          "name": "cardLastFour",
+          "type": "varchar(4)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "''"
+        }
+      },
+      "indexes": {
+        "userId_idx": {
+          "name": "userId_idx",
+          "columns": [
+            "userId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "Subscription_id": {
+          "name": "Subscription_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "Subscription_userId_unique": {
+          "name": "Subscription_userId_unique",
+          "columns": [
+            "userId"
+          ]
+        }
+      },
+      "checkConstraint": {}
+    },
+    "Tag": {
+      "name": "Tag",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "teamId": {
+          "name": "teamId",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "name_idx": {
+          "name": "name_idx",
+          "columns": [
+            "name"
+          ],
+          "isUnique": false
+        },
+        "userId_idx": {
+          "name": "userId_idx",
+          "columns": [
+            "userId"
+          ],
+          "isUnique": false
+        },
+        "teamId_idx": {
+          "name": "teamId_idx",
+          "columns": [
+            "teamId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "Tag_id": {
+          "name": "Tag_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "unique_tag_team": {
+          "name": "unique_tag_team",
+          "columns": [
+            "name",
+            "teamId"
+          ]
+        }
+      },
+      "checkConstraint": {}
+    },
+    "Team": {
+      "name": "Team",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "avatarUrl": {
+          "name": "avatarUrl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "defaultDomain": {
+          "name": "defaultDomain",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'ishortn.ink'"
+        },
+        "ownerId": {
+          "name": "ownerId",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "onUpdate": true
+        },
+        "deletedAt": {
+          "name": "deletedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "ownerId_idx": {
+          "name": "ownerId_idx",
+          "columns": [
+            "ownerId"
+          ],
+          "isUnique": false
+        },
+        "deletedAt_idx": {
+          "name": "deletedAt_idx",
+          "columns": [
+            "deletedAt"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "Team_id": {
+          "name": "Team_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "Team_slug_unique": {
+          "name": "Team_slug_unique",
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "checkConstraint": {}
+    },
+    "TeamInvite": {
+      "name": "TeamInvite",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "teamId": {
+          "name": "teamId",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "inviteRole": {
+          "name": "inviteRole",
+          "type": "enum('admin','member')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'member'"
+        },
+        "token": {
+          "name": "token",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "invitedBy": {
+          "name": "invitedBy",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "acceptedAt": {
+          "name": "acceptedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "team_idx": {
+          "name": "team_idx",
+          "columns": [
+            "teamId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "TeamInvite_id": {
+          "name": "TeamInvite_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "TeamInvite_token_unique": {
+          "name": "TeamInvite_token_unique",
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "checkConstraint": {}
+    },
+    "TeamMember": {
+      "name": "TeamMember",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "teamId": {
+          "name": "teamId",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "enum('owner','admin','member')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "onUpdate": true
+        }
+      },
+      "indexes": {
+        "team_user_idx": {
+          "name": "team_user_idx",
+          "columns": [
+            "teamId",
+            "userId"
+          ],
+          "isUnique": false
+        },
+        "user_idx": {
+          "name": "user_idx",
+          "columns": [
+            "userId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "TeamMember_id": {
+          "name": "TeamMember_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "unique_team_user": {
+          "name": "unique_team_user",
+          "columns": [
+            "teamId",
+            "userId"
+          ]
+        }
+      },
+      "checkConstraint": {}
+    },
+    "Token": {
+      "name": "Token",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "token": {
+          "name": "token",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "userId_idx": {
+          "name": "userId_idx",
+          "columns": [
+            "userId"
+          ],
+          "isUnique": false
+        },
+        "token_idx": {
+          "name": "token_idx",
+          "columns": [
+            "token"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "Token_id": {
+          "name": "Token_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "UniqueLinkVisit": {
+      "name": "UniqueLinkVisit",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "linkId": {
+          "name": "linkId",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ipHash": {
+          "name": "ipHash",
+          "type": "char(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "linkId_idx": {
+          "name": "linkId_idx",
+          "columns": [
+            "linkId"
+          ],
+          "isUnique": false
+        },
+        "ipHash_idx": {
+          "name": "ipHash_idx",
+          "columns": [
+            "ipHash"
+          ],
+          "isUnique": false
+        },
+        "linkId_createdAt_idx": {
+          "name": "linkId_createdAt_idx",
+          "columns": [
+            "linkId",
+            "createdAt"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "UniqueLinkVisit_id": {
+          "name": "UniqueLinkVisit_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "unique_visit_idx": {
+          "name": "unique_visit_idx",
+          "columns": [
+            "linkId",
+            "ipHash"
+          ]
+        }
+      },
+      "checkConstraint": {}
+    },
+    "User": {
+      "name": "User",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "imageUrl": {
+          "name": "imageUrl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "qrCodeCount": {
+          "name": "qrCodeCount",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "monthlyLinkCount": {
+          "name": "monthlyLinkCount",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "lastLinkCountReset": {
+          "name": "lastLinkCountReset",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "monthlyEventCount": {
+          "name": "monthlyEventCount",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "lastEventCountReset": {
+          "name": "lastEventCountReset",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "eventUsageAlertLevel": {
+          "name": "eventUsageAlertLevel",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "lastViewedChangelogSlug": {
+          "name": "lastViewedChangelogSlug",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "deletedAt": {
+          "name": "deletedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "isAdmin": {
+          "name": "isAdmin",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "banned": {
+          "name": "banned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "bannedAt": {
+          "name": "bannedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "bannedReason": {
+          "name": "bannedReason",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "deletedAt_idx": {
+          "name": "deletedAt_idx",
+          "columns": [
+            "deletedAt"
+          ],
+          "isUnique": false
+        },
+        "createdAt_idx": {
+          "name": "createdAt_idx",
+          "columns": [
+            "createdAt"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "User_id": {
+          "name": "User_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "User_email_unique": {
+          "name": "User_email_unique",
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "checkConstraint": {}
+    },
+    "UtmTemplate": {
+      "name": "UtmTemplate",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "utmSource": {
+          "name": "utmSource",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "utmMedium": {
+          "name": "utmMedium",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "utmCampaign": {
+          "name": "utmCampaign",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "utmTerm": {
+          "name": "utmTerm",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "utmContent": {
+          "name": "utmContent",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "teamId": {
+          "name": "teamId",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "onUpdate": true
+        }
+      },
+      "indexes": {
+        "userId_idx": {
+          "name": "userId_idx",
+          "columns": [
+            "userId"
+          ],
+          "isUnique": false
+        },
+        "teamId_idx": {
+          "name": "teamId_idx",
+          "columns": [
+            "teamId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "UtmTemplate_id": {
+          "name": "UtmTemplate_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    }
+  },
+  "views": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "tables": {},
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -407,6 +407,13 @@
       "when": 1776374240998,
       "tag": "0057_charming_sleepwalker",
       "breakpoints": true
+    },
+    {
+      "idx": 58,
+      "version": "5",
+      "when": 1776425374368,
+      "tag": "0058_violet_timeslip",
+      "breakpoints": true
     }
   ]
 }

--- a/src/app/(landing)/changelog/_components/changelog-timeline.tsx
+++ b/src/app/(landing)/changelog/_components/changelog-timeline.tsx
@@ -126,13 +126,11 @@ function Entry({
           </p>
         )}
 
-        <div className="mt-6 rounded-xl border border-zinc-800 bg-zinc-950/40">
-          <div
-            className="changelog-prose prose prose-invert max-w-none p-6 prose-headings:font-heading prose-headings:font-semibold prose-headings:tracking-tight prose-headings:text-zinc-50 prose-h2:mt-6 prose-h2:text-lg prose-h3:mt-4 prose-h3:text-base prose-p:text-zinc-400 prose-a:text-blue-400 prose-a:no-underline hover:prose-a:text-blue-300 prose-strong:text-zinc-100 prose-strong:font-semibold prose-li:text-zinc-400 prose-li:marker:text-zinc-600 prose-code:text-zinc-200 prose-hr:border-zinc-800 prose-table:text-sm prose-th:bg-zinc-900 prose-th:text-zinc-300 prose-th:px-4 prose-th:py-2 prose-td:px-4 prose-td:py-2 prose-td:text-zinc-400 prose-blockquote:border-zinc-800 prose-blockquote:text-zinc-400"
-            // biome-ignore lint/security/noDangerouslySetInnerHtml: Markdown content is parsed and sanitized
-            dangerouslySetInnerHTML={{ __html: entry.htmlContent }}
-          />
-        </div>
+        <div
+          className="changelog-prose prose prose-invert mt-6 max-w-none prose-headings:font-heading prose-headings:font-semibold prose-headings:tracking-tight prose-headings:text-zinc-50 prose-h2:mt-6 prose-h2:text-lg prose-h3:mt-4 prose-h3:text-base prose-p:text-zinc-400 prose-a:text-blue-400 prose-a:no-underline hover:prose-a:text-blue-300 prose-strong:text-zinc-100 prose-strong:font-semibold prose-li:text-zinc-400 prose-li:marker:text-zinc-600 prose-code:text-zinc-200 prose-hr:border-zinc-800 prose-table:text-sm prose-th:bg-zinc-900 prose-th:text-zinc-300 prose-th:px-4 prose-th:py-2 prose-td:px-4 prose-td:py-2 prose-td:text-zinc-400 prose-blockquote:border-zinc-800 prose-blockquote:text-zinc-400"
+          // biome-ignore lint/security/noDangerouslySetInnerHtml: Markdown content is parsed and sanitized
+          dangerouslySetInnerHTML={{ __html: entry.htmlContent }}
+        />
       </div>
     </motion.li>
   );

--- a/src/app/(main)/cloaked/[url]/page.tsx
+++ b/src/app/(main)/cloaked/[url]/page.tsx
@@ -1,11 +1,13 @@
 import type { Metadata } from "next";
 
 import { fetchMetadataInfo } from "@/lib/utils/fetch-link-metadata";
+import { buildBeaconScript } from "@/lib/utils/verified-click-token";
 
 export const fetchCache = "force-no-store";
 
 type CloakedPageProps = {
   params: Promise<{ url: string }>;
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
 };
 
 /**
@@ -82,7 +84,12 @@ export async function generateMetadata(props: CloakedPageProps): Promise<Metadat
 
 export default async function CloakedPage(props: CloakedPageProps) {
   const params = await props.params;
+  const searchParams = await props.searchParams;
   const url = decodeURIComponent(params.url);
+  const token =
+    typeof searchParams.t === "string" && searchParams.t.length > 0
+      ? searchParams.t
+      : null;
 
   // Validate and normalize the URL before rendering
   let validatedUrl: string;
@@ -106,25 +113,32 @@ export default async function CloakedPage(props: CloakedPageProps) {
   }
 
   return (
-    <iframe
-      src={validatedUrl}
-      title="Cloaked content"
-      className="h-screen w-full border-none"
-      style={{
-        position: "fixed",
-        top: 0,
-        left: 0,
-        width: "100%",
-        height: "100%",
-        border: "none",
-        margin: 0,
-        padding: 0,
-        overflow: "hidden",
-      }}
-      // Security note: allow-same-origin is required for most websites to function properly
-      // (login, cookies, storage). allow-scripts is needed for interactive content.
-      // The URL is validated above to only allow http/https protocols.
-      sandbox="allow-scripts allow-same-origin allow-forms allow-popups allow-popups-to-escape-sandbox"
-    />
+    <>
+      {token && (
+        <script
+          dangerouslySetInnerHTML={{ __html: buildBeaconScript(token) }}
+        />
+      )}
+      <iframe
+        src={validatedUrl}
+        title="Cloaked content"
+        className="h-screen w-full border-none"
+        style={{
+          position: "fixed",
+          top: 0,
+          left: 0,
+          width: "100%",
+          height: "100%",
+          border: "none",
+          margin: 0,
+          padding: 0,
+          overflow: "hidden",
+        }}
+        // Security note: allow-same-origin is required for most websites to function properly
+        // (login, cookies, storage). allow-scripts is needed for interactive content.
+        // The URL is validated above to only allow http/https protocols.
+        sandbox="allow-scripts allow-same-origin allow-forms allow-popups allow-popups-to-escape-sandbox"
+      />
+    </>
   );
 }

--- a/src/app/(main)/dashboard/_components/links/link-card/edit-link-drawer.tsx
+++ b/src/app/(main)/dashboard/_components/links/link-card/edit-link-drawer.tsx
@@ -81,6 +81,7 @@ export function EditLinkDrawer({ link, open, onClose }: EditLinkDrawerProps) {
   const [isLinkCloakingOpen, setIsLinkCloakingOpen] = useState(false);
   const [isCheckingIframeable, setIsCheckingIframeable] = useState(false);
   const [iframeableResult, setIframeableResult] = useState<boolean | null>(null);
+  const [isVerifiedClicksOpen, setIsVerifiedClicksOpen] = useState(false);
   const [isMilestonesOpen, setIsMilestonesOpen] = useState(false);
   const [milestones, setMilestones] = useState<MilestoneEntry[]>([]);
 
@@ -127,6 +128,7 @@ export function EditLinkDrawer({ link, open, onClose }: EditLinkDrawerProps) {
           utm_content?: string;
         }) ?? undefined,
       cloaking: linkData.cloaking ?? false,
+      verifiedClicksEnabled: linkData.verifiedClicksEnabled ?? false,
       geoRules: geoRules?.map((rule) => ({
         type: rule.type,
         condition: rule.condition,
@@ -597,6 +599,7 @@ export function EditLinkDrawer({ link, open, onClose }: EditLinkDrawerProps) {
                     isOpen={isLinkCloakingOpen}
                     onToggle={() => setIsLinkCloakingOpen(!isLinkCloakingOpen)}
                     badge={!isUltraUser ? <PlanBadge plan="Ultra" /> : undefined}
+                    highlighted={!!form.watch("cloaking")}
                   >
                     <FormField
                       control={form.control}
@@ -648,6 +651,45 @@ export function EditLinkDrawer({ link, open, onClose }: EditLinkDrawerProps) {
                     {iframeableResult === false && (
                       <p className="text-[12px] text-amber-600 dark:text-amber-400">
                         This website doesn&apos;t allow cloaking. Try a different URL.
+                      </p>
+                    )}
+                  </SectionToggle>
+
+                  {/* Verified Clicks */}
+                  <SectionToggle
+                    title="Verified Clicks"
+                    description="Tell real visitors apart from automated traffic"
+                    isOpen={isVerifiedClicksOpen}
+                    onToggle={() => setIsVerifiedClicksOpen(!isVerifiedClicksOpen)}
+                    badge={!isProOrUltraUser ? <PlanBadge plan="Pro" /> : undefined}
+                    highlighted={!!form.watch("verifiedClicksEnabled")}
+                  >
+                    <FormField
+                      control={form.control}
+                      name="verifiedClicksEnabled"
+                      render={({ field }) => (
+                        <FormItem className="flex flex-row items-center justify-between rounded-lg border border-neutral-200 dark:border-border p-4">
+                          <div className="space-y-0.5">
+                            <FormLabel className="text-[13px] font-medium text-neutral-700 dark:text-neutral-300">
+                              Enable Verified Clicks
+                            </FormLabel>
+                            <FormDescription className="text-[12px] text-neutral-400 dark:text-neutral-500">
+                              With this on, your analytics shows which clicks came from real visitors, not automated traffic — so you can tell real engagement apart from noise.
+                            </FormDescription>
+                          </div>
+                          <FormControl>
+                            <Switch
+                              checked={field.value ?? false}
+                              onCheckedChange={field.onChange}
+                              disabled={!isProOrUltraUser}
+                            />
+                          </FormControl>
+                        </FormItem>
+                      )}
+                    />
+                    {!isProOrUltraUser && (
+                      <p className="text-[12px] text-neutral-400 dark:text-neutral-500">
+                        Verified clicks are available on Pro and Ultra plans.
                       </p>
                     )}
                   </SectionToggle>

--- a/src/app/(main)/dashboard/_components/section-toggle.tsx
+++ b/src/app/(main)/dashboard/_components/section-toggle.tsx
@@ -11,6 +11,7 @@ export function SectionToggle({
   isOpen,
   onToggle,
   badge,
+  highlighted,
   children,
 }: {
   title: string;
@@ -18,10 +19,19 @@ export function SectionToggle({
   isOpen: boolean;
   onToggle: () => void;
   badge?: React.ReactNode;
+  /** Light accent border to signal "feature turned on." */
+  highlighted?: boolean;
   children: React.ReactNode;
 }) {
   return (
-    <div className="rounded-lg border border-neutral-200 dark:border-border p-4">
+    <div
+      className={cn(
+        "rounded-lg border p-4 transition-colors",
+        highlighted
+          ? "border-emerald-300 dark:border-emerald-800/70"
+          : "border-neutral-200 dark:border-border",
+      )}
+    >
       <button
         type="button"
         className="flex w-full items-center justify-between text-left"

--- a/src/app/(main)/dashboard/analytics/[alias]/_components/quick-info-card.tsx
+++ b/src/app/(main)/dashboard/analytics/[alias]/_components/quick-info-card.tsx
@@ -1,27 +1,79 @@
+import { IconArrowDownRight, IconArrowUpRight, IconMinus } from "@tabler/icons-react";
+
 import { Card } from "@/components/ui/card";
+import { cn } from "@/lib/utils";
 
 type QuickInfoCardProps = {
   title: string;
   value: string | number | undefined;
   icon?: React.ReactNode;
+  growth?: number | null;
+  hint?: string;
 };
 
-export function QuickInfoCard({ title, value, icon }: QuickInfoCardProps) {
+type GrowthDirection = "up" | "down" | "flat";
+
+const GROWTH_VARIANTS: Record<
+  GrowthDirection,
+  { icon: React.ReactNode; className: string }
+> = {
+  up: {
+    icon: <IconArrowUpRight size={12} stroke={2} />,
+    className: "text-emerald-600 dark:text-emerald-400",
+  },
+  down: {
+    icon: <IconArrowDownRight size={12} stroke={2} />,
+    className: "text-red-500 dark:text-red-400",
+  },
+  flat: {
+    icon: <IconMinus size={12} stroke={2} />,
+    className: "text-neutral-400 dark:text-neutral-500",
+  },
+};
+
+export function QuickInfoCard({ title, value, icon, growth, hint }: QuickInfoCardProps) {
+  const hasGrowth = growth !== undefined && growth !== null && Number.isFinite(growth);
+  const direction: GrowthDirection | null = hasGrowth
+    ? growth === 0
+      ? "flat"
+      : growth > 0
+        ? "up"
+        : "down"
+    : null;
+  const variant = direction ? GROWTH_VARIANTS[direction] : null;
+
   return (
-    <Card className="group relative overflow-hidden rounded-xl border-neutral-200 dark:border-border p-5 shadow-none transition-colors duration-150 hover:border-neutral-300 dark:hover:border-neutral-600">
-      <div className="flex items-start justify-between">
-        <div className="space-y-1">
-          <p className="text-[11px] font-medium uppercase tracking-wider text-neutral-400 dark:text-neutral-500">
-            {title}
-          </p>
-          <p className="text-2xl font-semibold tabular-nums tracking-tight text-neutral-900 dark:text-foreground">
-            {value ?? "—"}
-          </p>
-        </div>
+    <Card className="group rounded-xl border-neutral-200 dark:border-border p-4 shadow-none transition-colors duration-150 hover:border-neutral-300 dark:hover:border-neutral-600">
+      <div className="flex items-center justify-between gap-2">
+        <p className="truncate text-[11px] font-medium uppercase tracking-wider text-neutral-400 dark:text-neutral-500">
+          {title}
+        </p>
         {icon && (
-          <div className="flex h-9 w-9 items-center justify-center rounded-lg bg-blue-50 dark:bg-blue-500/10 text-blue-600 dark:text-blue-400">
+          <span className="flex h-5 w-5 shrink-0 items-center justify-center text-neutral-400 dark:text-neutral-500">
             {icon}
-          </div>
+          </span>
+        )}
+      </div>
+      <div className="mt-1.5 flex items-baseline gap-2">
+        <span className="truncate text-xl font-semibold tabular-nums tracking-tight text-neutral-900 dark:text-foreground">
+          {value ?? "—"}
+        </span>
+        {variant && (
+          <span
+            className={cn(
+              "inline-flex shrink-0 items-center gap-0.5 text-[11px] font-medium tabular-nums",
+              variant.className,
+            )}
+            title="vs previous period"
+          >
+            {variant.icon}
+            {direction === "flat" ? "0%" : `${Math.abs(Math.round(growth!))}%`}
+          </span>
+        )}
+        {hint && !hasGrowth && (
+          <span className="truncate text-[11px] text-neutral-400 dark:text-neutral-500">
+            {hint}
+          </span>
         )}
       </div>
     </Card>

--- a/src/app/(main)/dashboard/analytics/[alias]/_components/quick-info-card.tsx
+++ b/src/app/(main)/dashboard/analytics/[alias]/_components/quick-info-card.tsx
@@ -33,13 +33,17 @@ const GROWTH_VARIANTS: Record<
 
 export function QuickInfoCard({ title, value, icon, growth, hint }: QuickInfoCardProps) {
   const hasGrowth = growth !== undefined && growth !== null && Number.isFinite(growth);
-  const direction: GrowthDirection | null = hasGrowth
-    ? growth === 0
-      ? "flat"
-      : growth > 0
-        ? "up"
-        : "down"
-    : null;
+  // Derive direction from the same rounded value we display, so 0.4% doesn't
+  // show "↑ 0%" — the arrow and the label have to agree.
+  const roundedGrowth = hasGrowth ? Math.round(growth) : null;
+  const direction: GrowthDirection | null =
+    roundedGrowth === null
+      ? null
+      : roundedGrowth === 0
+        ? "flat"
+        : roundedGrowth > 0
+          ? "up"
+          : "down";
   const variant = direction ? GROWTH_VARIANTS[direction] : null;
 
   return (
@@ -67,7 +71,7 @@ export function QuickInfoCard({ title, value, icon, growth, hint }: QuickInfoCar
             title="vs previous period"
           >
             {variant.icon}
-            {direction === "flat" ? "0%" : `${Math.abs(Math.round(growth!))}%`}
+            {direction === "flat" ? "0%" : `${Math.abs(roundedGrowth!)}%`}
           </span>
         )}
         {hint && !hasGrowth && (

--- a/src/app/(main)/dashboard/analytics/[alias]/page.tsx
+++ b/src/app/(main)/dashboard/analytics/[alias]/page.tsx
@@ -83,7 +83,7 @@ export default async function LinkAnalyticsPage(
       <div
         className={cn(
           "mt-6 grid grid-cols-2 gap-3 md:mt-8 md:gap-4",
-          verifiedVisits > 0 ? "md:grid-cols-4" : "md:grid-cols-3",
+          verifiedVisits > 0 ? "md:grid-cols-4" : "md:grid-cols-2",
         )}
       >
         <QuickInfoCard

--- a/src/app/(main)/dashboard/analytics/[alias]/page.tsx
+++ b/src/app/(main)/dashboard/analytics/[alias]/page.tsx
@@ -1,6 +1,7 @@
-import { IconClick, IconTrendingUp, IconUsers, IconWorld } from "@tabler/icons-react";
+import { IconClick, IconShieldCheck, IconShieldHalf, IconUsers } from "@tabler/icons-react";
 
 import { aggregateVisits } from "@/lib/core/analytics";
+import { cn } from "@/lib/utils";
 import { api } from "@/trpc/server";
 
 import UpgradeText from "../../qrcodes/_components/upgrade-text";
@@ -23,6 +24,13 @@ type LinksAnalyticsPageProps = {
   searchParams: Promise<Record<string, string | string[] | undefined>>;
 };
 
+// Null when prior is 0 — a 0→N change has no meaningful ratio, so hide the pill
+// rather than show a misleading 100%/∞.
+const percentGrowth = (current: number, prior: number | undefined | null) => {
+  if (prior === undefined || prior === null || prior === 0) return null;
+  return ((current - prior) / prior) * 100;
+};
+
 export default async function LinkAnalyticsPage(
   props: LinksAnalyticsPageProps
 ) {
@@ -31,22 +39,21 @@ export default async function LinkAnalyticsPage(
   const range = (searchParams?.range ?? "7d") as RangeEnum;
   const domain = (searchParams?.domain as string) ?? "ishortn.ink";
 
-  const {
-    totalVisits,
-    uniqueVisits,
-    topCountry,
-    referers,
-    topReferrer,
-    isProPlan,
-    geoRules,
-  } = await api.link.linkVisits.query({
-    id: params.alias,
-    domain,
-    range,
-  });
+  const { totalVisits, uniqueVisits, referers, isProPlan, geoRules, previous } =
+    await api.link.linkVisits.query({
+      id: params.alias,
+      domain,
+      range,
+    });
 
   const aggregatedVisits = aggregateVisits(totalVisits, uniqueVisits);
   const countryData = aggregatedVisits.clicksPerCountry;
+  const verifiedVisits = aggregatedVisits.verifiedClicks;
+
+  const totalGrowth = percentGrowth(totalVisits.length, previous?.total);
+  const uniqueGrowth = percentGrowth(uniqueVisits.length, previous?.unique);
+  const verifiedGrowth = percentGrowth(verifiedVisits, previous?.verified);
+  const verifiedRate = totalVisits.length > 0 ? (verifiedVisits / totalVisits.length) * 100 : 0;
 
   return (
     <div>
@@ -73,27 +80,40 @@ export default async function LinkAnalyticsPage(
       </div>
 
       {/* quick info cards */}
-      <div className="mt-6 grid grid-cols-1 gap-4 md:mt-8 md:grid-cols-4">
+      <div
+        className={cn(
+          "mt-6 grid grid-cols-2 gap-3 md:mt-8 md:gap-4",
+          verifiedVisits > 0 ? "md:grid-cols-4" : "md:grid-cols-3",
+        )}
+      >
         <QuickInfoCard
           title="Total Visits"
-          value={totalVisits.length}
-          icon={<IconClick size={16} stroke={1.5} className="text-blue-600 dark:text-blue-400" />}
+          value={totalVisits.length.toLocaleString()}
+          icon={<IconClick size={14} stroke={1.5} />}
+          growth={totalGrowth}
         />
         <QuickInfoCard
           title="Unique Visits"
-          value={uniqueVisits.length}
-          icon={<IconUsers size={16} stroke={1.5} className="text-blue-600 dark:text-blue-400" />}
+          value={uniqueVisits.length.toLocaleString()}
+          icon={<IconUsers size={14} stroke={1.5} />}
+          growth={uniqueGrowth}
         />
-        <QuickInfoCard
-          title="Top Country"
-          value={topCountry}
-          icon={<IconWorld size={16} stroke={1.5} className="text-blue-600 dark:text-blue-400" />}
-        />
-        <QuickInfoCard
-          title="Top Referrer"
-          value={topReferrer}
-          icon={<IconTrendingUp size={16} stroke={1.5} className="text-blue-600 dark:text-blue-400" />}
-        />
+        {verifiedVisits > 0 && (
+          <>
+            <QuickInfoCard
+              title="Verified Visits"
+              value={verifiedVisits.toLocaleString()}
+              icon={<IconShieldCheck size={14} stroke={1.5} />}
+              growth={verifiedGrowth}
+            />
+            <QuickInfoCard
+              title="Verified Rate"
+              value={`${verifiedRate.toFixed(verifiedRate >= 10 ? 0 : 1)}%`}
+              icon={<IconShieldHalf size={14} stroke={1.5} />}
+              hint={`${verifiedVisits} of ${totalVisits.length}`}
+            />
+          </>
+        )}
       </div>
 
       <div className="mt-8 md:mt-10">

--- a/src/app/(main)/dashboard/link/new/page.tsx
+++ b/src/app/(main)/dashboard/link/new/page.tsx
@@ -88,6 +88,7 @@ export default function CreateLinkPage() {
   const [isLinkCloakingOpen, setIsLinkCloakingOpen] = useState(false);
   const [isCheckingIframeable, setIsCheckingIframeable] = useState(false);
   const [iframeableResult, setIframeableResult] = useState<boolean | null>(null);
+  const [isVerifiedClicksOpen, setIsVerifiedClicksOpen] = useState(false);
 
   const userSubscription = api.subscriptions.get.useQuery();
   const customDomainsQuery = api.customDomain.list.useQuery();
@@ -757,6 +758,7 @@ export default function CreateLinkPage() {
               isOpen={isLinkCloakingOpen}
               onToggle={() => setIsLinkCloakingOpen(!isLinkCloakingOpen)}
               badge={!isUltraUser ? <PlanBadge plan="Ultra" /> : undefined}
+              highlighted={!!form.watch("cloaking")}
             >
               <FormField
                 control={form.control}
@@ -812,6 +814,45 @@ export default function CreateLinkPage() {
               {iframeableResult === false && (
                 <p className="text-[12px] text-amber-600 dark:text-amber-400">
                   This website doesn&apos;t allow cloaking. Try a different URL.
+                </p>
+              )}
+            </SectionToggle>
+
+            {/* Verified Clicks Section */}
+            <SectionToggle
+              title="Verified Clicks"
+              description="Tell real visitors apart from automated traffic"
+              isOpen={isVerifiedClicksOpen}
+              onToggle={() => setIsVerifiedClicksOpen(!isVerifiedClicksOpen)}
+              badge={!isProUser ? <PlanBadge plan="Pro" /> : undefined}
+              highlighted={!!form.watch("verifiedClicksEnabled")}
+            >
+              <FormField
+                control={form.control}
+                name="verifiedClicksEnabled"
+                render={({ field }) => (
+                  <FormItem className="flex flex-row items-center justify-between rounded-lg border border-neutral-200 dark:border-border p-4">
+                    <div className="space-y-0.5">
+                      <FormLabel className="text-[13px] font-medium text-neutral-700 dark:text-neutral-300">
+                        Enable Verified Clicks
+                      </FormLabel>
+                      <FormDescription className="text-[12px] text-neutral-400 dark:text-neutral-500">
+                        With this on, your analytics shows which clicks came from real visitors, not automated traffic — so you can tell real engagement apart from noise.
+                      </FormDescription>
+                    </div>
+                    <FormControl>
+                      <Switch
+                        checked={field.value ?? false}
+                        onCheckedChange={field.onChange}
+                        disabled={!isProUser}
+                      />
+                    </FormControl>
+                  </FormItem>
+                )}
+              />
+              {!isProUser && (
+                <p className="text-[12px] text-neutral-400 dark:text-neutral-500">
+                  Verified clicks are available on Pro and Ultra plans.
                 </p>
               )}
             </SectionToggle>

--- a/src/app/(main)/verified-redirect/[alias]/page.tsx
+++ b/src/app/(main)/verified-redirect/[alias]/page.tsx
@@ -1,6 +1,10 @@
 import type { Metadata } from "next";
 
-import { buildBeaconScript } from "@/lib/utils/verified-click-token";
+import {
+  buildBeaconScript,
+  hashDestination,
+  verifyVerifiedClickToken,
+} from "@/lib/utils/verified-click-token";
 
 export const fetchCache = "force-no-store";
 export const dynamic = "force-dynamic";
@@ -26,6 +30,14 @@ function validateDestination(raw: string | undefined | null): string | null {
   }
 }
 
+function InvalidRedirect() {
+  return (
+    <div className="flex h-screen w-full items-center justify-center">
+      <p className="text-gray-500">Invalid redirect</p>
+    </div>
+  );
+}
+
 export default async function VerifiedRedirectPage(
   props: VerifiedRedirectPageProps,
 ) {
@@ -33,27 +45,26 @@ export default async function VerifiedRedirectPage(
   const to = validateDestination(
     typeof searchParams.to === "string" ? searchParams.to : null,
   );
-  const token =
+  const rawToken =
     typeof searchParams.t === "string" && searchParams.t.length > 0
       ? searchParams.t
       : null;
 
-  if (!to) {
-    return (
-      <div className="flex h-screen w-full items-center justify-center">
-        <p className="text-gray-500">Invalid redirect</p>
-      </div>
-    );
+  // `to` must match the destination signed into the token at issue time.
+  // Without this guard the page is an open redirect — any attacker-crafted
+  // `?to=` would be obediently followed by window.location.replace.
+  if (!to || !rawToken) return <InvalidRedirect />;
+  const decoded = verifyVerifiedClickToken(rawToken);
+  if (!decoded || decoded.destHash !== hashDestination(to)) {
+    return <InvalidRedirect />;
   }
 
-  const beaconAndRedirect = `${
-    token ? buildBeaconScript(token) : ""
-  }window.location.replace(${JSON.stringify(to)});`;
+  const inline = `${buildBeaconScript(rawToken)}window.location.replace(${JSON.stringify(to)});`;
 
   return (
     <>
       <meta httpEquiv="refresh" content={`0; url=${to}`} />
-      <script dangerouslySetInnerHTML={{ __html: beaconAndRedirect }} />
+      <script dangerouslySetInnerHTML={{ __html: inline }} />
       <noscript>
         <p style={{ fontFamily: "sans-serif", padding: "1rem" }}>
           Redirecting... <a href={to}>continue</a>

--- a/src/app/(main)/verified-redirect/[alias]/page.tsx
+++ b/src/app/(main)/verified-redirect/[alias]/page.tsx
@@ -1,0 +1,64 @@
+import type { Metadata } from "next";
+
+import { buildBeaconScript } from "@/lib/utils/verified-click-token";
+
+export const fetchCache = "force-no-store";
+export const dynamic = "force-dynamic";
+
+type VerifiedRedirectPageProps = {
+  params: Promise<{ alias: string }>;
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
+};
+
+export const metadata: Metadata = {
+  title: "Redirecting...",
+  robots: { index: false, follow: false },
+};
+
+function validateDestination(raw: string | undefined | null): string | null {
+  if (!raw) return null;
+  try {
+    const parsed = new URL(raw);
+    if (parsed.protocol !== "http:" && parsed.protocol !== "https:") return null;
+    return parsed.toString();
+  } catch {
+    return null;
+  }
+}
+
+export default async function VerifiedRedirectPage(
+  props: VerifiedRedirectPageProps,
+) {
+  const searchParams = await props.searchParams;
+  const to = validateDestination(
+    typeof searchParams.to === "string" ? searchParams.to : null,
+  );
+  const token =
+    typeof searchParams.t === "string" && searchParams.t.length > 0
+      ? searchParams.t
+      : null;
+
+  if (!to) {
+    return (
+      <div className="flex h-screen w-full items-center justify-center">
+        <p className="text-gray-500">Invalid redirect</p>
+      </div>
+    );
+  }
+
+  const beaconAndRedirect = `${
+    token ? buildBeaconScript(token) : ""
+  }window.location.replace(${JSON.stringify(to)});`;
+
+  return (
+    <>
+      <meta httpEquiv="refresh" content={`0; url=${to}`} />
+      <script dangerouslySetInnerHTML={{ __html: beaconAndRedirect }} />
+      <noscript>
+        <p style={{ fontFamily: "sans-serif", padding: "1rem" }}>
+          Redirecting... <a href={to}>continue</a>
+        </p>
+      </noscript>
+    </>
+  );
+}

--- a/src/app/(main)/verify-password/[linkId]/page.tsx
+++ b/src/app/(main)/verify-password/[linkId]/page.tsx
@@ -44,6 +44,19 @@ export default function VerifyPasswordPage({ params }: VerifyPasswordPageProps) 
     }
 
     toast.success("Password verified! Redirecting...");
+
+    // When the link has verified clicks on, route through the interstitial
+    // page so the beacon fires. Force a full navigation (not router.push)
+    // because the interstitial relies on an inline <script> that only runs
+    // reliably on a fresh page load.
+    if (result.verificationToken) {
+      const alias = encodeURIComponent(result.alias ?? "l");
+      const to = encodeURIComponent(result.url!);
+      const t = encodeURIComponent(result.verificationToken);
+      window.location.href = `/verified-redirect/${alias}?to=${to}&t=${t}`;
+      return;
+    }
+
     router.push(result.url!);
   };
 

--- a/src/app/api/link/route.ts
+++ b/src/app/api/link/route.ts
@@ -13,6 +13,7 @@ import { runBackgroundTask } from "@/lib/utils/background";
 import { recordClick, resolveLink } from "@/middlewares/record-click";
 import { db } from "@/server/db";
 import { geoRule, link as linkTable, linkVisit } from "@/server/db/schema";
+import { issueVerifiedClickToken } from "@/server/lib/verified-click";
 
 /**
  * Mark a link as disabled in the DB and purge its cache entry. Runs in the
@@ -139,8 +140,13 @@ export async function GET(request: NextRequest) {
       return Response.json({ url: `${baseUrl}/verify-password/${link.id}` });
     }
 
-    // Fetch geo rules (cache first, then DB)
-    let geoRules = await getGeoRulesFromCache(link.id);
+    // Fetch geo rules and eligibility for a verified-click token in parallel.
+    const [cachedGeoRules, tokenIssue] = await Promise.all([
+      getGeoRulesFromCache(link.id),
+      issueVerifiedClickToken(link),
+    ]);
+
+    let geoRules = cachedGeoRules;
     if (!geoRules) {
       const rulesFromDb = await db.query.geoRule.findMany({
         where: eq(geoRule.linkId, link.id),
@@ -153,6 +159,8 @@ export async function GET(request: NextRequest) {
     }
 
     const geoResult = matchGeoRules(geoRules, country !== "Unknown" ? country : null);
+    const visitId = tokenIssue?.visitId ?? null;
+    const verificationToken = tokenIssue?.verificationToken ?? null;
 
     if (geoResult.matched) {
       if (geoResult.action === "block") {
@@ -161,23 +169,37 @@ export async function GET(request: NextRequest) {
       }
 
       void runBackgroundTask(
-        recordClick(request.headers, link, ip, country, city, geoResult.ruleId),
+        recordClick({
+          headers: request.headers,
+          link,
+          ip,
+          country,
+          city,
+          matchedGeoRuleId: geoResult.ruleId,
+          visitId,
+        }),
       );
 
       const destinationUrl = appendUtmParams(geoResult.destination, link.utmParams as UtmParams);
-      return Response.json({ url: destinationUrl });
+      return Response.json({ url: destinationUrl, visitId, verificationToken });
     }
 
-    // Validate link.url before processing
     if (!link.url) {
       console.error("Link has no URL:", link.id);
       return Response.json({ error: "Link has no destination URL" }, { status: 404 });
     }
 
-    void runBackgroundTask(recordClick(request.headers, link, ip, country, city));
+    void runBackgroundTask(
+      recordClick({ headers: request.headers, link, ip, country, city, visitId }),
+    );
 
     const destinationUrl = appendUtmParams(link.url, link.utmParams as UtmParams);
-    return Response.json({ url: destinationUrl, cloaking: link.cloaking ?? false });
+    return Response.json({
+      url: destinationUrl,
+      cloaking: link.cloaking ?? false,
+      visitId,
+      verificationToken,
+    });
   } catch (error) {
     console.error("Error processing link:", error);
     return Response.json({ error: "Internal server error" }, { status: 500 });

--- a/src/app/api/link/route.ts
+++ b/src/app/api/link/route.ts
@@ -10,10 +10,14 @@ import {
 } from "@/lib/core/cache";
 import { matchGeoRules } from "@/lib/core/geo-rules/matcher";
 import { runBackgroundTask } from "@/lib/utils/background";
+import {
+  generateVisitId,
+  signVerifiedClickToken,
+} from "@/lib/utils/verified-click-token";
 import { recordClick, resolveLink } from "@/middlewares/record-click";
 import { db } from "@/server/db";
 import { geoRule, link as linkTable, linkVisit } from "@/server/db/schema";
-import { issueVerifiedClickToken } from "@/server/lib/verified-click";
+import { isOwnerOnPaidPlan } from "@/server/lib/user-plan";
 
 /**
  * Mark a link as disabled in the DB and purge its cache entry. Runs in the
@@ -140,10 +144,14 @@ export async function GET(request: NextRequest) {
       return Response.json({ url: `${baseUrl}/verify-password/${link.id}` });
     }
 
-    // Fetch geo rules and eligibility for a verified-click token in parallel.
-    const [cachedGeoRules, tokenIssue] = await Promise.all([
+    // Geo-rules fetch and paid-plan check are independent; run them in parallel.
+    // Token signing has to wait until we know the final destination so we can
+    // bind it into the HMAC and prevent `to` tampering on the interstitial.
+    const [cachedGeoRules, ownerPaid] = await Promise.all([
       getGeoRulesFromCache(link.id),
-      issueVerifiedClickToken(link),
+      link.verifiedClicksEnabled
+        ? isOwnerOnPaidPlan(link.userId, link.teamId)
+        : Promise.resolve(false),
     ]);
 
     let geoRules = cachedGeoRules;
@@ -159,14 +167,26 @@ export async function GET(request: NextRequest) {
     }
 
     const geoResult = matchGeoRules(geoRules, country !== "Unknown" ? country : null);
-    const visitId = tokenIssue?.visitId ?? null;
-    const verificationToken = tokenIssue?.verificationToken ?? null;
+
+    const issueToken = (
+      destination: string,
+    ): { visitId: string | null; verificationToken: string | null } => {
+      if (!ownerPaid) return { visitId: null, verificationToken: null };
+      const candidate = generateVisitId();
+      const token = signVerifiedClickToken(candidate, destination);
+      return token
+        ? { visitId: candidate, verificationToken: token }
+        : { visitId: null, verificationToken: null };
+    };
 
     if (geoResult.matched) {
       if (geoResult.action === "block") {
         const geoParam = geoResult.ruleId ? `?geo=${geoResult.ruleId}` : "";
         return Response.json({ url: `${baseUrl}/blocked/${link.id}${geoParam}` });
       }
+
+      const destinationUrl = appendUtmParams(geoResult.destination, link.utmParams as UtmParams);
+      const { visitId, verificationToken } = issueToken(destinationUrl);
 
       void runBackgroundTask(
         recordClick({
@@ -180,7 +200,6 @@ export async function GET(request: NextRequest) {
         }),
       );
 
-      const destinationUrl = appendUtmParams(geoResult.destination, link.utmParams as UtmParams);
       return Response.json({ url: destinationUrl, visitId, verificationToken });
     }
 
@@ -189,11 +208,13 @@ export async function GET(request: NextRequest) {
       return Response.json({ error: "Link has no destination URL" }, { status: 404 });
     }
 
+    const destinationUrl = appendUtmParams(link.url, link.utmParams as UtmParams);
+    const { visitId, verificationToken } = issueToken(destinationUrl);
+
     void runBackgroundTask(
       recordClick({ headers: request.headers, link, ip, country, city, visitId }),
     );
 
-    const destinationUrl = appendUtmParams(link.url, link.utmParams as UtmParams);
     return Response.json({
       url: destinationUrl,
       cloaking: link.cloaking ?? false,

--- a/src/app/api/v1/clicks/verify/route.ts
+++ b/src/app/api/v1/clicks/verify/route.ts
@@ -1,0 +1,50 @@
+import { and, eq, isNull, sql } from "drizzle-orm";
+import type { NextRequest } from "next/server";
+
+import { verifyVerifiedClickToken } from "@/lib/utils/verified-click-token";
+import { db } from "@/server/db";
+import { linkVisit } from "@/server/db/schema";
+
+// Retry covers the race where the beacon lands before `recordClick` (running
+// in waitUntil) has inserted the row. Missed verifications are acceptable
+// noise; missed rows past the retry budget are dropped.
+const MAX_RETRIES = 2;
+const RETRY_DELAY_MS = 300;
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function markVerified(visitId: string): Promise<boolean> {
+  for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
+    const [result] = await db
+      .update(linkVisit)
+      .set({ verifiedAt: sql`CURRENT_TIMESTAMP` })
+      .where(and(eq(linkVisit.visitId, visitId), isNull(linkVisit.verifiedAt)));
+
+    if ((result?.affectedRows ?? 0) > 0) return true;
+    if (attempt < MAX_RETRIES) await sleep(RETRY_DELAY_MS);
+  }
+  return false;
+}
+
+export async function POST(request: NextRequest): Promise<Response> {
+  let token: string | null = null;
+  try {
+    const body = (await request.json()) as { token?: unknown };
+    if (typeof body.token === "string") token = body.token;
+  } catch {
+    // fall through — token stays null
+  }
+
+  if (!token) return new Response(null, { status: 400 });
+
+  const decoded = verifyVerifiedClickToken(token);
+  if (!decoded) return new Response(null, { status: 400 });
+
+  // 202 rather than a non-2xx when the row hasn't landed after retries — keeps
+  // browsers from retrying and the request was semantically valid.
+  return new Response(null, {
+    status: (await markVerified(decoded.visitId)) ? 204 : 202,
+  });
+}

--- a/src/env.mjs
+++ b/src/env.mjs
@@ -36,6 +36,10 @@ export const env = createEnv({
     // Optional for backwards compatibility — when unset, we fall back to plain
     // SHA-256, which preserves old behavior but is trivially reversible.
     IP_HASH_SECRET: z.string().min(16).optional(),
+    // Secret key used to HMAC-sign verified-click tokens issued to destination-page
+    // beacons. Optional: when unset, tokens are not issued and no verification
+    // events are accepted — the feature is effectively disabled.
+    VERIFIED_CLICKS_SECRET: z.string().min(32).optional(),
   },
 
   /**
@@ -72,6 +76,7 @@ export const env = createEnv({
     R2_BUCKET_NAME: process.env.R2_BUCKET_NAME,
     R2_PUBLIC_URL: process.env.R2_PUBLIC_URL,
     IP_HASH_SECRET: process.env.IP_HASH_SECRET,
+    VERIFIED_CLICKS_SECRET: process.env.VERIFIED_CLICKS_SECRET,
     // Client-side env vars
     NEXT_PUBLIC_APP_URL: process.env.NEXT_PUBLIC_APP_URL,
   },

--- a/src/lib/core/analytics/index.ts
+++ b/src/lib/core/analytics/index.ts
@@ -88,6 +88,7 @@ export const aggregateVisits = (
 ) => {
   const clicksPerDate: Record<string, number> = {};
   const uniqueClicksPerDate: Record<string, number> = {};
+  const verifiedClicksPerDate: Record<string, number> = {};
   const clicksPerCountry: Record<string, number> = {};
   const clicksPerCity: Record<string, number> = {};
   const clicksPerContinent: Record<string, number> = {};
@@ -95,11 +96,19 @@ export const aggregateVisits = (
   const clicksPerOS: Record<string, number> = {};
   const clicksPerBrowser: Record<string, number> = {};
   const clicksPerModel: Record<string, number> = {};
+  let totalClicks = 0;
+  let verifiedClicks = 0;
 
   // biome-ignore lint/complexity/noForEach: <explanation>
   visits.forEach((visit) => {
     const date = new Date(visit.createdAt!).toISOString().split("T")[0];
     safeIncrement(clicksPerDate, date!);
+    totalClicks += 1;
+
+    if (visit.verifiedAt) {
+      verifiedClicks += 1;
+      safeIncrement(verifiedClicksPerDate, date!);
+    }
 
     if (visit.country) safeIncrement(clicksPerCountry, visit.country);
     if (visit.city) safeIncrement(clicksPerCity, visit.city);
@@ -112,7 +121,10 @@ export const aggregateVisits = (
 
   if (!uniqueVisits)
     return {
+      totalClicks,
+      verifiedClicks,
       clicksPerDate,
+      verifiedClicksPerDate,
       clicksPerCountry,
       clicksPerCity,
       clicksPerContinent,
@@ -129,8 +141,11 @@ export const aggregateVisits = (
   });
 
   return {
+    totalClicks,
+    verifiedClicks,
     clicksPerDate,
     uniqueClicksPerDate,
+    verifiedClicksPerDate,
     clicksPerCountry,
     clicksPerCity,
     clicksPerContinent,

--- a/src/lib/core/cache/index.ts
+++ b/src/lib/core/cache/index.ts
@@ -51,6 +51,10 @@ const linkSchema = z.object({
     .string()
     .transform((val) => val === "true")
     .default(false),
+  verifiedClicksEnabled: z
+    .string()
+    .transform((val) => val === "true")
+    .default(false),
   isQrCode: z
     .string()
     .transform((val) => val === "true")
@@ -91,6 +95,7 @@ function convertToLink(data: Record<string, string>): Link {
     utmParams: parsed.utmParams ?? null,
     createdByUserId: parsed.createdByUserId ?? null,
     cloaking: parsed.cloaking ?? false,
+    verifiedClicksEnabled: parsed.verifiedClicksEnabled ?? false,
     isQrCode: parsed.isQrCode ?? false,
     blocked: parsed.blocked ?? false,
     blockedAt: parsed.blockedAt ?? null,

--- a/src/lib/utils/verified-click-token.ts
+++ b/src/lib/utils/verified-click-token.ts
@@ -1,12 +1,14 @@
-import { createHmac, randomUUID, timingSafeEqual } from "node:crypto";
+import { createHash, createHmac, randomUUID, timingSafeEqual } from "node:crypto";
 
 import { env } from "@/env.mjs";
 
 // Payload is plaintext; the only secret is the HMAC signature. Replay is
 // bounded by the 5-minute TTL plus the verify endpoint's `verifiedAt IS NULL`
-// guard, so any valid token can mark a visit verified at most once.
+// guard, so any valid token can mark a visit verified at most once. The
+// destination hash is signed into the token so the interstitial page can
+// reject requests whose `to` query param doesn't match the original issue.
 
-const TOKEN_VERSION = "v1";
+const TOKEN_VERSION = "v2";
 const TOKEN_TTL_MS = 5 * 60 * 1000;
 const CLOCK_SKEW_TOLERANCE_MS = 5_000;
 
@@ -27,40 +29,73 @@ function getSecret(): string | null {
   return env.VERIFIED_CLICKS_SECRET ?? null;
 }
 
+/** Short, URL-safe fingerprint that binds a token to its intended destination. */
+export function hashDestination(destination: string): string {
+  return base64urlEncode(
+    createHash("sha256").update(destination).digest().subarray(0, 16),
+  );
+}
+
 export function generateVisitId(): string {
   return randomUUID();
 }
 
 /** Returns null when the secret is unset; caller treats that as feature-disabled. */
-export function signVerifiedClickToken(visitId: string): string | null {
+export function signVerifiedClickToken(
+  visitId: string,
+  destination: string,
+): string | null {
   const secret = getSecret();
   if (!secret) return null;
 
   const issuedAt = Date.now();
-  const payload = `${TOKEN_VERSION}.${visitId}.${issuedAt}`;
+  const destHash = hashDestination(destination);
+  const payload = `${TOKEN_VERSION}.${visitId}.${destHash}.${issuedAt}`;
   const sig = base64urlEncode(
     createHmac("sha256", secret).update(payload).digest(),
   );
   return `${payload}.${sig}`;
 }
 
+const INLINE_SCRIPT_ESCAPES: Record<string, string> = {
+  "<": "\\u003C",
+  ">": "\\u003E",
+  "&": "\\u0026",
+  "\u2028": "\\u2028",
+  "\u2029": "\\u2029",
+};
+
+/** JSON-encode a value for safe embedding inside an inline `<script>` tag. */
+function encodeForInlineScript(value: string): string {
+  return JSON.stringify(value).replace(
+    /[<>&\u2028\u2029]/g,
+    (char) => INLINE_SCRIPT_ESCAPES[char] ?? char,
+  );
+}
+
 /** Inline JS for the beacon. Callers render it in a `<script>` tag. */
 export function buildBeaconScript(token: string): string {
-  const safeToken = JSON.stringify(token);
+  const safeToken = encodeForInlineScript(token);
   return `(function(){try{fetch('/api/v1/clicks/verify',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({token:${safeToken}}),keepalive:true}).catch(function(){});}catch(e){}})();`;
 }
 
 export function verifyVerifiedClickToken(
   token: string,
-): { visitId: string } | null {
+): { visitId: string; destHash: string } | null {
   const secret = getSecret();
   if (!secret) return null;
 
   const parts = token.split(".");
-  if (parts.length !== 4) return null;
+  if (parts.length !== 5) return null;
 
-  const [version, visitId, issuedAtStr, providedSig] = parts;
-  if (version !== TOKEN_VERSION || !visitId || !issuedAtStr || !providedSig) {
+  const [version, visitId, destHash, issuedAtStr, providedSig] = parts;
+  if (
+    version !== TOKEN_VERSION ||
+    !visitId ||
+    !destHash ||
+    !issuedAtStr ||
+    !providedSig
+  ) {
     return null;
   }
 
@@ -71,11 +106,11 @@ export function verifyVerifiedClickToken(
   if (now - issuedAt > TOKEN_TTL_MS) return null;
   if (issuedAt - now > CLOCK_SKEW_TOLERANCE_MS) return null;
 
-  const payload = `${version}.${visitId}.${issuedAtStr}`;
+  const payload = `${version}.${visitId}.${destHash}.${issuedAtStr}`;
   const expected = createHmac("sha256", secret).update(payload).digest();
   const provided = base64urlDecode(providedSig);
   if (provided.length !== expected.length) return null;
   if (!timingSafeEqual(provided, expected)) return null;
 
-  return { visitId };
+  return { visitId, destHash };
 }

--- a/src/lib/utils/verified-click-token.ts
+++ b/src/lib/utils/verified-click-token.ts
@@ -1,0 +1,81 @@
+import { createHmac, randomUUID, timingSafeEqual } from "node:crypto";
+
+import { env } from "@/env.mjs";
+
+// Payload is plaintext; the only secret is the HMAC signature. Replay is
+// bounded by the 5-minute TTL plus the verify endpoint's `verifiedAt IS NULL`
+// guard, so any valid token can mark a visit verified at most once.
+
+const TOKEN_VERSION = "v1";
+const TOKEN_TTL_MS = 5 * 60 * 1000;
+const CLOCK_SKEW_TOLERANCE_MS = 5_000;
+
+function base64urlEncode(buf: Buffer): string {
+  return buf
+    .toString("base64")
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/, "");
+}
+
+function base64urlDecode(str: string): Buffer {
+  const pad = str.length % 4 === 0 ? "" : "=".repeat(4 - (str.length % 4));
+  return Buffer.from(str.replace(/-/g, "+").replace(/_/g, "/") + pad, "base64");
+}
+
+function getSecret(): string | null {
+  return env.VERIFIED_CLICKS_SECRET ?? null;
+}
+
+export function generateVisitId(): string {
+  return randomUUID();
+}
+
+/** Returns null when the secret is unset; caller treats that as feature-disabled. */
+export function signVerifiedClickToken(visitId: string): string | null {
+  const secret = getSecret();
+  if (!secret) return null;
+
+  const issuedAt = Date.now();
+  const payload = `${TOKEN_VERSION}.${visitId}.${issuedAt}`;
+  const sig = base64urlEncode(
+    createHmac("sha256", secret).update(payload).digest(),
+  );
+  return `${payload}.${sig}`;
+}
+
+/** Inline JS for the beacon. Callers render it in a `<script>` tag. */
+export function buildBeaconScript(token: string): string {
+  const safeToken = JSON.stringify(token);
+  return `(function(){try{fetch('/api/v1/clicks/verify',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({token:${safeToken}}),keepalive:true}).catch(function(){});}catch(e){}})();`;
+}
+
+export function verifyVerifiedClickToken(
+  token: string,
+): { visitId: string } | null {
+  const secret = getSecret();
+  if (!secret) return null;
+
+  const parts = token.split(".");
+  if (parts.length !== 4) return null;
+
+  const [version, visitId, issuedAtStr, providedSig] = parts;
+  if (version !== TOKEN_VERSION || !visitId || !issuedAtStr || !providedSig) {
+    return null;
+  }
+
+  const issuedAt = Number(issuedAtStr);
+  if (!Number.isFinite(issuedAt)) return null;
+
+  const now = Date.now();
+  if (now - issuedAt > TOKEN_TTL_MS) return null;
+  if (issuedAt - now > CLOCK_SKEW_TOLERANCE_MS) return null;
+
+  const payload = `${version}.${visitId}.${issuedAtStr}`;
+  const expected = createHmac("sha256", secret).update(payload).digest();
+  const provided = base64urlDecode(providedSig);
+  if (provided.length !== expected.length) return null;
+  if (!timingSafeEqual(provided, expected)) return null;
+
+  return { visitId };
+}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -21,6 +21,7 @@ async function resolveLinkAndLogAnalytics(request: NextRequest) {
     pathname.startsWith("/dashboard") ||
     pathname.startsWith("/_next/") ||
     pathname.startsWith("/cloaked/") ||
+    pathname.startsWith("/verified-redirect/") ||
     pathname.startsWith("/opengraph-image") ||
     pathname.endsWith(".png") ||
     pathname.endsWith(".ico") ||
@@ -124,9 +125,30 @@ async function resolveLinkAndLogAnalytics(request: NextRequest) {
   const acceptCh =
     "Sec-CH-UA-Platform-Version, Sec-CH-UA-Model, Sec-CH-UA-Arch, Sec-CH-UA-Bitness, Sec-CH-UA-Full-Version-List";
 
+  const verificationToken =
+    typeof data.verificationToken === "string" ? data.verificationToken : null;
+
   if (data.cloaking) {
     const encodedUrl = encodeURIComponent(redirectUrl);
-    const rewriteResponse = NextResponse.rewrite(new URL(`/cloaked/${encodedUrl}`, request.url));
+    const tokenQuery = verificationToken
+      ? `?t=${encodeURIComponent(verificationToken)}`
+      : "";
+    const rewriteResponse = NextResponse.rewrite(
+      new URL(`/cloaked/${encodedUrl}${tokenQuery}`, request.url),
+    );
+    rewriteResponse.headers.set("Accept-CH", acceptCh);
+    return rewriteResponse;
+  }
+
+  if (verificationToken) {
+    const alias = pathname.replace(/^\//, "") || "link";
+    const rewriteUrl = new URL(
+      `/verified-redirect/${encodeURIComponent(alias)}`,
+      request.url,
+    );
+    rewriteUrl.searchParams.set("to", redirectUrl);
+    rewriteUrl.searchParams.set("t", verificationToken);
+    const rewriteResponse = NextResponse.rewrite(rewriteUrl);
     rewriteResponse.headers.set("Accept-CH", acceptCh);
     return rewriteResponse;
   }

--- a/src/middlewares/record-click.ts
+++ b/src/middlewares/record-click.ts
@@ -72,20 +72,24 @@ function resolveGeo(country: string, city: string) {
   }
 }
 
+type RecordClickOptions = {
+  headers: Headers;
+  link: Link;
+  ip: string;
+  country: string;
+  city: string;
+  matchedGeoRuleId?: number;
+  visitId?: string | null;
+};
+
 /**
  * Records a click for an already-resolved link. Callers are responsible for
  * deciding whether to record (e.g. skip for password-protected redirects that
  * haven't been unlocked yet) — this function records unconditionally aside from
  * bot filtering and quota enforcement.
  */
-export async function recordClick(
-  headers: Headers,
-  link: Link,
-  ip: string,
-  country: string,
-  city: string,
-  matchedGeoRuleId?: number,
-): Promise<void> {
+export async function recordClick(opts: RecordClickOptions): Promise<void> {
+  const { headers, link, ip, country, city, matchedGeoRuleId, visitId } = opts;
   const userAgent = headers.get("user-agent") ?? "";
   if (userAgent && isBot(userAgent)) return;
 
@@ -130,6 +134,7 @@ export async function recordClick(
       city: cityName,
       continent: continentName,
       matchedGeoRuleId: matchedGeoRuleId ?? null,
+      visitId: visitId ?? null,
     }),
     recordUniqueClick(ipHash, link.id),
   ]);

--- a/src/server/api/routers/link/link.input.ts
+++ b/src/server/api/routers/link/link.input.ts
@@ -117,6 +117,7 @@ export const createLinkSchema = z.object({
     })
     .optional(),
   cloaking: z.boolean().optional(),
+  verifiedClicksEnabled: z.boolean().optional(),
   geoRules: z.array(geoRuleInputSchema).optional(),
 });
 
@@ -132,6 +133,7 @@ export const updateLinkSchema = createLinkSchema.partial().extend({
   publicStats: z.boolean().optional(),
   note: z.string().optional(),
   cloaking: z.boolean().optional(),
+  verifiedClicksEnabled: z.boolean().optional(),
 });
 
 export const verifyLinkPasswordSchema = z.object({

--- a/src/server/api/routers/link/link.service.ts
+++ b/src/server/api/routers/link/link.service.ts
@@ -1078,9 +1078,10 @@ export const getLinkVisits = async (
   }
 
   // Previous-period window for % delta: same duration immediately before
-  // the current window. Skip for "all" since there is no comparable prior.
-  const hasPreviousPeriod = range !== "all";
+  // the current window. Skip for "all" and for inverted windows that can
+  // arise from calendar ranges landing on a non-positive duration.
   const windowMs = now.getTime() - startDate.getTime();
+  const hasPreviousPeriod = range !== "all" && windowMs > 0;
   const prevEnd = startDate;
   const prevStart = new Date(startDate.getTime() - windowMs);
 
@@ -1506,7 +1507,9 @@ export const verifyLinkPassword = async (
   const clientIp = (ctx.headers.get("x-forwarded-for") ?? "").split(",")[0]?.trim() ?? "";
   const ipHash = hashIp(clientIp);
 
-  const tokenIssue = await issueVerifiedClickToken(link);
+  const tokenIssue = link.url
+    ? await issueVerifiedClickToken(link, link.url)
+    : null;
 
   await ctx.db.insert(linkVisit).values({
     linkId: link.id,

--- a/src/server/api/routers/link/link.service.ts
+++ b/src/server/api/routers/link/link.service.ts
@@ -8,9 +8,11 @@ import {
   desc,
   eq,
   getTableColumns,
+  gte,
   inArray,
   isNull,
   like,
+  lt,
   or,
   sql,
 } from "drizzle-orm";
@@ -22,6 +24,10 @@ import {
 import { assertUrlSafe } from "@/server/lib/phishing";
 import { retrieveDeviceAndGeolocationData } from "@/lib/core/analytics";
 import { hashIp } from "@/lib/utils/ip-hash";
+import {
+  assertCanEnableVerifiedClicks,
+  issueVerifiedClickToken,
+} from "@/server/lib/verified-click";
 import {
   buildCacheKey,
   deleteFromCache,
@@ -386,6 +392,8 @@ export const createLink = async (
     }
   }
 
+  if (input.verifiedClicksEnabled) assertCanEnableVerifiedClicks(plan);
+
   input.metadata = {
     title: inputMetaData?.title ?? fetchedMetadata.title,
     description: inputMetaData?.description ?? fetchedMetadata.description,
@@ -412,6 +420,7 @@ export const createLink = async (
       ...input.metadata,
     },
     cloaking: input.cloaking ?? false,
+    verifiedClicksEnabled: input.verifiedClicksEnabled ?? false,
   });
 
   // Associate tags with the link
@@ -542,6 +551,10 @@ export const updateLink = async (
       );
     }
   }
+
+  // Downgrades are caught again at token-issuance time in /api/link, so a
+  // stale `verifiedClicksEnabled=true` doesn't produce tokens for free users.
+  if (input.verifiedClicksEnabled) assertCanEnableVerifiedClicks(workspacePlan);
 
   // Extract tags and geoRules from input
   const { tags: tagNames, geoRules: geoRulesInput, ...linkData } = input;
@@ -1017,6 +1030,7 @@ export const getLinkVisits = async (
       topReferrer: "N/A",
       isProPlan: userHasPaidPlan,
       geoRules: [],
+      previous: null,
     };
   }
 
@@ -1063,7 +1077,14 @@ export const getLinkVisits = async (
       startDate = subDays(now, 7); // Default to last 7 days
   }
 
-  const [totalVisits, uniqueVisits, linkGeoRules] = await Promise.all([
+  // Previous-period window for % delta: same duration immediately before
+  // the current window. Skip for "all" since there is no comparable prior.
+  const hasPreviousPeriod = range !== "all";
+  const windowMs = now.getTime() - startDate.getTime();
+  const prevEnd = startDate;
+  const prevStart = new Date(startDate.getTime() - windowMs);
+
+  const [totalVisits, uniqueVisits, linkGeoRules, prevCounts] = await Promise.all([
     ctx.db.query.linkVisit.findMany({
       where: (visit, { eq, and, gte, lte }) =>
         and(
@@ -1087,7 +1108,42 @@ export const getLinkVisits = async (
         action: true,
       },
     }),
+    hasPreviousPeriod
+      ? Promise.all([
+          ctx.db
+            .select({
+              total: count(),
+              verified: sql<number>`SUM(CASE WHEN ${linkVisit.verifiedAt} IS NOT NULL THEN 1 ELSE 0 END)`,
+            })
+            .from(linkVisit)
+            .where(
+              and(
+                eq(linkVisit.linkId, foundLink.id),
+                gte(linkVisit.createdAt, prevStart),
+                lt(linkVisit.createdAt, prevEnd),
+              ),
+            ),
+          ctx.db
+            .select({ value: count() })
+            .from(uniqueLinkVisit)
+            .where(
+              and(
+                eq(uniqueLinkVisit.linkId, foundLink.id),
+                gte(uniqueLinkVisit.createdAt, prevStart),
+                lt(uniqueLinkVisit.createdAt, prevEnd),
+              ),
+            ),
+        ])
+      : Promise.resolve(null),
   ]);
+
+  const previous = prevCounts
+    ? {
+        total: prevCounts[0][0]?.total ?? 0,
+        unique: prevCounts[1][0]?.value ?? 0,
+        verified: Number(prevCounts[0][0]?.verified ?? 0),
+      }
+    : null;
 
   if (totalVisits.length === 0) {
     return {
@@ -1098,6 +1154,7 @@ export const getLinkVisits = async (
       topReferrer: "N/A",
       isProPlan: userHasPaidPlan,
       geoRules: linkGeoRules,
+      previous,
     };
   }
 
@@ -1139,6 +1196,7 @@ export const getLinkVisits = async (
     topReferrer: topReferrer !== "null" ? topReferrer : "Direct",
     isProPlan: userHasPaidPlan,
     geoRules: linkGeoRules,
+    previous,
   };
 };
 
@@ -1448,9 +1506,12 @@ export const verifyLinkPassword = async (
   const clientIp = (ctx.headers.get("x-forwarded-for") ?? "").split(",")[0]?.trim() ?? "";
   const ipHash = hashIp(clientIp);
 
+  const tokenIssue = await issueVerifiedClickToken(link);
+
   await ctx.db.insert(linkVisit).values({
     linkId: link.id,
     ...deviceDetails,
+    visitId: tokenIssue?.visitId ?? null,
   });
 
   await ctx.db
@@ -1461,7 +1522,11 @@ export const verifyLinkPassword = async (
   // Fire milestone check for password-protected links (recordClick skips these)
   void runBackgroundTask(checkAndFireMilestones(link.id, link.userId));
 
-  return link;
+  return {
+    url: link.url,
+    alias: link.alias,
+    verificationToken: tokenIssue?.verificationToken ?? null,
+  };
 };
 
 export const changeLinkPassword = async (

--- a/src/server/db/schema.ts
+++ b/src/server/db/schema.ts
@@ -235,6 +235,7 @@ export const link = mysqlTable(
     archived: boolean("archived").default(false),
     folderId: int("folderId"),
     cloaking: boolean("cloaking").default(false),
+    verifiedClicksEnabled: boolean("verifiedClicksEnabled").default(false),
     isQrCode: boolean("isQrCode").default(false),
     // Admin moderation
     blocked: boolean("blocked").default(false),
@@ -289,6 +290,8 @@ export const linkVisit = mysqlTable(
     city: varchar("city", { length: 255 }),
     continent: varchar("continent", { length: 255 }).default("N/A"),
     matchedGeoRuleId: int("matchedGeoRuleId"), // Reference to the geo rule that matched (for analytics)
+    visitId: char("visitId", { length: 36 }), // uuid used by verified-click beacon to identify this row; null when verified clicks is disabled for the link
+    verifiedAt: timestamp("verifiedAt"), // set when the destination-page beacon POSTs back with a valid token
     createdAt: timestamp("createdAt").defaultNow(),
   },
   (table) => ({
@@ -296,6 +299,7 @@ export const linkVisit = mysqlTable(
     geoRuleIdIdx: index("geoRuleId_idx").on(table.matchedGeoRuleId),
     linkCreatedAtIdx: index("linkId_createdAt_idx").on(table.linkId, table.createdAt),
     createdAtIdx: index("createdAt_idx").on(table.createdAt),
+    visitIdIdx: unique("visitId_idx").on(table.visitId),
   }),
 );
 

--- a/src/server/lib/user-plan.ts
+++ b/src/server/lib/user-plan.ts
@@ -2,12 +2,31 @@ import { eq } from "drizzle-orm";
 
 import { getPlanCaps, Plan, resolvePlan } from "@/lib/billing/plans";
 import { db } from "@/server/db";
-import { user } from "@/server/db/schema";
+import { subscription, user } from "@/server/db/schema";
 
 import type { PLAN_CAPS } from "@/lib/billing/plans";
 import type { Subscription, User } from "@/server/db/schema";
 
 type DbClient = typeof db;
+
+/**
+ * Hot-path paid-plan check used by the redirect pipeline. Avoids the full
+ * UserPlanContext query — we only need a boolean. Team-owned links
+ * short-circuit without a DB hit since teams are always on Ultra.
+ */
+export async function isOwnerOnPaidPlan(
+  userId: string,
+  teamId: number | null,
+  dbClient: DbClient = db,
+): Promise<boolean> {
+  if (teamId !== null) return true;
+
+  const sub = await dbClient.query.subscription.findFirst({
+    where: eq(subscription.userId, userId),
+  });
+
+  return resolvePlan(sub ?? null) !== "free";
+}
 
 export type UserPlanContext = {
   userRecord: User;

--- a/src/server/lib/verified-click.ts
+++ b/src/server/lib/verified-click.ts
@@ -17,18 +17,22 @@ export function assertCanEnableVerifiedClicks(plan: Plan): void {
 /**
  * Returns null when the feature is off, the owner isn't paid, or the signing
  * secret isn't configured. Callers treat null as "record an ordinary click,
- * skip the beacon."
+ * skip the beacon." The token is bound to `destination` so the interstitial
+ * page can reject swapped-URL requests.
  */
-export async function issueVerifiedClickToken(link: {
-  userId: string;
-  teamId: number | null;
-  verifiedClicksEnabled: boolean | null;
-}): Promise<{ visitId: string; verificationToken: string } | null> {
+export async function issueVerifiedClickToken(
+  link: {
+    userId: string;
+    teamId: number | null;
+    verifiedClicksEnabled: boolean | null;
+  },
+  destination: string,
+): Promise<{ visitId: string; verificationToken: string } | null> {
   if (!link.verifiedClicksEnabled) return null;
   if (!(await isOwnerOnPaidPlan(link.userId, link.teamId))) return null;
 
   const visitId = generateVisitId();
-  const verificationToken = signVerifiedClickToken(visitId);
+  const verificationToken = signVerifiedClickToken(visitId, destination);
   if (!verificationToken) return null;
 
   return { visitId, verificationToken };

--- a/src/server/lib/verified-click.ts
+++ b/src/server/lib/verified-click.ts
@@ -1,0 +1,35 @@
+import type { Plan } from "@/lib/billing/plans";
+import {
+  generateVisitId,
+  signVerifiedClickToken,
+} from "@/lib/utils/verified-click-token";
+
+import { isOwnerOnPaidPlan } from "./user-plan";
+
+export function assertCanEnableVerifiedClicks(plan: Plan): void {
+  if (plan === "free") {
+    throw new Error(
+      "Verified clicks are only available on Pro and Ultra plans. Please upgrade to use this feature.",
+    );
+  }
+}
+
+/**
+ * Returns null when the feature is off, the owner isn't paid, or the signing
+ * secret isn't configured. Callers treat null as "record an ordinary click,
+ * skip the beacon."
+ */
+export async function issueVerifiedClickToken(link: {
+  userId: string;
+  teamId: number | null;
+  verifiedClicksEnabled: boolean | null;
+}): Promise<{ visitId: string; verificationToken: string } | null> {
+  if (!link.verifiedClicksEnabled) return null;
+  if (!(await isOwnerOnPaidPlan(link.userId, link.teamId))) return null;
+
+  const visitId = generateVisitId();
+  const verificationToken = signVerifiedClickToken(visitId);
+  if (!verificationToken) return null;
+
+  return { visitId, verificationToken };
+}


### PR DESCRIPTION
## Summary

Adds a "verified clicks" layer that separates genuine visitor clicks from automated traffic (link scanners, URL previewers, security tools). Analytics surfaces a verified count and ratio alongside total clicks so customers can see how much of their click volume is actual human engagement.

## Changes

- **Beacon pipeline**: same-origin POST fired from `/cloaked/[url]` or a new `/verified-redirect/[alias]` interstitial, authenticated via an HMAC-signed token with a 5-minute TTL
- **New endpoint**: `POST /api/v1/clicks/verify` marks the matching `LinkVisit` row verified, with retry-and-drop for the race against the background click insert
- **Schema**: `link.verifiedClicksEnabled` (opt-in toggle), `linkVisit.visitId` (uuid, unique), `linkVisit.verifiedAt`
- **Settings UI**: Pro/Ultra-gated toggle on both the new-link form and the edit drawer; the expandable section picks up a light green accent when active
- **Analytics**: new "Verified Visits" + "Verified Rate" cards, hidden until the link has any verified traffic
- **Password-protected links**: `verifyLinkPassword` now issues the same token and routes through the interstitial after unlock
- **Public API**: `/api/v1/analytics/[alias]` response gains `verifiedClicks` and `verifiedClicksPerDate` (additive, non-breaking)
- **Release note**: `content/changelogs/2026-04-17-verified-clicks.md`
- Drive-by cleanup: removed a nested card-in-a-card on the changelog timeline (separate commit)

## Deployment

1. Apply migration `drizzle/0058_violet_timeslip.sql`
2. Set `VERIFIED_CLICKS_SECRET` (32+ chars) in prod and staging — feature is a silent no-op until configured

## Testing

- Typecheck passes
- **Manual browser verification still pending**: load a cloaked+verified link and a plain verified link, confirm the beacon POST hits `/api/v1/clicks/verify` with 204 and `verifiedAt` populates in the DB. This is the one thing CI can't cover.

## Known limits

- A headless browser that executes JS (e.g. Puppeteer) will fire the beacon and count as verified — "verified" means "a browser environment loaded the page," not strictly "human"
- `isOwnerOnPaidPlan` hits the DB on every verified-enabled redirect; fine for current adoption, worth a Redis cache if the feature goes wide

## Type of Change

- [x] feat: New feature

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced Verified Clicks to distinguish real visitor engagement from automated traffic
  * Added "Verified Visits" and "Verified Rate" cards in analytics alongside Total/Unique Visits
  * Per-link toggle when creating or editing links; tracking begins when enabled while preserving prior click history
  * Supported for regular, cloaked, and password-protected links
  * Feature available on Pro and Ultra plans with enablement from link creation or the dashboard
<!-- end of auto-generated comment: release notes by coderabbit.ai -->