### PR TITLE
feat(analytics): track verified-clicks toggle adoption

### DIFF
--- a/src/app/(main)/dashboard/_components/links/link-card/edit-link-drawer.tsx
+++ b/src/app/(main)/dashboard/_components/links/link-card/edit-link-drawer.tsx
@@ -51,6 +51,7 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { Switch } from "@/components/ui/switch";
+import { POSTHOG_EVENTS, trackEvent } from "@/lib/analytics/events";
 import { clientLogger } from "@/lib/logger/client";
 import { cn } from "@/lib/utils";
 import { updateLinkSchema } from "@/server/api/routers/link/link.input";
@@ -197,6 +198,8 @@ export function EditLinkDrawer({ link, open, onClose }: EditLinkDrawerProps) {
   async function onSubmit(values: z.infer<typeof updateLinkSchema>) {
     values.tags = tags;
     const thresholds = milestones.map((m) => m.threshold);
+    const wasEnabled = link.verifiedClicksEnabled ?? false;
+    const isEnabled = values.verifiedClicksEnabled ?? false;
     toast.promise(
       Promise.all([
         formUpdateMutation.mutateAsync(values),
@@ -205,6 +208,18 @@ export function EditLinkDrawer({ link, open, onClose }: EditLinkDrawerProps) {
           thresholds,
         }),
       ]).then(() => {
+        if (isEnabled !== wasEnabled) {
+          trackEvent(
+            isEnabled
+              ? POSTHOG_EVENTS.VERIFIED_CLICKS_ENABLED
+              : POSTHOG_EVENTS.VERIFIED_CLICKS_DISABLED,
+            {
+              linkId: link.id,
+              plan: subscriptionStatus?.plan ?? "free",
+              source: "edit",
+            },
+          );
+        }
         onClose();
       }),
       {

--- a/src/app/(main)/dashboard/link/new/page.tsx
+++ b/src/app/(main)/dashboard/link/new/page.tsx
@@ -261,6 +261,12 @@ export default function CreateLinkPage() {
       has_expiration: !!values.disableLinkAfterDate || !!values.disableLinkAfterClicks,
       domain: values.domain || "ishortn.ink",
     });
+    if (values.verifiedClicksEnabled) {
+      trackEvent(POSTHOG_EVENTS.VERIFIED_CLICKS_ENABLED, {
+        plan: userSubscription?.data?.subscriptions?.plan ?? "free",
+        source: "create",
+      });
+    }
   }
 
   useEffect(() => {

--- a/src/lib/analytics/events.ts
+++ b/src/lib/analytics/events.ts
@@ -19,6 +19,10 @@ export const POSTHOG_EVENTS = {
   ANALYTICS_VIEWED: "analytics_viewed",
   ANALYTICS_OVERVIEW_VIEWED: "analytics_overview_viewed",
 
+  // Verified clicks feature
+  VERIFIED_CLICKS_ENABLED: "verified_clicks_enabled",
+  VERIFIED_CLICKS_DISABLED: "verified_clicks_disabled",
+
   // API events
   API_KEY_CREATED: "api_key_created",
   API_KEY_REVOKED: "api_key_revoked",


### PR DESCRIPTION
## Summary

Wires PostHog events on the verified-clicks toggle so we can actually see who's trying the feature. Right now the only signal of adoption is \`SELECT COUNT(*) FROM Link WHERE verifiedClicksEnabled = true\` — no time series, no plan segmentation, no funnel.

## Changes

- Adds \`VERIFIED_CLICKS_ENABLED\` and \`VERIFIED_CLICKS_DISABLED\` to \`POSTHOG_EVENTS\`.
- Fires \`ENABLED\` when the toggle is newly turned on — either on link create, or on an edit where the previous state was off.
- Fires \`DISABLED\` when an edit transitions a previously-enabled link back to off.
- Both events carry \`{ plan, source: "create" | "edit" }\`; the edit path also includes \`linkId\`.

## What this answers

- **Who tried it**: count distinct users firing \`VERIFIED_CLICKS_ENABLED\` in PostHog.
- **Plan mix**: segment by \`plan\` property.
- **Retention**: firing \`ENABLED\` then \`DISABLED\` within a window = bounced.
- **Entry point**: \`source\` tells us whether users discover the feature in the create flow or the edit drawer.

## Not included

- No server-side events — the client-side PostHog pattern matches the rest of the codebase (\`LINK_CREATED\`, \`ANALYTICS_VIEWED\`, etc.). Adding posthog-node is a larger change.
- No "feature seen" event — PostHog autocapture already fires \`\$pageview\` on \`/dashboard/link/new\` and click events on the edit button. That's sufficient for a "saw it" denominator without adding code.

## Testing

- Typecheck clean.
- Manual: toggle verified clicks on a new link → confirm \`verified_clicks_enabled\` appears in PostHog live events. Repeat on an edit.

## Type of Change

- [x] feat: New feature