### PR TITLE
fix(landing): repair mobile responsiveness across marketing pages

### DIFF
--- a/src/app/(landing)/_components/cta.tsx
+++ b/src/app/(landing)/_components/cta.tsx
@@ -7,13 +7,12 @@ import { Icon } from "./warm-primitives";
 export const CTA = () => {
   return (
     <section
-      className="warm-section"
+      className="warm-section warm-cta"
       style={{
         background: "var(--warm-ink)",
         color: "var(--warm-paper)",
         position: "relative",
         overflow: "hidden",
-        padding: "160px 0",
       }}
     >
       <div
@@ -61,7 +60,7 @@ export const CTA = () => {
         </div>
         <h2
           className="warm-display"
-          style={{ margin: 0, fontSize: "clamp(72px, 12vw, 140px)" }}
+          style={{ margin: 0, fontSize: "clamp(52px, 14vw, 140px)", overflowWrap: "break-word" }}
         >
           Your links
           <br />

--- a/src/app/(landing)/_components/faq.tsx
+++ b/src/app/(landing)/_components/faq.tsx
@@ -109,13 +109,14 @@ export const Faq = ({ faqs = defaultFaqs }: { faqs?: FaqShape[] }) => {
               <button
                 type="button"
                 onClick={() => setOpen(open === i ? -1 : i)}
+                className="warm-faq-button"
                 style={{
                   width: "100%",
                   display: "flex",
                   justifyContent: "space-between",
                   alignItems: "center",
-                  padding: "26px 0",
-                  gap: 40,
+                  padding: "22px 0",
+                  gap: 16,
                   background: "transparent",
                   border: "none",
                   cursor: "pointer",
@@ -125,12 +126,13 @@ export const Faq = ({ faqs = defaultFaqs }: { faqs?: FaqShape[] }) => {
                 }}
               >
                 <span
+                  className="warm-faq-question"
                   style={{
                     fontFamily: "var(--font-warm-display)",
-                    fontSize: 24,
                     fontWeight: 500,
                     letterSpacing: "-0.015em",
                     lineHeight: 1.2,
+                    minWidth: 0,
                   }}
                 >
                   {it.q}
@@ -181,6 +183,15 @@ export const Faq = ({ faqs = defaultFaqs }: { faqs?: FaqShape[] }) => {
       </div>
       <style>{`
         .warm-faq-grid { grid-template-columns: 1fr; }
+        .warm-faq-question { font-size: 18px; }
+        .warm-faq-button { padding: 20px 0 !important; gap: 16px !important; }
+        @media (min-width: 480px) {
+          .warm-faq-question { font-size: 20px; }
+        }
+        @media (min-width: 768px) {
+          .warm-faq-question { font-size: 24px; }
+          .warm-faq-button { padding: 26px 0 !important; gap: 40px !important; }
+        }
         @media (min-width: 860px) {
           .warm-faq-grid { grid-template-columns: 340px 1fr; gap: 80px; }
           .warm-faq-intro { position: sticky; top: 100px; }

--- a/src/app/(landing)/_components/footer.tsx
+++ b/src/app/(landing)/_components/footer.tsx
@@ -53,7 +53,8 @@ export const Footer = () => {
       style={{
         background: "var(--warm-ink)",
         color: "var(--warm-paper)",
-        padding: "80px 0 40px",
+        padding: "64px 0 32px",
+        overflow: "hidden",
       }}
     >
       <div className="warm-container">
@@ -201,15 +202,16 @@ export const Footer = () => {
         <div
           aria-hidden
           style={{
-            marginTop: 60,
+            marginTop: 48,
             fontFamily: "var(--font-warm-display)",
-            fontSize: "clamp(120px, 20vw, 300px)",
+            fontSize: "clamp(80px, 20vw, 300px)",
             lineHeight: 0.8,
             color: "rgba(255,255,255,0.04)",
             letterSpacing: "-0.03em",
             textAlign: "center",
             userSelect: "none",
             fontStyle: "italic",
+            whiteSpace: "nowrap",
           }}
         >
           iShortn

--- a/src/app/(landing)/_components/hero.tsx
+++ b/src/app/(landing)/_components/hero.tsx
@@ -46,7 +46,7 @@ export const Hero = () => {
           </div>
           <h1
             className="warm-display warm-hero-title"
-            style={{ margin: 0, fontSize: "clamp(54px, 9vw, 104px)" }}
+            style={{ margin: 0, fontSize: "clamp(48px, 11vw, 104px)" }}
           >
             Links, made
             <br />
@@ -244,12 +244,11 @@ export const Hero = () => {
       </div>
 
       <div
-        className="warm-container"
+        className="warm-container warm-hero-featured"
         style={{
-          marginTop: 96,
+          marginTop: 72,
           display: "flex",
           alignItems: "center",
-          gap: 40,
           justifyContent: "center",
           flexWrap: "wrap",
         }}
@@ -266,9 +265,9 @@ export const Hero = () => {
         ].map((x) => (
           <span
             key={x}
+            className="warm-hero-featured-item"
             style={{
               fontFamily: "var(--font-warm-display)",
-              fontSize: 18,
               color: "var(--warm-ink-soft)",
               opacity: 0.7,
             }}
@@ -279,6 +278,21 @@ export const Hero = () => {
       </div>
 
       <style>{`
+        .warm-hero-featured {
+          gap: 16px 20px;
+        }
+        .warm-hero-featured-item {
+          font-size: 15px;
+        }
+        @media (min-width: 640px) {
+          .warm-hero-featured {
+            margin-top: 96px !important;
+            gap: 40px;
+          }
+          .warm-hero-featured-item {
+            font-size: 18px;
+          }
+        }
         .warm-hero-grid {
           grid-template-columns: 1fr;
         }

--- a/src/app/(landing)/blog/[slug]/page.tsx
+++ b/src/app/(landing)/blog/[slug]/page.tsx
@@ -106,7 +106,7 @@ export default async function BlogPostPage({ params }: BlogPostPageProps) {
         dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbSchema) }}
       />
 
-      <section style={{ padding: "120px 0 40px" }}>
+      <section className="warm-subhero">
         <div className="warm-container" style={{ maxWidth: 860 }}>
           <Link
             href="/blog"

--- a/src/app/(landing)/blog/page.tsx
+++ b/src/app/(landing)/blog/page.tsx
@@ -45,7 +45,7 @@ export default async function BlogPage() {
     <main style={{ background: "var(--warm-bg)", color: "var(--warm-ink)" }}>
       <Header />
 
-      <section style={{ padding: "120px 0 48px" }}>
+      <section className="warm-subhero">
         <div className="warm-container">
           <div className="warm-eyebrow" style={{ marginBottom: 24 }}>
             <Icon.Sparkle
@@ -55,7 +55,7 @@ export default async function BlogPage() {
           </div>
           <h1
             className="warm-display"
-            style={{ margin: 0, fontSize: "clamp(54px, 9vw, 104px)" }}
+            style={{ margin: 0, fontSize: "clamp(44px, 11vw, 104px)" }}
           >
             Writing from
             <br />

--- a/src/app/(landing)/changelog/_components/changelog-hero.tsx
+++ b/src/app/(landing)/changelog/_components/changelog-hero.tsx
@@ -11,7 +11,8 @@ export function ChangelogHero() {
           style={{
             margin: 0,
             maxWidth: 900,
-            fontSize: "clamp(54px, 9vw, 84px)",
+            fontSize: "clamp(44px, 9vw, 84px)",
+            overflowWrap: "break-word",
           }}
         >
           What we've{" "}
@@ -24,10 +25,10 @@ export function ChangelogHero() {
         </h1>
         <p
           style={{
-            fontSize: 19,
+            fontSize: 17,
             color: "var(--warm-ink-soft)",
             maxWidth: 620,
-            marginTop: 24,
+            marginTop: 20,
             lineHeight: 1.5,
           }}
         >

--- a/src/app/(landing)/changelog/_components/changelog-timeline.tsx
+++ b/src/app/(landing)/changelog/_components/changelog-timeline.tsx
@@ -100,11 +100,11 @@ export function ChangelogTimeline({ entries }: ChangelogTimelineProps) {
 
       <main>
         <section className="cl-subscribe">
-          <div style={{ flex: 1 }}>
+          <div style={{ flex: 1, minWidth: 0 }}>
             <div
+              className="cl-subscribe-title"
               style={{
                 fontFamily: "var(--font-warm-display)",
-                fontSize: 22,
                 fontWeight: 500,
                 letterSpacing: "-0.01em",
               }}
@@ -113,7 +113,7 @@ export function ChangelogTimeline({ entries }: ChangelogTimelineProps) {
             </div>
             <div
               style={{
-                fontSize: 14,
+                fontSize: 13,
                 color: "var(--warm-mute)",
                 marginTop: 4,
               }}

--- a/src/app/(landing)/compare/[slug]/page.tsx
+++ b/src/app/(landing)/compare/[slug]/page.tsx
@@ -85,7 +85,7 @@ export default async function ComparePage({
     <main style={{ background: "var(--warm-bg)", color: "var(--warm-ink)" }}>
       <Header />
 
-      <section style={{ padding: "120px 0 48px" }}>
+      <section className="warm-subhero">
         <div className="warm-container">
           <div className="warm-eyebrow" style={{ marginBottom: 24 }}>
             <Icon.Sparkle
@@ -95,7 +95,7 @@ export default async function ComparePage({
           </div>
           <h1
             className="warm-display"
-            style={{ margin: 0, fontSize: "clamp(54px, 9vw, 104px)" }}
+            style={{ margin: 0, fontSize: "clamp(44px, 11vw, 104px)" }}
           >
             {competitor.name}
             <br />

--- a/src/app/(landing)/features/page.tsx
+++ b/src/app/(landing)/features/page.tsx
@@ -32,7 +32,7 @@ export default function FeaturesPage() {
     <main style={{ background: "var(--warm-bg)", color: "var(--warm-ink)" }}>
       <Header />
 
-      <section style={{ padding: "120px 0 48px" }}>
+      <section className="warm-subhero">
         <div className="warm-container">
           <div className="warm-eyebrow" style={{ marginBottom: 24 }}>
             <Icon.Sparkle
@@ -42,7 +42,7 @@ export default function FeaturesPage() {
           </div>
           <h1
             className="warm-display"
-            style={{ margin: 0, fontSize: "clamp(54px, 9vw, 104px)", maxWidth: 980 }}
+            style={{ margin: 0, fontSize: "clamp(44px, 11vw, 104px)", maxWidth: 980 }}
           >
             Everything inside,
             <br />

--- a/src/app/(landing)/pricing/page.tsx
+++ b/src/app/(landing)/pricing/page.tsx
@@ -53,7 +53,7 @@ export default function PricingPage() {
     <main style={{ background: "var(--warm-bg)", color: "var(--warm-ink)" }}>
       <Header />
 
-      <section style={{ padding: "120px 0 48px" }}>
+      <section className="warm-subhero">
         <div className="warm-container">
           <div className="warm-eyebrow" style={{ marginBottom: 24 }}>
             <Icon.Heart
@@ -63,7 +63,7 @@ export default function PricingPage() {
           </div>
           <h1
             className="warm-display"
-            style={{ margin: 0, fontSize: "clamp(54px, 9vw, 104px)" }}
+            style={{ margin: 0, fontSize: "clamp(44px, 11vw, 104px)" }}
           >
             Fair prices,
             <br />

--- a/src/app/(landing)/privacy/page.tsx
+++ b/src/app/(landing)/privacy/page.tsx
@@ -20,7 +20,7 @@ export default function PrivacyPage() {
     <main style={{ background: "var(--warm-bg)", color: "var(--warm-ink)" }}>
       <Header />
 
-      <section style={{ padding: "96px 0 32px" }}>
+      <section className="warm-subhero">
         <div className="warm-container">
           <div className="warm-eyebrow" style={{ marginBottom: 24 }}>
             <span className="warm-eyebrow-dot" />
@@ -28,7 +28,7 @@ export default function PrivacyPage() {
           </div>
           <h1
             className="warm-display"
-            style={{ margin: 0, fontSize: "clamp(54px, 9vw, 104px)" }}
+            style={{ margin: 0, fontSize: "clamp(44px, 11vw, 104px)" }}
           >
             Privacy <em style={{ fontStyle: "italic", color: "var(--warm-accent)" }}>policy</em>.
           </h1>

--- a/src/app/(landing)/terms/page.tsx
+++ b/src/app/(landing)/terms/page.tsx
@@ -20,7 +20,7 @@ export default function TermsPage() {
     <main style={{ background: "var(--warm-bg)", color: "var(--warm-ink)" }}>
       <Header />
 
-      <section style={{ padding: "96px 0 32px" }}>
+      <section className="warm-subhero">
         <div className="warm-container">
           <div className="warm-eyebrow" style={{ marginBottom: 24 }}>
             <span className="warm-eyebrow-dot" />
@@ -28,7 +28,7 @@ export default function TermsPage() {
           </div>
           <h1
             className="warm-display"
-            style={{ margin: 0, fontSize: "clamp(54px, 9vw, 104px)" }}
+            style={{ margin: 0, fontSize: "clamp(44px, 11vw, 104px)" }}
           >
             Terms of <em style={{ fontStyle: "italic", color: "var(--warm-accent)" }}>service</em>.
           </h1>

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -239,6 +239,7 @@ html {
   letter-spacing: -0.02em;
   line-height: 0.98;
   font-variation-settings: "opsz" 144, "SOFT" 50;
+  overflow-wrap: break-word;
 }
 
 [data-theme="warm"] .warm-italic {
@@ -258,13 +259,42 @@ html {
 }
 
 [data-theme="warm"] .warm-section {
-  padding: 96px 0;
+  padding: 72px 0;
   position: relative;
+}
+
+@media (min-width: 640px) {
+  [data-theme="warm"] .warm-section {
+    padding: 96px 0;
+  }
 }
 
 @media (min-width: 768px) {
   [data-theme="warm"] .warm-section {
     padding: 120px 0;
+  }
+}
+
+[data-theme="warm"] .warm-cta {
+  padding: 96px 0;
+}
+@media (min-width: 768px) {
+  [data-theme="warm"] .warm-cta {
+    padding: 160px 0;
+  }
+}
+
+[data-theme="warm"] .warm-subhero {
+  padding: 72px 0 32px;
+}
+@media (min-width: 640px) {
+  [data-theme="warm"] .warm-subhero {
+    padding: 96px 0 40px;
+  }
+}
+@media (min-width: 768px) {
+  [data-theme="warm"] .warm-subhero {
+    padding: 120px 0 48px;
   }
 }
 
@@ -384,15 +414,23 @@ html {
 
 /* Changelog — warm variant specific styles */
 [data-theme="warm"] .cl-head {
-  padding: 80px 0 48px;
+  padding: 48px 0 32px;
   border-bottom: 1px solid var(--warm-line-soft);
+}
+@media (min-width: 768px) {
+  [data-theme="warm"] .cl-head {
+    padding: 80px 0 48px;
+  }
 }
 [data-theme="warm"] .cl-grid {
   display: grid;
   grid-template-columns: 1fr;
-  gap: 48px;
-  padding: 48px 0 120px;
+  gap: 32px;
+  padding: 32px 0 96px;
   align-items: start;
+}
+[data-theme="warm"] .cl-grid > * {
+  min-width: 0;
 }
 @media (min-width: 900px) {
   [data-theme="warm"] .cl-grid {
@@ -403,12 +441,6 @@ html {
 }
 [data-theme="warm"] .cl-rail {
   font-size: 13px;
-}
-@media (min-width: 900px) {
-  [data-theme="warm"] .cl-rail {
-    position: sticky;
-    top: 100px;
-  }
 }
 [data-theme="warm"] .cl-rail-label {
   font-size: 11px;
@@ -434,11 +466,66 @@ html {
   border-color: var(--warm-accent);
   font-weight: 500;
 }
+@media (max-width: 899px) {
+  [data-theme="warm"] .cl-rail {
+    display: flex;
+    flex-wrap: nowrap;
+    align-items: center;
+    gap: 8px;
+    overflow-x: auto;
+    padding-bottom: 8px;
+    margin: 0 -24px;
+    padding-left: 24px;
+    padding-right: 24px;
+    scrollbar-width: none;
+  }
+  [data-theme="warm"] .cl-rail::-webkit-scrollbar {
+    display: none;
+  }
+  [data-theme="warm"] .cl-rail .cl-rail-label {
+    display: none;
+  }
+  [data-theme="warm"] .cl-rail a {
+    display: inline-flex;
+    align-items: center;
+    flex: 0 0 auto;
+    padding: 6px 12px;
+    margin: 0;
+    border-radius: 999px;
+    border: 1px solid var(--warm-line);
+    border-left: 1px solid var(--warm-line);
+    background: var(--warm-paper);
+    white-space: nowrap;
+  }
+  [data-theme="warm"] .cl-rail a > div:last-child {
+    display: none;
+  }
+  [data-theme="warm"] .cl-rail a.cl-rail-active {
+    background: var(--warm-accent);
+    border-color: var(--warm-accent);
+    color: var(--warm-accent-ink);
+  }
+  [data-theme="warm"] .cl-rail > div:last-child {
+    display: none;
+  }
+}
+@media (min-width: 900px) {
+  [data-theme="warm"] .cl-rail {
+    position: sticky;
+    top: 100px;
+  }
+}
 
 [data-theme="warm"] .cl-entry {
   display: grid;
   grid-template-columns: 1fr;
-  margin-bottom: 96px;
+  margin-bottom: 72px;
+  min-width: 0;
+}
+@media (min-width: 768px) {
+  [data-theme="warm"] .cl-entry {
+    margin-bottom: 96px;
+  }
 }
 [data-theme="warm"] .cl-entry-meta {
   display: flex;
@@ -468,10 +555,16 @@ html {
   font-family: var(--font-warm-display);
   font-weight: 400;
   letter-spacing: -0.025em;
-  font-size: 36px;
+  font-size: 30px;
   line-height: 1.05;
   margin: 0 0 8px;
   font-variation-settings: "opsz" 144, "SOFT" 50;
+  overflow-wrap: break-word;
+}
+@media (min-width: 480px) {
+  [data-theme="warm"] .cl-entry-title {
+    font-size: 36px;
+  }
 }
 @media (min-width: 768px) {
   [data-theme="warm"] .cl-entry-title {
@@ -513,6 +606,8 @@ html {
   color: var(--warm-ink-soft);
   font-size: 15px;
   line-height: 1.7;
+  overflow-wrap: anywhere;
+  word-break: break-word;
 }
 [data-theme="warm"] .cl-entry-prose p {
   margin: 0 0 14px;
@@ -622,11 +717,12 @@ html {
   background: var(--warm-paper);
   border: 1px solid var(--warm-line);
   border-radius: var(--warm-radius-lg);
-  padding: 28px;
+  padding: 20px;
   display: flex;
   flex-direction: column;
-  gap: 20px;
-  margin-bottom: 60px;
+  gap: 16px;
+  margin-bottom: 48px;
+  min-width: 0;
 }
 @media (min-width: 720px) {
   [data-theme="warm"] .cl-subscribe {
@@ -636,27 +732,65 @@ html {
     padding: 36px 40px;
   }
 }
+[data-theme="warm"] .cl-subscribe > div:first-child {
+  min-width: 0;
+}
+[data-theme="warm"] .cl-subscribe-title {
+  font-size: 18px;
+}
+@media (min-width: 480px) {
+  [data-theme="warm"] .cl-subscribe-title {
+    font-size: 20px;
+  }
+}
+@media (min-width: 720px) {
+  [data-theme="warm"] .cl-subscribe-title {
+    font-size: 22px;
+  }
+}
 [data-theme="warm"] .cl-subscribe-form {
   display: flex;
   background: var(--warm-bg);
   border-radius: 999px;
-  padding: 6px;
+  padding: 5px;
   border: 1px solid var(--warm-line);
-  flex: 1;
-  max-width: 420px;
+  width: 100%;
+  flex-shrink: 1;
+}
+@media (min-width: 720px) {
+  [data-theme="warm"] .cl-subscribe-form {
+    flex: 1;
+    max-width: 420px;
+    padding: 6px;
+  }
 }
 [data-theme="warm"] .cl-subscribe-form input {
   flex: 1;
-  padding: 10px 16px;
+  padding: 10px 14px;
   background: transparent;
   border: 0;
   outline: 0;
   font-size: 14px;
   min-width: 0;
+  width: 100%;
   color: var(--warm-ink);
+}
+@media (min-width: 720px) {
+  [data-theme="warm"] .cl-subscribe-form input {
+    padding: 10px 16px;
+  }
 }
 [data-theme="warm"] .cl-subscribe-form input::placeholder {
   color: var(--warm-mute-soft);
+}
+[data-theme="warm"] .cl-subscribe-form button {
+  flex-shrink: 0;
+  padding: 10px 16px;
+}
+@media (min-width: 720px) {
+  [data-theme="warm"] .cl-subscribe-form button {
+    padding: 10px 20px;
+  }
 }
 
 [data-theme="warm"] .cl-older {


### PR DESCRIPTION
## Summary

The changelog page and other marketing pages had horizontal overflow and oversized typography on narrow viewports. This PR addresses the root causes (grid-item min-width, min font-size floors, outsized padding) across the landing surface.

## Changes

### Changelog
- Add `min-width: 0` to `.cl-grid > *` — fixes the horizontal scrollbar caused by the default `min-width: auto` on grid items letting prose content push the track wider than the viewport.
- Collapse the releases rail into a horizontal scrollable pill strip below 900px so it stops occupying a full mobile screen.
- Responsive subscribe card: full-width form, scaled title (18 -> 20 -> 22px), input/button padding scales down.
- Entry title scales 30 -> 36 -> 44px; prose gets `overflow-wrap: anywhere` to break long tokens.
- Hero padding and title clamp floor reduced.

### Other landing pages
- Lowered the `clamp` floor on page `<h1>` from 54px to 44px (48px on the home hero) so headings fit narrow phones.
- CTA heading: `clamp(72px, 12vw, 140px)` -> `clamp(52px, 14vw, 140px)`; CTA vertical padding now responsive (96 -> 160px).
- Added `.warm-subhero` utility (72 -> 96 -> 120px top padding by breakpoint); applied to pricing, features, blog, blog post, compare, privacy, and terms hero sections.
- FAQ button: reduced mobile gap (40 -> 16px) and question size (24 -> 18px).
- Footer: `overflow: hidden`, decorative wordmark min 120 -> 80px + `white-space: nowrap`.
- Hero "Featured on" row: responsive gap and font size.
- Global `.warm-display` gains `overflow-wrap: break-word`; `.warm-section` padding 96 -> 72px on narrow mobile.

## Type of Change

- [x] fix: Bug fix

## Test plan

- [x] `bun run typecheck` passes
- [x] All landing routes return 200 under `bun dev`
- [ ] Visual QA on /, /changelog, /pricing, /features, /blog, /compare/bitly, /privacy, /terms at ~390px and ~768px viewports
- [ ] Confirm no horizontal page scrollbar appears on any landing page at mobile widths
- [ ] Confirm the changelog releases rail works as a horizontal pill strip on mobile and reverts to the sticky sidebar at >=900px

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined responsive typography across landing pages, blog, and changelog sections for improved readability at different screen sizes.
  * Adjusted spacing and padding consistency throughout the site.
  * Enhanced text wrapping for long titles and headings to prevent overflow.
  * Improved responsive layout behavior with better mobile-to-desktop transitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->