### PR TITLE
feat(domains): add isht.ink platform short-link domain

### DIFF
--- a/src/app/(main)/[linkAlias]/page.tsx
+++ b/src/app/(main)/[linkAlias]/page.tsx
@@ -2,6 +2,7 @@ import { headers } from "next/headers";
 import { notFound, redirect } from "next/navigation";
 
 import { socialMediaAgents } from "@/lib/constants/app";
+import { DEFAULT_PLATFORM_DOMAIN } from "@/lib/constants/domains";
 import { api } from "@/trpc/server";
 
 import { LinkPasswordVerification } from "./link-password-verification";
@@ -21,7 +22,7 @@ export type LinkMetadata = {
   image: string;
 };
 
-const DEFAULT_DOMAIN = "ishortn.ink";
+const DEFAULT_DOMAIN = DEFAULT_PLATFORM_DOMAIN;
 
 const cleanUrl = (url: string) => url.replace(/^(https?:\/\/)?(www\.)?/, "");
 

--- a/src/app/(main)/dashboard/_components/links/link-card/edit-link-drawer.tsx
+++ b/src/app/(main)/dashboard/_components/links/link-card/edit-link-drawer.tsx
@@ -52,6 +52,7 @@ import {
 } from "@/components/ui/select";
 import { Switch } from "@/components/ui/switch";
 import { POSTHOG_EVENTS, trackEvent } from "@/lib/analytics/events";
+import { DEFAULT_PLATFORM_DOMAIN, PLATFORM_DOMAINS } from "@/lib/constants/domains";
 import { clientLogger } from "@/lib/logger/client";
 import { cn } from "@/lib/utils";
 import { updateLinkSchema } from "@/server/api/routers/link/link.input";
@@ -407,11 +408,15 @@ export function EditLinkDrawer({ link, open, onClose }: EditLinkDrawerProps) {
                             <div className="flex h-9 w-full items-center overflow-hidden rounded-md border border-neutral-200 dark:border-border bg-white dark:bg-card transition-colors focus-within:ring-2 focus-within:ring-neutral-300">
                               <Select>
                                 <SelectTrigger className="h-full w-max shrink-0 gap-1 border-0 bg-transparent px-3 text-[13px] font-medium text-neutral-500 shadow-none ring-0 hover:text-neutral-900 focus:ring-0">
-                                  <SelectValue placeholder={link.domain || "ishortn.ink"} />
+                                  <SelectValue placeholder={link.domain || DEFAULT_PLATFORM_DOMAIN} />
                                 </SelectTrigger>
                                 <SelectContent>
                                   <SelectGroup>
-                                    <SelectItem value="ishortn.ink">ishortn.ink</SelectItem>
+                                    {PLATFORM_DOMAINS.map((domain) => (
+                                      <SelectItem key={domain} value={domain}>
+                                        {domain}
+                                      </SelectItem>
+                                    ))}
                                   </SelectGroup>
                                 </SelectContent>
                               </Select>

--- a/src/app/(main)/dashboard/_components/links/link-card/update-modal.tsx
+++ b/src/app/(main)/dashboard/_components/links/link-card/update-modal.tsx
@@ -50,6 +50,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
+import { DEFAULT_PLATFORM_DOMAIN, PLATFORM_DOMAINS } from "@/lib/constants/domains";
 import { cn } from "@/lib/utils";
 import { updateLinkSchema } from "@/server/api/routers/link/link.input";
 import { api } from "@/trpc/react";
@@ -252,13 +253,15 @@ export function UpdateLinkModal({ link, open, setOpen }: LinkEditModalProps) {
                                 <section className="flex items-center">
                                   <Select>
                                     <SelectTrigger className="h-9 w-max rounded-r-none border-r-0 border-neutral-200 dark:border-border bg-neutral-50 dark:bg-accent/50 text-[13px]">
-                                      <SelectValue placeholder="ishortn.ink" />
+                                      <SelectValue placeholder={DEFAULT_PLATFORM_DOMAIN} />
                                     </SelectTrigger>
                                     <SelectContent>
                                       <SelectGroup>
-                                        <SelectItem value="ishortn.ink">
-                                          ishortn.ink
-                                        </SelectItem>
+                                        {PLATFORM_DOMAINS.map((domain) => (
+                                          <SelectItem key={domain} value={domain}>
+                                            {domain}
+                                          </SelectItem>
+                                        ))}
                                       </SelectGroup>
                                     </SelectContent>
                                   </Select>

--- a/src/app/(main)/dashboard/_components/navigation/workspace-switcher.tsx
+++ b/src/app/(main)/dashboard/_components/navigation/workspace-switcher.tsx
@@ -16,6 +16,7 @@ import {
   PopoverContent,
   PopoverTrigger,
 } from "@/components/ui/popover";
+import { getAppBaseDomain } from "@/lib/constants/domains";
 import { cn } from "@/lib/utils";
 
 type Team = {
@@ -55,7 +56,7 @@ export function WorkspaceSwitcher({
     teamSlug?: string,
   ) => {
     setIsOpen(false);
-    const baseDomain = process.env.NEXT_PUBLIC_APP_DOMAIN || "ishortn.ink";
+    const baseDomain = getAppBaseDomain();
 
     if (type === "personal") {
       window.location.href = `${window.location.protocol}//${baseDomain}/dashboard`;

--- a/src/app/(main)/dashboard/analytics/[alias]/page.tsx
+++ b/src/app/(main)/dashboard/analytics/[alias]/page.tsx
@@ -1,5 +1,6 @@
 import { IconClick, IconShieldCheck, IconShieldHalf, IconUsers } from "@tabler/icons-react";
 
+import { DEFAULT_PLATFORM_DOMAIN } from "@/lib/constants/domains";
 import { aggregateVisits } from "@/lib/core/analytics";
 import { cn } from "@/lib/utils";
 import { api } from "@/trpc/server";
@@ -37,7 +38,7 @@ export default async function LinkAnalyticsPage(
   const searchParams = await props.searchParams;
   const params = await props.params;
   const range = (searchParams?.range ?? "7d") as RangeEnum;
-  const domain = (searchParams?.domain as string) ?? "ishortn.ink";
+  const domain = (searchParams?.domain as string) ?? DEFAULT_PLATFORM_DOMAIN;
 
   const { totalVisits, uniqueVisits, referers, isProPlan, geoRules, previous } =
     await api.link.linkVisits.query({

--- a/src/app/(main)/dashboard/analytics/overview/_components/analytics-filter.tsx
+++ b/src/app/(main)/dashboard/analytics/overview/_components/analytics-filter.tsx
@@ -26,6 +26,7 @@ import {
   PopoverContent,
   PopoverTrigger,
 } from "@/components/ui/popover";
+import { DEFAULT_PLATFORM_DOMAIN, PLATFORM_DOMAINS } from "@/lib/constants/domains";
 import { api } from "@/trpc/react";
 import { cn } from "@/lib/utils";
 
@@ -148,9 +149,12 @@ export function AnalyticsFilter() {
   };
 
   const getDomainItems = () => {
-    const items = [
-      { value: "ishortn.ink", label: "ishortn.ink", subtitle: "Default" },
-    ];
+    const items: { value: string; label: string; subtitle: string }[] =
+      PLATFORM_DOMAINS.map((domain) => ({
+        value: domain,
+        label: domain,
+        subtitle: domain === DEFAULT_PLATFORM_DOMAIN ? "Default" : "Platform",
+      }));
     if (domains) {
       domains.forEach((domain) => {
         if (domain.domain) {

--- a/src/app/(main)/dashboard/link/new/_components/link-preview.tsx
+++ b/src/app/(main)/dashboard/link/new/_components/link-preview.tsx
@@ -1,4 +1,6 @@
-const DEFAULT_FAVICON = "https://www.google.com/s2/favicons?domain=ishortn.ink&sz=64";
+import { DEFAULT_PLATFORM_DOMAIN } from "@/lib/constants/domains";
+
+const DEFAULT_FAVICON = `https://www.google.com/s2/favicons?domain=${DEFAULT_PLATFORM_DOMAIN}&sz=64`;
 
 export function LinkPreviewComponent({
   destinationURL,
@@ -29,7 +31,7 @@ export function LinkPreviewComponent({
       </div>
       <span className="text-[13px] text-neutral-600 dark:text-neutral-400">{metaDescription}</span>
       <span className="text-[12px] text-neutral-400 dark:text-neutral-500">
-        {destinationURL?.replace(/(^\w+:|^)\/\//, "").split("/")[0] || "ishortn.ink"}
+        {destinationURL?.replace(/(^\w+:|^)\/\//, "").split("/")[0] || DEFAULT_PLATFORM_DOMAIN}
       </span>
       {metaImage && (
         /* eslint-disable-next-line @next/next/no-img-element */

--- a/src/app/(main)/dashboard/link/new/page.tsx
+++ b/src/app/(main)/dashboard/link/new/page.tsx
@@ -38,6 +38,7 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { Switch } from "@/components/ui/switch";
+import { DEFAULT_PLATFORM_DOMAIN, PLATFORM_DOMAINS } from "@/lib/constants/domains";
 import { clientLogger } from "@/lib/logger/client";
 import { fetchMetadataInfo } from "@/lib/utils/fetch-link-metadata";
 import { createLinkSchema } from "@/server/api/routers/link/link.input";
@@ -108,12 +109,15 @@ export default function CreateLinkPage() {
 
   const form = useForm<z.infer<typeof createLinkSchema>>({
     resolver: zodResolver(createLinkSchema),
-    defaultValues: initialUrl ? { url: initialUrl } : undefined,
+    defaultValues: {
+      domain: DEFAULT_PLATFORM_DOMAIN,
+      ...(initialUrl ? { url: initialUrl } : {}),
+    },
   });
 
   const [debouncedUrl] = useDebounce(destinationURL, 500);
   const [debouncedAlias] = useDebounce(form.watch("alias"), 500);
-  const selectedDomain = form.watch("domain") ?? "ishortn.ink";
+  const selectedDomain = form.watch("domain") ?? DEFAULT_PLATFORM_DOMAIN;
 
   async function generateAliases(metadata: {
     title: string;
@@ -263,7 +267,7 @@ export default function CreateLinkPage() {
       has_custom_alias: !!values.alias,
       has_password: !!values.password,
       has_expiration: !!values.disableLinkAfterDate || !!values.disableLinkAfterClicks,
-      domain: values.domain || "ishortn.ink",
+      domain: values.domain,
     });
     if (values.verifiedClicksEnabled) {
       trackEvent(POSTHOG_EVENTS.VERIFIED_CLICKS_ENABLED, {
@@ -279,10 +283,10 @@ export default function CreateLinkPage() {
     }
   }, [customDomainsQuery.data]);
 
-  // Fetch ishortn.ink metadata on initial load
+  // Fetch platform-default metadata on initial load
   useEffect(() => {
     if (isInitialLoad) {
-      fetchMetadataInfo("https://ishortn.ink")
+      fetchMetadataInfo(`https://${DEFAULT_PLATFORM_DOMAIN}`)
         .then((metadata) => {
           setMetaData(metadata);
         })
@@ -481,16 +485,21 @@ export default function CreateLinkPage() {
                     <FormControl>
                       <div className="flex h-9 w-full items-center overflow-hidden rounded-lg border border-neutral-200 dark:border-border bg-white dark:bg-card transition-colors hover:border-neutral-300 dark:hover:border-border focus-within:border-neutral-300 focus-within:ring-1 focus-within:ring-neutral-300">
                         <Select
+                          value={selectedDomain}
                           onValueChange={(value) => {
                             form.setValue("domain", value);
                           }}
                         >
                           <SelectTrigger className="h-full w-max shrink-0 gap-1 border-0 bg-transparent px-3 text-[13px] font-medium text-neutral-500 shadow-none ring-0 hover:text-neutral-700 focus:ring-0">
-                            <SelectValue placeholder="ishortn.ink" />
+                            <SelectValue placeholder={DEFAULT_PLATFORM_DOMAIN} />
                           </SelectTrigger>
                           <SelectContent>
                             <SelectGroup>
-                              <SelectItem value="ishortn.ink">ishortn.ink</SelectItem>
+                              {PLATFORM_DOMAINS.map((domain) => (
+                                <SelectItem key={domain} value={domain}>
+                                  {domain}
+                                </SelectItem>
+                              ))}
                               {userDomains.length > 0 &&
                                 userDomains.map((domain) => (
                                   <SelectItem key={domain.id} value={domain.domain!}>

--- a/src/app/(main)/dashboard/qrcodes/[id]/page.tsx
+++ b/src/app/(main)/dashboard/qrcodes/[id]/page.tsx
@@ -1,6 +1,7 @@
 import { IconClick, IconTrendingUp, IconUsers, IconWorld } from "@tabler/icons-react";
 
 import { aggregateVisits } from "@/lib/core/analytics";
+import { DEFAULT_PLATFORM_DOMAIN } from "@/lib/constants/domains";
 import { api } from "@/trpc/server";
 
 import UpgradeText from "../_components/upgrade-text";
@@ -36,7 +37,7 @@ export default async function QRCodeAnalyticsPage(props: QRCodeAnalyticsPageProp
   }
 
   const alias = qrCode.link.alias!;
-  const domain = qrCode.link.domain ?? "ishortn.ink";
+  const domain = qrCode.link.domain ?? DEFAULT_PLATFORM_DOMAIN;
 
   const {
     totalVisits,

--- a/src/app/(main)/dashboard/qrcodes/create/utils.ts
+++ b/src/app/(main)/dashboard/qrcodes/create/utils.ts
@@ -1,7 +1,15 @@
 import { z } from "zod";
 
+import { PLATFORM_DOMAINS } from "@/lib/constants/domains";
+
 export function isValidUrlAndNotIshortn(url: string) {
   const urlSchema = z.string().url();
-  const isValidUrl = urlSchema.safeParse(url);
-  return isValidUrl.success && !isValidUrl.data.includes("ishortn.ink");
+  const result = urlSchema.safeParse(url);
+  if (!result.success) return false;
+  try {
+    const host = new URL(result.data).hostname.toLowerCase();
+    return !PLATFORM_DOMAINS.some((platform) => host === platform || host.endsWith(`.${platform}`));
+  } catch {
+    return false;
+  }
 }

--- a/src/app/(main)/dashboard/settings/general/settings-form.tsx
+++ b/src/app/(main)/dashboard/settings/general/settings-form.tsx
@@ -22,6 +22,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
+import { PLATFORM_DOMAINS } from "@/lib/constants/domains";
 import { api } from "@/trpc/react";
 
 import type { RouterOutputs } from "@/trpc/shared";
@@ -68,7 +69,7 @@ export function SettingsForm({
   }
 
   const activeDomains = [
-    { domain: "ishortn.ink", status: "active" as const },
+    ...PLATFORM_DOMAINS.map((domain) => ({ domain, status: "active" as const })),
     ...availableDomains.filter((d) => d.status === "active"),
   ];
 

--- a/src/app/(main)/dashboard/teams/members/page.tsx
+++ b/src/app/(main)/dashboard/teams/members/page.tsx
@@ -65,9 +65,10 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
+import { getAppBaseDomain } from "@/lib/constants/domains";
 import { api } from "@/trpc/react";
 
-const baseDomain = process.env.NEXT_PUBLIC_APP_DOMAIN || "ishortn.ink";
+const baseDomain = getAppBaseDomain();
 
 const inviteSchema = z.object({
   email: z.string().email("Invalid email").optional().or(z.literal("")),

--- a/src/app/(main)/dashboard/teams/new/page.tsx
+++ b/src/app/(main)/dashboard/teams/new/page.tsx
@@ -23,6 +23,7 @@ import {
   FormMessage,
 } from "@/components/ui/form";
 import { Input } from "@/components/ui/input";
+import { DEFAULT_PLATFORM_DOMAIN, getAppBaseDomain } from "@/lib/constants/domains";
 import { api } from "@/trpc/react";
 
 const slugRegex = /^[a-z0-9][a-z0-9-]*[a-z0-9]$|^[a-z0-9]$/;
@@ -82,7 +83,7 @@ export default function CreateTeamPage() {
   const createTeamMutation = api.team.create.useMutation({
     onSuccess: (data) => {
       toast.success("Team created successfully!");
-      const baseDomain = process.env.NEXT_PUBLIC_APP_DOMAIN || "ishortn.ink";
+      const baseDomain = getAppBaseDomain();
       window.location.href = `${window.location.protocol}//${data.slug}.${baseDomain}/dashboard`;
     },
     onError: (error) => {
@@ -189,7 +190,7 @@ export default function CreateTeamPage() {
                         }}
                       />
                       <span className="inline-flex h-9 items-center rounded-r-lg border border-l-0 border-neutral-200 dark:border-border bg-neutral-50 dark:bg-accent/50 px-3 text-[13px] text-neutral-400 dark:text-neutral-500">
-                        .ishortn.ink
+                        .{DEFAULT_PLATFORM_DOMAIN}
                       </span>
                     </div>
                   </FormControl>
@@ -248,7 +249,7 @@ export default function CreateTeamPage() {
           <p className="text-[12px] leading-relaxed text-neutral-400 dark:text-neutral-500">
             Your team will have its own workspace at{" "}
             <span className="font-mono text-neutral-600 dark:text-neutral-400">
-              {slug || "your-team"}.ishortn.ink
+              {slug || "your-team"}.{DEFAULT_PLATFORM_DOMAIN}
             </span>
             . You&apos;ll be the owner with full access and can invite members after setup.
           </p>

--- a/src/app/(main)/dashboard/teams/settings/page.tsx
+++ b/src/app/(main)/dashboard/teams/settings/page.tsx
@@ -33,6 +33,7 @@ import {
   FormMessage,
 } from "@/components/ui/form";
 import { Input } from "@/components/ui/input";
+import { DEFAULT_PLATFORM_DOMAIN, getAppBaseDomain } from "@/lib/constants/domains";
 import { api } from "@/trpc/react";
 
 const slugRegex = /^[a-z0-9][a-z0-9-]*[a-z0-9]$|^[a-z0-9]$/;
@@ -107,7 +108,7 @@ export default function TeamSettingsPage() {
     }
   );
 
-  const baseDomain = process.env.NEXT_PUBLIC_APP_DOMAIN || "ishortn.ink";
+  const baseDomain = getAppBaseDomain();
 
   const updateTeamMutation = api.team.update.useMutation({
     onSuccess: () => {
@@ -302,7 +303,7 @@ export default function TeamSettingsPage() {
                               }
                             />
                             <span className="inline-flex h-9 items-center rounded-r-lg border border-l-0 border-neutral-200 dark:border-border bg-neutral-50 dark:bg-accent/50 px-3 text-[13px] text-neutral-400 dark:text-neutral-500">
-                              .ishortn.ink
+                              .{DEFAULT_PLATFORM_DOMAIN}
                             </span>
                           </div>
                         </FormControl>

--- a/src/app/(main)/teams/accept-invite/page.tsx
+++ b/src/app/(main)/teams/accept-invite/page.tsx
@@ -17,6 +17,7 @@ import { toast } from "sonner";
 
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Button } from "@/components/ui/button";
+import { getAppBaseDomain } from "@/lib/constants/domains";
 import { cn } from "@/lib/utils";
 import { api } from "@/trpc/react";
 
@@ -109,7 +110,7 @@ function AcceptInviteContent() {
     }
   );
 
-  const baseDomain = process.env.NEXT_PUBLIC_APP_DOMAIN || "ishortn.ink";
+  const baseDomain = getAppBaseDomain();
 
   const acceptInviteMutation = api.team.acceptInvite.useMutation({
     onSuccess: (data) => {

--- a/src/app/api/links/iframeable/route.ts
+++ b/src/app/api/links/iframeable/route.ts
@@ -1,5 +1,6 @@
 import { type NextRequest, NextResponse } from "next/server";
 
+import { DEFAULT_PLATFORM_DOMAIN } from "@/lib/constants/domains";
 import { logger } from "@/lib/logger";
 import { isIframeable } from "@/lib/utils/is-iframeable";
 
@@ -39,7 +40,9 @@ export async function GET(request: NextRequest) {
 
     // Get the request domain (the domain that will be embedding the iframe)
     const requestDomain =
-      request.headers.get("x-forwarded-host") ?? request.headers.get("host") ?? "ishortn.ink";
+      request.headers.get("x-forwarded-host") ??
+      request.headers.get("host") ??
+      DEFAULT_PLATFORM_DOMAIN;
 
     const iframeable = await isIframeable({
       url,

--- a/src/app/api/v1/analytics/[alias]/route.ts
+++ b/src/app/api/v1/analytics/[alias]/route.ts
@@ -1,3 +1,4 @@
+import { DEFAULT_PLATFORM_DOMAIN } from "@/lib/constants/domains";
 import { aggregateVisits } from "@/lib/core/analytics";
 import { db } from "@/server/db";
 
@@ -11,7 +12,7 @@ export async function GET(request: NextRequest, props: { params: Promise<{ alias
 
   const searchParams = request.nextUrl.searchParams
   const query = searchParams.get('domain')
-  const domain = query ?? "ishortn.ink"
+  const domain = query ?? DEFAULT_PLATFORM_DOMAIN
 
   const token = await validateAndGetToken(apiKey);
   if (!token) {

--- a/src/app/api/v1/analytics/[alias]/route.ts
+++ b/src/app/api/v1/analytics/[alias]/route.ts
@@ -12,7 +12,7 @@ export async function GET(request: NextRequest, props: { params: Promise<{ alias
 
   const searchParams = request.nextUrl.searchParams
   const query = searchParams.get('domain')
-  const domain = query ?? DEFAULT_PLATFORM_DOMAIN
+  const domain = query?.trim() || DEFAULT_PLATFORM_DOMAIN
 
   const token = await validateAndGetToken(apiKey);
   if (!token) {

--- a/src/app/api/v1/links/[alias]/route.ts
+++ b/src/app/api/v1/links/[alias]/route.ts
@@ -1,5 +1,6 @@
 import { and, eq } from "drizzle-orm";
 
+import { DEFAULT_PLATFORM_DOMAIN } from "@/lib/constants/domains";
 import { logger } from "@/lib/logger";
 import { db } from "@/server/db";
 import { link } from "@/server/db/schema";
@@ -17,7 +18,7 @@ export async function GET(request: NextRequest, props: { params: Promise<{ alias
 
   const searchParams = request.nextUrl.searchParams;
   const query = searchParams.get("domain");
-  const domain = query ?? "ishortn.ink";
+  const domain = query ?? DEFAULT_PLATFORM_DOMAIN;
 
   const token = await validateAndGetToken(apiKey);
   if (!token) {
@@ -39,7 +40,7 @@ export async function PATCH(request: NextRequest, props: { params: Promise<{ ali
 
   const searchParams = request.nextUrl.searchParams;
   const query = searchParams.get("domain");
-  const domain = query ?? "ishortn.ink";
+  const domain = query ?? DEFAULT_PLATFORM_DOMAIN;
 
   const token = await validateAndGetToken(apiKey);
   if (!token) {

--- a/src/app/api/v1/links/[alias]/route.ts
+++ b/src/app/api/v1/links/[alias]/route.ts
@@ -18,7 +18,7 @@ export async function GET(request: NextRequest, props: { params: Promise<{ alias
 
   const searchParams = request.nextUrl.searchParams;
   const query = searchParams.get("domain");
-  const domain = query ?? DEFAULT_PLATFORM_DOMAIN;
+  const domain = query?.trim() || DEFAULT_PLATFORM_DOMAIN;
 
   const token = await validateAndGetToken(apiKey);
   if (!token) {
@@ -40,7 +40,7 @@ export async function PATCH(request: NextRequest, props: { params: Promise<{ ali
 
   const searchParams = request.nextUrl.searchParams;
   const query = searchParams.get("domain");
-  const domain = query ?? DEFAULT_PLATFORM_DOMAIN;
+  const domain = query?.trim() || DEFAULT_PLATFORM_DOMAIN;
 
   const token = await validateAndGetToken(apiKey);
   if (!token) {

--- a/src/app/api/v1/links/route.ts
+++ b/src/app/api/v1/links/route.ts
@@ -2,6 +2,7 @@ import bcrypt from "bcryptjs";
 import { and, eq } from "drizzle-orm";
 import { z } from "zod";
 
+import { DEFAULT_PLATFORM_DOMAIN } from "@/lib/constants/domains";
 import { generateShortLink } from "@/lib/core/links";
 import { db } from "@/server/db";
 import { link } from "@/server/db/schema";
@@ -25,7 +26,7 @@ export async function POST(request: Request) {
   }
 
   const parsedData = input.data as ShortenLinkInput;
-  if (parsedData.alias && (await checkLinkAliasCollision(parsedData.alias, parsedData.domain ?? "ishortn.ink"))) {
+  if (parsedData.alias && (await checkLinkAliasCollision(parsedData.alias, parsedData.domain ?? DEFAULT_PLATFORM_DOMAIN))) {
     return new Response("Alias already exists", { status: 400 });
   }
 
@@ -132,7 +133,7 @@ async function createNewLink(
     disableLinkAfterClicks: data.expiresAfter,
     disableLinkAfterDate: data.expiresAt ? new Date(data.expiresAt) : null,
     passwordHash: data.password,
-    domain: data.domain ?? "ishortn.ink",
+    domain: data.domain ?? DEFAULT_PLATFORM_DOMAIN,
     userId,
     utmParams: data.utmParams ?? null,
   };

--- a/src/app/api/v1/links/route.ts
+++ b/src/app/api/v1/links/route.ts
@@ -26,7 +26,7 @@ export async function POST(request: Request) {
   }
 
   const parsedData = input.data as ShortenLinkInput;
-  if (parsedData.alias && (await checkLinkAliasCollision(parsedData.alias, parsedData.domain ?? DEFAULT_PLATFORM_DOMAIN))) {
+  if (parsedData.alias && (await checkLinkAliasCollision(parsedData.alias, parsedData.domain?.trim() || DEFAULT_PLATFORM_DOMAIN))) {
     return new Response("Alias already exists", { status: 400 });
   }
 
@@ -133,7 +133,7 @@ async function createNewLink(
     disableLinkAfterClicks: data.expiresAfter,
     disableLinkAfterDate: data.expiresAt ? new Date(data.expiresAt) : null,
     passwordHash: data.password,
-    domain: data.domain ?? DEFAULT_PLATFORM_DOMAIN,
+    domain: data.domain?.trim() || DEFAULT_PLATFORM_DOMAIN,
     userId,
     utmParams: data.utmParams ?? null,
   };

--- a/src/lib/constants/domains.ts
+++ b/src/lib/constants/domains.ts
@@ -1,0 +1,33 @@
+// Platform-provided short-link domains. First entry is the default for new
+// links and the preferred host for marketing/team subdomain previews. All
+// entries must be wired at the infrastructure layer (DNS + SSL + host) and
+// resolve to this Next.js app.
+export const PLATFORM_DOMAINS = ["isht.ink", "ishortn.ink"] as const;
+
+export type PlatformDomain = (typeof PLATFORM_DOMAINS)[number];
+
+export const DEFAULT_PLATFORM_DOMAIN: PlatformDomain = PLATFORM_DOMAINS[0];
+
+export function isPlatformDomain(domain: string | null | undefined): domain is PlatformDomain {
+  return !!domain && (PLATFORM_DOMAINS as readonly string[]).includes(domain);
+}
+
+// Base host for user-facing app URLs (team invites, workspace switching,
+// accept-invite redirects). Respects NEXT_PUBLIC_APP_DOMAIN override.
+export function getAppBaseDomain(): string {
+  return process.env.NEXT_PUBLIC_APP_DOMAIN || DEFAULT_PLATFORM_DOMAIN;
+}
+
+// Returns the leading label when `host` is a team subdomain of a platform
+// domain (e.g. "acme.isht.ink" -> "acme"). Returns null for bare platform
+// hosts and anything outside the catalogue.
+export function extractPlatformSubdomain(host: string): string | null {
+  for (const platformDomain of PLATFORM_DOMAINS) {
+    if (!host.endsWith(`.${platformDomain}`)) continue;
+    const parts = host.split(".");
+    if (parts.length !== platformDomain.split(".").length + 1) continue;
+    const candidate = parts[0]?.trim().toLowerCase();
+    if (candidate) return candidate;
+  }
+  return null;
+}

--- a/src/lib/constants/domains.ts
+++ b/src/lib/constants/domains.ts
@@ -20,13 +20,15 @@ export function getAppBaseDomain(): string {
 
 // Returns the leading label when `host` is a team subdomain of a platform
 // domain (e.g. "acme.isht.ink" -> "acme"). Returns null for bare platform
-// hosts and anything outside the catalogue.
+// hosts and anything outside the catalogue. Host matching is case-insensitive
+// to match DNS semantics, and a trailing dot (FQDN form) is tolerated.
 export function extractPlatformSubdomain(host: string): string | null {
+  const normalized = host.trim().replace(/\.$/, "").toLowerCase();
   for (const platformDomain of PLATFORM_DOMAINS) {
-    if (!host.endsWith(`.${platformDomain}`)) continue;
-    const parts = host.split(".");
+    if (!normalized.endsWith(`.${platformDomain}`)) continue;
+    const parts = normalized.split(".");
     if (parts.length !== platformDomain.split(".").length + 1) continue;
-    const candidate = parts[0]?.trim().toLowerCase();
+    const candidate = parts[0];
     if (candidate) return candidate;
   }
   return null;

--- a/src/lib/core/cache/index.ts
+++ b/src/lib/core/cache/index.ts
@@ -2,6 +2,7 @@ import { Redis } from "ioredis";
 import { z } from "zod";
 
 import { env } from "@/env.mjs";
+import { DEFAULT_PLATFORM_DOMAIN } from "@/lib/constants/domains";
 
 import type { Link } from "@/server/db/schema";
 
@@ -241,7 +242,7 @@ async function deleteGeoRulesFromCache(linkId: number): Promise<boolean> {
 /** Normalize a raw domain by stripping protocol, www prefix, and mapping localhost to default. */
 function normalizeDomain(domain: string): string {
   const cleaned = domain.replace(/^https?:\/\//, "").replace(/^www\./, "");
-  return domain.includes("localhost") ? "ishortn.ink" : cleaned;
+  return domain.includes("localhost") ? DEFAULT_PLATFORM_DOMAIN : cleaned;
 }
 
 /** Build a Redis cache key from a raw (possibly protocol-prefixed) domain and alias. */

--- a/src/server/api/routers/link/link.service.ts
+++ b/src/server/api/routers/link/link.service.ts
@@ -22,6 +22,7 @@ import {
   isUnlimitedGeoRules,
 } from "@/lib/billing/plans";
 import { assertUrlSafe } from "@/server/lib/phishing";
+import { DEFAULT_PLATFORM_DOMAIN } from "@/lib/constants/domains";
 import { retrieveDeviceAndGeolocationData } from "@/lib/core/analytics";
 import { logger } from "@/lib/logger";
 import { hashIp } from "@/lib/utils/ip-hash";
@@ -338,7 +339,7 @@ export const createLink = async (
   const { plan, currentCount, limit } = await checkWorkspaceLinkLimit(ctx);
   const isPaidPlan = plan !== "free";
 
-  const domain = input.domain ?? "ishortn.ink";
+  const domain = input.domain ?? DEFAULT_PLATFORM_DOMAIN;
   const alias =
     input.alias && input.alias !== "" ? input.alias : await generateShortLink();
 
@@ -1627,7 +1628,7 @@ export const bulkCreateLinks = async (
         userId: ownership.userId,
         teamId: ownership.teamId,
         createdByUserId: ctx.auth.userId, // Track the actual user who created the link
-        domain: record.domain ?? "ishortn.ink",
+        domain: record.domain ?? DEFAULT_PLATFORM_DOMAIN,
         note: record.note,
       });
     }),

--- a/src/server/api/routers/link/link.service.ts
+++ b/src/server/api/routers/link/link.service.ts
@@ -339,7 +339,7 @@ export const createLink = async (
   const { plan, currentCount, limit } = await checkWorkspaceLinkLimit(ctx);
   const isPaidPlan = plan !== "free";
 
-  const domain = input.domain ?? DEFAULT_PLATFORM_DOMAIN;
+  const domain = input.domain?.trim() || DEFAULT_PLATFORM_DOMAIN;
   const alias =
     input.alias && input.alias !== "" ? input.alias : await generateShortLink();
 
@@ -1628,7 +1628,7 @@ export const bulkCreateLinks = async (
         userId: ownership.userId,
         teamId: ownership.teamId,
         createdByUserId: ctx.auth.userId, // Track the actual user who created the link
-        domain: record.domain ?? DEFAULT_PLATFORM_DOMAIN,
+        domain: record.domain?.trim() || DEFAULT_PLATFORM_DOMAIN,
         note: record.note,
       });
     }),

--- a/src/server/api/routers/link/transfer.service.ts
+++ b/src/server/api/routers/link/transfer.service.ts
@@ -2,6 +2,7 @@ import { TRPCError } from "@trpc/server";
 import { and, eq, inArray, isNull, sql } from "drizzle-orm";
 
 import { getPlanCaps } from "@/lib/billing/plans";
+import { isPlatformDomain } from "@/lib/constants/domains";
 import {
   customDomain,
   link,
@@ -319,7 +320,7 @@ export async function validateTransfer(
 
   // Check custom domain availability in target workspace
   const customDomains = [
-    ...new Set(sourceLinks.filter((l) => l.domain !== "ishortn.ink").map((l) => l.domain)),
+    ...new Set(sourceLinks.filter((l) => !isPlatformDomain(l.domain)).map((l) => l.domain)),
   ];
 
   if (customDomains.length > 0) {

--- a/src/server/api/routers/link/utils.ts
+++ b/src/server/api/routers/link/utils.ts
@@ -1,6 +1,7 @@
 import { TRPCError } from "@trpc/server";
 import { and, eq, sql } from "drizzle-orm";
 
+import { DEFAULT_PLATFORM_DOMAIN } from "@/lib/constants/domains";
 import { redis } from "@/lib/core/cache";
 import { normalizeAlias } from "@/lib/utils";
 import { link, team, user } from "@/server/db/schema";
@@ -121,7 +122,7 @@ export async function getUserDefaultDomain(ctx: ProtectedTRPCContext): Promise<s
   const cachedDomain = await redis.get(cacheKey);
 
   if (cachedDomain) {
-    return cachedDomain ?? "ishortn.ink";
+    return cachedDomain ?? DEFAULT_PLATFORM_DOMAIN;
   }
 
   const userInfo = await ctx.db.query.user.findFirst({
@@ -131,7 +132,7 @@ export async function getUserDefaultDomain(ctx: ProtectedTRPCContext): Promise<s
     },
   });
 
-  const defaultDomain = userInfo?.siteSettings?.defaultDomain ?? "ishortn.ink";
+  const defaultDomain = userInfo?.siteSettings?.defaultDomain ?? DEFAULT_PLATFORM_DOMAIN;
   await redis.set(cacheKey, defaultDomain, "EX", 300); // 5 minutes
 
   return defaultDomain;
@@ -156,7 +157,7 @@ export async function getWorkspaceDefaultDomain(ctx: WorkspaceTRPCContext): Prom
       where: eq(team.id, ctx.workspace.teamId),
     });
 
-    const defaultDomain = teamRecord?.defaultDomain ?? "ishortn.ink";
+    const defaultDomain = teamRecord?.defaultDomain ?? DEFAULT_PLATFORM_DOMAIN;
     await redis.set(cacheKey, defaultDomain, "EX", 300); // 5 minutes
 
     return defaultDomain;

--- a/src/server/api/routers/qrcode/qrcode.service.ts
+++ b/src/server/api/routers/qrcode/qrcode.service.ts
@@ -14,6 +14,7 @@ import {
 } from "@/server/lib/workspace";
 import {
   checkWorkspaceLinkLimit,
+  getWorkspaceDefaultDomain,
   incrementWorkspaceLinkCount,
 } from "../link/utils";
 
@@ -70,14 +71,17 @@ export const createQrCode = async (ctx: WorkspaceTRPCContext, input: QRCodeInput
 
   await assertUrlSafe(input.content);
 
-  const alias = await generateShortLink();
-  const trackingUrl = `https://ishortn.ink/${alias}`;
+  const [alias, domain] = await Promise.all([
+    generateShortLink(),
+    getWorkspaceDefaultDomain(ctx),
+  ]);
+  const trackingUrl = `https://${domain}/${alias}`;
 
   const { insertedQrCodeId } = await ctx.db.transaction(async (tx) => {
     const hiddenLinkResult = await tx.insert(link).values({
       url: input.content,
       alias,
-      domain: "ishortn.ink",
+      domain,
       name: input.title || "QR Code",
       isQrCode: true,
       userId: ownership.userId ?? ctx.auth.userId,

--- a/src/server/api/routers/settings/settings.service.ts
+++ b/src/server/api/routers/settings/settings.service.ts
@@ -1,5 +1,6 @@
 import { eq } from "drizzle-orm";
 
+import { DEFAULT_PLATFORM_DOMAIN, isPlatformDomain } from "@/lib/constants/domains";
 import { redis } from "@/lib/core/cache";
 import { siteSettings } from "@/server/db/schema";
 
@@ -15,7 +16,7 @@ export async function getSiteSettings(ctx: ProtectedTRPCContext) {
   if (!settings) {
     const [newSettings] = await ctx.db.insert(siteSettings).values({
       userId: ctx.auth.userId,
-      defaultDomain: "ishortn.ink",
+      defaultDomain: DEFAULT_PLATFORM_DOMAIN,
     });
 
     return ctx.db.query.siteSettings.findFirst({
@@ -34,8 +35,7 @@ export async function updateSiteSettings(
     where: (table, { eq }) => eq(table.userId, ctx.auth.userId),
   });
 
-  // If domain is not ishortn.ink, verify that the user owns the domain
-  if (input.defaultDomain !== "ishortn.ink") {
+  if (!isPlatformDomain(input.defaultDomain)) {
     const domain = await ctx.db.query.customDomain.findFirst({
       where: (table, { and }) =>
         and(

--- a/src/server/api/routers/team/team.service.ts
+++ b/src/server/api/routers/team/team.service.ts
@@ -4,6 +4,7 @@ import { and, eq, isNull } from "drizzle-orm";
 import crypto from "node:crypto";
 
 import { redis } from "@/lib/core/cache";
+import { getAppBaseDomain, isPlatformDomain } from "@/lib/constants/domains";
 import { runBackgroundTask } from "@/lib/utils/background";
 import { customDomain, RESERVED_TEAM_SLUGS, team, teamInvite, teamMember, user } from "@/server/db/schema";
 import { sendTeamInviteEmail } from "@/server/lib/notifications/team-invite";
@@ -100,8 +101,7 @@ export async function getTeam(ctx: TeamTRPCContext) {
 export async function updateTeam(ctx: TeamTRPCContext, input: UpdateTeamInput) {
   requirePermission(ctx.workspace, "team.settings", "update team settings");
 
-  // Validate default domain if provided and not the default
-  if (input.defaultDomain && input.defaultDomain !== "ishortn.ink") {
+  if (input.defaultDomain && !isPlatformDomain(input.defaultDomain)) {
     const validDomain = await ctx.db.query.customDomain.findFirst({
       where: and(
         eq(customDomain.domain, input.defaultDomain),
@@ -568,7 +568,7 @@ export async function createInvite(
     );
   }
 
-  const baseDomain = process.env.NEXT_PUBLIC_APP_DOMAIN || "ishortn.ink";
+  const baseDomain = getAppBaseDomain();
 
   return {
     inviteId: Number(result.insertId),

--- a/src/server/api/trpc.ts
+++ b/src/server/api/trpc.ts
@@ -3,6 +3,7 @@ import { initTRPC, TRPCError } from "@trpc/server";
 import superjson from "superjson";
 import { ZodError } from "zod";
 
+import { DEFAULT_PLATFORM_DOMAIN } from "@/lib/constants/domains";
 import { db } from "@/server/db";
 import { user } from "@/server/db/schema";
 import {
@@ -114,7 +115,7 @@ export type WorkspaceTRPCContext = ProtectedTRPCContext & {
  */
 export const workspaceProcedure = protectedProcedure.use(
   async ({ ctx, next }) => {
-    const hostname = ctx.headers.get("host") ?? "ishortn.ink";
+    const hostname = ctx.headers.get("host") ?? DEFAULT_PLATFORM_DOMAIN;
 
     const workspace = await resolveWorkspaceContext(
       ctx.auth.userId,

--- a/src/server/lib/notifications/account-transfer.ts
+++ b/src/server/lib/notifications/account-transfer.ts
@@ -1,6 +1,7 @@
 import AccountTransferEmail from "@/emails/account-transfer";
 import TransferCompletedEmail from "@/emails/transfer-completed";
 import TransferDeclinedEmail from "@/emails/transfer-declined";
+import { getAppBaseDomain } from "@/lib/constants/domains";
 import { logger } from "@/lib/logger";
 
 import type { ResourceCounts } from "@/server/api/routers/account-transfer/account-transfer.service";
@@ -28,7 +29,7 @@ export async function sendAccountTransferEmail({
 }: SendAccountTransferEmailInput) {
   if (!resend) return;
 
-  const baseDomain = process.env.NEXT_PUBLIC_APP_DOMAIN || "ishortn.ink";
+  const baseDomain = getAppBaseDomain();
   const acceptUrl = `https://${baseDomain}/account/accept-transfer?token=${encodeURIComponent(token)}`;
 
   try {

--- a/src/server/lib/notifications/team-invite.ts
+++ b/src/server/lib/notifications/team-invite.ts
@@ -1,4 +1,5 @@
 import TeamInviteEmail from "@/emails/team-invite";
+import { getAppBaseDomain } from "@/lib/constants/domains";
 import { logger } from "@/lib/logger";
 
 import { resend } from "./resend-client";
@@ -26,7 +27,7 @@ export async function sendTeamInviteEmail({
 }: SendTeamInviteEmailInput) {
   if (!resend) return;
 
-  const baseDomain = process.env.NEXT_PUBLIC_APP_DOMAIN || "ishortn.ink";
+  const baseDomain = getAppBaseDomain();
   const inviteUrl = `https://${baseDomain}/teams/accept-invite?token=${encodeURIComponent(token)}`;
 
   try {

--- a/src/server/lib/workspace/workspace.service.ts
+++ b/src/server/lib/workspace/workspace.service.ts
@@ -2,6 +2,7 @@ import { TRPCError } from "@trpc/server";
 import { and, eq, isNull } from "drizzle-orm";
 
 import { resolvePlan } from "@/lib/billing/plans";
+import { extractPlatformSubdomain } from "@/lib/constants/domains";
 import { db } from "@/server/db";
 import { RESERVED_TEAM_SLUGS, team, teamMember } from "@/server/db/schema";
 
@@ -12,9 +13,13 @@ type DbClient = typeof db;
 /**
  * Extracts the subdomain from a hostname.
  *
+ * Any catalogue platform domain is accepted, so `acme.isht.ink` and
+ * `acme.ishortn.ink` both resolve to team slug `acme`.
+ *
  * Examples:
+ * - "acme.isht.ink" -> "acme"
  * - "acme.ishortn.ink" -> "acme"
- * - "ishortn.ink" -> null
+ * - "isht.ink" -> null
  * - "localhost:3000" -> null
  * - "acme.localhost:3000" -> "acme" (for local development)
  *
@@ -25,18 +30,7 @@ export function extractSubdomain(hostname: string): string | null {
   // Remove port if present
   const host = hostname.split(":")[0] ?? hostname;
 
-  let subdomain: string | null = null;
-
-  // Check for production subdomains (*.ishortn.ink)
-  if (host.endsWith(".ishortn.ink")) {
-    const parts = host.split(".");
-    if (parts.length === 3) {
-      const candidate = parts[0]?.trim().toLowerCase();
-      if (candidate && candidate.length > 0) {
-        subdomain = candidate;
-      }
-    }
-  }
+  let subdomain: string | null = extractPlatformSubdomain(host);
 
   // Check for local development subdomains (*.localhost)
   if (!subdomain && host.endsWith(".localhost")) {


### PR DESCRIPTION
## Summary

Introduces `isht.ink` as a second platform short-link domain alongside `ishortn.ink`, with `isht.ink` as the default for new links. Users can pick either from the link-creation dropdown; existing links on `ishortn.ink` continue to resolve unchanged.

Motivation: `ishortn.ink` has been flagged by some safe-browsing blocklists (common fate of URL shorteners). Running both domains hedges reputation risk — if one gets flagged, traffic can shift to the other. False-positive submissions for `ishortn.ink` are in flight.

## Changes

- New catalogue module `src/lib/constants/domains.ts` exposes `PLATFORM_DOMAINS`, `DEFAULT_PLATFORM_DOMAIN`, `isPlatformDomain()`, `getAppBaseDomain()`, `extractPlatformSubdomain()`.
- ~30 callsites updated: hardcoded `"ishortn.ink"` fallbacks replaced with `DEFAULT_PLATFORM_DOMAIN`; identity checks (`=== "ishortn.ink"`) replaced with `isPlatformDomain()`.
- Domain dropdowns (create link, settings, analytics filter, update modal, edit drawer) render from the catalogue.
- Team subdomain resolver in `workspace.service.ts` now accepts any catalogue suffix — `acme.isht.ink` and `acme.ishortn.ink` both resolve to team `acme`.
- Team-creation UI previews new teams as `slug.isht.ink`.
- Incidental bug fix: QR codes now resolve the tracking URL from the workspace's default domain (previously hardcoded to `ishortn.ink`, breaking QR tracking for users on custom domains).

Application-layer change only — no DB migration, no column default changes. Existing `ishortn.ink` rows are untouched and keep working.

## Type of Change

- [x] feat: New feature
- [x] fix: Bug fix (QR tracking URL)
- [x] refactor: Code refactoring

## Testing

- `bun run typecheck` clean on changed files (only pre-existing `pino` errors on `src/lib/logger/index.ts`, unrelated).
- Biome: 53 diagnostics on modified files before and after — zero new lint regressions.
- Manual verification recommended:
  - Create-link page (`/dashboard/link/new`): dropdown shows `isht.ink` first, both selectable.
  - New link without an explicit domain choice lands with `domain: "isht.ink"` in DB.
  - Existing `ishortn.ink/<alias>` links still resolve.
  - New team slug previews as `your-team.isht.ink`; existing `acme.ishortn.ink` subdomains still route to team `acme`.
  - QR code created in a workspace with a custom default domain uses that domain in the tracking URL.

## Related Issues

None.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Centralized platform domain management with support for multiple domains (ishortn.ink and isht.ink).
  * Domain selection dropdowns throughout the app now dynamically display all available platform domains.
  * Standardized domain resolution across links, QR codes, analytics, workspace invitations, and team management for consistent behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->