### PR TITLE
docs(changelog): announce isht.ink domain

### DIFF
--- a/content/changelogs/2026-04-19-isht-ink-domain.md
+++ b/content/changelogs/2026-04-19-isht-ink-domain.md
@@ -1,0 +1,25 @@
+---
+date: 2026-04-19T12:00:00
+version: 2.4.0
+title: Meet isht.ink
+shortDesc: A shorter default domain for your short links — ishortn.ink still works
+category: new
+---
+
+Your short links can now use **isht.ink** — four characters shorter than `ishortn.ink`, for links that need to fit tight spaces like SMS, print, and bios. It's the new default for new links, and the old domain continues to work exactly as before.
+
+## What's new
+
+When you create a link, the domain dropdown now shows both `isht.ink` and `ishortn.ink`. New links default to `isht.ink`. You can pick either one per link — or switch between them depending on the context.
+
+## Your existing links
+
+Nothing changes. Every link you've already created on `ishortn.ink` keeps resolving at the exact same URL. No redirects, no migrations, no broken QR codes, no dead links in printed material.
+
+## Teams
+
+Team workspaces can also live on the new domain. A team with slug `acme` is reachable at both `acme.isht.ink` and `acme.ishortn.ink` — either URL opens the same workspace.
+
+## Picking a default
+
+If you have custom domains verified, you can still set a preferred default from [Settings → General](/dashboard/settings/general). The dropdown now includes both platform domains alongside any custom domains you own.


### PR DESCRIPTION
## Summary

Adds a user-facing changelog entry for the `isht.ink` domain rollout that landed in #299. Frames the change as user choice (shorter domain option, existing links unchanged) without mentioning the underlying blocklist mitigation.

## Changes

- `content/changelogs/2026-04-19-isht-ink-domain.md` — single entry, `version: 2.4.0`, `category: new`.

## Type of Change

- [x] docs: Documentation

## Testing

Content-only. Renders through the existing changelog pipeline on merge.

## Related Issues

Follow-up to #299.