### PR TITLE
fix(verified-clicks): canonicalize destination URL for hash comparison

### DIFF
--- a/src/lib/utils/verified-click-token.ts
+++ b/src/lib/utils/verified-click-token.ts
@@ -29,10 +29,24 @@ function getSecret(): string | null {
   return env.VERIFIED_CLICKS_SECRET ?? null;
 }
 
+/** Canonicalize so sign-side and verify-side produce identical bytes regardless
+ * of trailing slashes, hostname case, default ports, etc. If the URL fails to
+ * parse, fall back to the raw string so both sides still agree. */
+function canonicalizeDestination(raw: string): string {
+  try {
+    return new URL(raw).toString();
+  } catch {
+    return raw;
+  }
+}
+
 /** Short, URL-safe fingerprint that binds a token to its intended destination. */
 export function hashDestination(destination: string): string {
   return base64urlEncode(
-    createHash("sha256").update(destination).digest().subarray(0, 16),
+    createHash("sha256")
+      .update(canonicalizeDestination(destination))
+      .digest()
+      .subarray(0, 16),
   );
 }
 


### PR DESCRIPTION
## Summary

Hotfix for #293. The destination-binding added in that PR is rejecting every legitimate verified redirect because sign-side and verify-side hash different strings.

## Root cause

- Route signs the token with the URL as returned by \`appendUtmParams\`. When a link has no UTM params, that function returns the raw \`link.url\` **without normalizing**.
- Middleware passes the URL through \`new URL().toString()\` before handing it to the interstitial, and the interstitial's \`validateDestination\` normalizes again.
- Raw vs canonical form produces different SHA-256 hashes, so \`destHash !== hashDestination(to)\` triggers on every click and the page shows "Invalid redirect."

## Fix

Canonicalize inside \`hashDestination\` itself so callers don't have to remember and both sides always hash the same input. If the URL fails to parse, fall back to the raw string (both sides will agree on that fallback too).

## Testing

- Typecheck clean.
- Manual browser test still needed after deploy — confirm a verified-enabled link redirects through and \`verifiedAt\` populates in the DB.

## Type of Change

- [x] fix: Bug fix