### PR TITLE
feat(qrcode): allow choosing a custom domain on QR creation

### DIFF
--- a/src/app/(main)/dashboard/qrcodes/create/page.tsx
+++ b/src/app/(main)/dashboard/qrcodes/create/page.tsx
@@ -5,7 +5,6 @@ import {
   IconDownload,
   IconLoader2,
   IconRefresh,
-  IconSparkles,
   IconTrash,
 } from "@tabler/icons-react";
 import { useTransitionRouter } from "next-view-transitions";
@@ -28,6 +27,15 @@ import {
 } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { DEFAULT_PLATFORM_DOMAIN, PLATFORM_DOMAINS } from "@/lib/constants/domains";
 import { cn } from "@/lib/utils";
 import { api } from "@/trpc/react";
 import { generateQRCode, defaultGeneratorState } from "@/lib/qr-generator";
@@ -57,6 +65,23 @@ function QRCodeCreationPage() {
 
   const [qrCodeTitle, setQRCodeTitle] = useState<string>("");
   const [destinationUrl, setDestinationUrl] = useState<string>("");
+  const [selectedDomain, setSelectedDomain] = useState<string>(
+    DEFAULT_PLATFORM_DOMAIN,
+  );
+
+  const customDomainsQuery = api.customDomain.list.useQuery();
+  const userDomains = customDomainsQuery.data ?? [];
+
+  const destinationLooksValid = useMemo(() => {
+    const value = destinationUrl.trim();
+    if (!value || !value.includes(".")) return false;
+    try {
+      const url = new URL(value.includes("://") ? value : `https://${value}`);
+      return url.hostname.includes(".");
+    } catch {
+      return false;
+    }
+  }, [destinationUrl]);
 
   // Advanced QR state using the new generator
   const [qrState, setQrState] = useState<QRCodeGeneratorState>(() => ({
@@ -257,6 +282,7 @@ function QRCodeCreationPage() {
         patternStyle: qrState.pixelStyle as string,
         cornerStyle: qrState.markerShape as string,
         selectedColor: qrState.darkColor,
+        domain: selectedDomain,
       });
 
       try {
@@ -311,7 +337,7 @@ function QRCodeCreationPage() {
   return (
     <section className="grid grid-cols-1 gap-5 md:grid-cols-11">
       {/* Left Column - Configuration */}
-      <div className="md:col-span-5">
+      <div className="min-w-0 md:col-span-5">
         <h2 className="text-xl font-semibold tracking-tight text-neutral-900 dark:text-foreground">
           Create a QR code
         </h2>
@@ -352,6 +378,36 @@ function QRCodeCreationPage() {
                 The URL people will be redirected to when scanning the QR code
               </p>
             </div>
+
+            {destinationLooksValid && (
+              <div className="space-y-1.5">
+                <Label className="text-[13px] font-medium text-neutral-700 dark:text-neutral-300">
+                  Link domain
+                </Label>
+                <Select value={selectedDomain} onValueChange={setSelectedDomain}>
+                  <SelectTrigger className="h-9 w-full border-neutral-200 dark:border-border bg-white dark:bg-card text-[13px] text-neutral-700 dark:text-neutral-300">
+                    <SelectValue placeholder={DEFAULT_PLATFORM_DOMAIN} />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectGroup>
+                      {PLATFORM_DOMAINS.map((domain) => (
+                        <SelectItem key={domain} value={domain}>
+                          {domain}
+                        </SelectItem>
+                      ))}
+                      {userDomains.map((domain) => (
+                        <SelectItem key={domain.id} value={domain.domain!}>
+                          {domain.domain}
+                        </SelectItem>
+                      ))}
+                    </SelectGroup>
+                  </SelectContent>
+                </Select>
+                <p className="text-[12px] text-neutral-400 dark:text-neutral-500">
+                  Pick the domain shown when someone scans your QR code.
+                </p>
+              </div>
+            )}
           </div>
 
           {/* Design Section */}
@@ -455,45 +511,40 @@ function QRCodeCreationPage() {
                 </div>
               ) : presets && presets.length > 0 ? (
                 <div className="space-y-2">
+                  <span className="text-[12px] font-medium text-neutral-400 dark:text-neutral-500">
+                    Saved Presets
+                  </span>
                   <div className="flex items-center gap-2">
-                    <IconSparkles
-                      size={14}
-                      stroke={1.5}
-                      className="text-blue-500"
-                    />
-                    <span className="text-[12px] font-medium text-neutral-400 dark:text-neutral-500">
-                      Saved Presets
-                    </span>
-                  </div>
-                  <div className="flex flex-wrap gap-2">
-                    {presets.map((preset) => (
-                      <div
-                        key={preset.id}
-                        className={cn(
-                          "group relative inline-flex items-center gap-1.5 rounded-md border px-2.5 py-1.5 text-[12px] font-medium cursor-pointer transition-colors",
-                          selectedPresetId === preset.id
-                            ? "border-blue-500 bg-blue-50 dark:bg-blue-500/10 text-blue-700"
-                            : "border-neutral-200 dark:border-border text-neutral-600 dark:text-neutral-400 hover:bg-neutral-50 dark:hover:bg-accent/50",
-                        )}
-                        onClick={() => loadPreset(preset.id)}
+                    <Select
+                      value={selectedPresetId ? String(selectedPresetId) : undefined}
+                      onValueChange={(value) => loadPreset(Number(value))}
+                    >
+                      <SelectTrigger className="h-9 flex-1 border-neutral-200 dark:border-border bg-white dark:bg-card text-[13px] text-neutral-700 dark:text-neutral-300">
+                        <SelectValue placeholder="Select a preset" />
+                      </SelectTrigger>
+                      <SelectContent>
+                        <SelectGroup>
+                          {presets.map((preset) => (
+                            <SelectItem key={preset.id} value={String(preset.id)}>
+                              {preset.name}
+                            </SelectItem>
+                          ))}
+                        </SelectGroup>
+                      </SelectContent>
+                    </Select>
+                    {selectedPresetId !== null && (
+                      <button
+                        type="button"
+                        aria-label="Delete selected preset"
+                        className="inline-flex h-9 w-9 shrink-0 items-center justify-center rounded-md border border-neutral-200 dark:border-border text-neutral-500 transition-colors hover:border-red-200 hover:bg-red-50 hover:text-red-600 disabled:cursor-not-allowed disabled:opacity-50 dark:hover:bg-red-500/10"
+                        onClick={() =>
+                          deletePresetMutation.mutate({ id: selectedPresetId })
+                        }
+                        disabled={deletePresetMutation.isLoading}
                       >
-                        <span>{preset.name}</span>
-                        <button
-                          type="button"
-                          className="rounded p-0.5 opacity-0 transition-all hover:bg-red-100 group-hover:opacity-100"
-                          onClick={(e) => {
-                            e.stopPropagation();
-                            deletePresetMutation.mutate({ id: preset.id });
-                          }}
-                        >
-                          <IconTrash
-                            size={12}
-                            stroke={1.5}
-                            className="text-red-500"
-                          />
-                        </button>
-                      </div>
-                    ))}
+                        <IconTrash size={14} stroke={1.5} />
+                      </button>
+                    )}
                   </div>
                 </div>
               ) : (
@@ -572,7 +623,7 @@ function QRCodeCreationPage() {
       </div>
 
       {/* Right Column - Preview */}
-      <div className="mt-4 flex flex-col gap-4 md:col-span-5 md:mt-0">
+      <div className="mt-4 flex min-w-0 flex-col gap-4 md:col-span-5 md:mt-0">
         <div className="flex flex-col gap-1">
           <h2 className="text-xl font-semibold tracking-tight text-neutral-900 dark:text-foreground">
             Preview

--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -77,7 +77,7 @@ const SelectContent = React.forwardRef<
       className={cn(
         "relative z-50 max-h-[--radix-select-content-available-height] min-w-[8rem] overflow-y-auto overflow-x-hidden rounded-xl border border-gray-200 dark:border-border bg-white dark:bg-card p-1.5 text-gray-900 dark:text-foreground shadow-lg dark:shadow-black/20 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-[--radix-select-content-transform-origin]",
         position === "popper" &&
-          "data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1",
+          "w-[var(--radix-select-trigger-width)] data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1",
         className
       )}
       position={position}

--- a/src/server/api/routers/link/link.service.ts
+++ b/src/server/api/routers/link/link.service.ts
@@ -66,6 +66,7 @@ import {
 import { associateTagsWithLink, getTagsForLink } from "../tag/tag.service";
 
 import {
+  assertDomainAllowed,
   checkWorkspaceLinkLimit,
   getWorkspaceDefaultDomain,
   incrementWorkspaceLinkCount,
@@ -340,6 +341,7 @@ export const createLink = async (
   const isPaidPlan = plan !== "free";
 
   const domain = input.domain?.trim() || DEFAULT_PLATFORM_DOMAIN;
+  await assertDomainAllowed(ctx, domain);
   const alias =
     input.alias && input.alias !== "" ? input.alias : await generateShortLink();
 
@@ -528,6 +530,12 @@ export const updateLink = async (
   // Use workspace plan - team workspaces have Ultra features
   const workspacePlan = ctx.workspace.plan;
   const isPaidUser = workspacePlan !== "free";
+
+  // If domain is being changed, it must be platform-owned or a verified
+  // custom domain for this workspace.
+  if (input.domain !== undefined && input.domain !== existingLink.domain) {
+    await assertDomainAllowed(ctx, input.domain);
+  }
 
   // If alias is being changed, validate it
   if (input.alias && input.alias !== existingLink.alias) {

--- a/src/server/api/routers/link/utils.ts
+++ b/src/server/api/routers/link/utils.ts
@@ -1,10 +1,10 @@
 import { TRPCError } from "@trpc/server";
 import { and, eq, sql } from "drizzle-orm";
 
-import { DEFAULT_PLATFORM_DOMAIN } from "@/lib/constants/domains";
+import { DEFAULT_PLATFORM_DOMAIN, isPlatformDomain } from "@/lib/constants/domains";
 import { redis } from "@/lib/core/cache";
 import { normalizeAlias } from "@/lib/utils";
-import { link, team, user } from "@/server/db/schema";
+import { customDomain, link, team, user } from "@/server/db/schema";
 import { getUserPlanContext, normalizeMonthlyLinkCount } from "@/server/lib/user-plan";
 import { workspaceFilter } from "@/server/lib/workspace";
 
@@ -165,6 +165,35 @@ export async function getWorkspaceDefaultDomain(ctx: WorkspaceTRPCContext): Prom
 
   // Personal workspace: use user's default domain
   return getUserDefaultDomain(ctx);
+}
+
+/**
+ * Guards against clients submitting arbitrary `domain` values on link/QR
+ * writes. Accepts platform-owned domains, or custom domains that are both
+ * verified ("active") and scoped to the caller's workspace. Throws on
+ * anything else — DNS is case-insensitive, so we normalize before lookup.
+ */
+export async function assertDomainAllowed(
+  ctx: WorkspaceTRPCContext,
+  domain: string,
+): Promise<void> {
+  const normalized = domain.trim().toLowerCase();
+  if (isPlatformDomain(normalized)) return;
+
+  const owned = await ctx.db.query.customDomain.findFirst({
+    where: and(
+      sql`lower(${customDomain.domain}) = ${normalized}`,
+      eq(customDomain.status, "active"),
+      workspaceFilter(ctx.workspace, customDomain.userId, customDomain.teamId),
+    ),
+  });
+
+  if (!owned) {
+    throw new TRPCError({
+      code: "FORBIDDEN",
+      message: "Selected domain is not available for this workspace.",
+    });
+  }
 }
 
 const MINIMUM_ALIAS_LENGTH_FREE = 6;

--- a/src/server/api/routers/qrcode/qrcode.input.ts
+++ b/src/server/api/routers/qrcode/qrcode.input.ts
@@ -8,6 +8,7 @@ export const qrcodeInput = z.object({
   patternStyle: z.string(),
   cornerStyle: z.string(),
   selectedColor: z.string(),
+  domain: z.string().optional(),
 });
 
 export const qrcodeSaveImageInput = z.object({

--- a/src/server/api/routers/qrcode/qrcode.service.ts
+++ b/src/server/api/routers/qrcode/qrcode.service.ts
@@ -13,6 +13,7 @@ import {
   workspaceOwnership,
 } from "@/server/lib/workspace";
 import {
+  assertDomainAllowed,
   checkWorkspaceLinkLimit,
   getWorkspaceDefaultDomain,
 } from "../link/utils";
@@ -93,9 +94,13 @@ export const createQrCode = userFacing(
 
     await assertUrlSafe(input.content);
 
+    const requestedDomain = input.domain?.trim();
+    if (requestedDomain) {
+      await assertDomainAllowed(ctx, requestedDomain);
+    }
     const [alias, domain] = await Promise.all([
       generateShortLink(),
-      getWorkspaceDefaultDomain(ctx),
+      requestedDomain ? Promise.resolve(requestedDomain) : getWorkspaceDefaultDomain(ctx),
     ]);
     const trackingUrl = `https://${domain}/${alias}`;
 


### PR DESCRIPTION
## Summary

Adds custom domain selection to QR code creation, hardens server-side authorization on every code path that writes a tracking domain, and locks the shared Select dropdown width to its trigger.

## Changes

- **feat(qrcode):** new "Link domain" selector on QR create lists the workspace's platform domains plus verified custom domains. Hidden until the destination URL parses as a URL/host so it stays out of the way for new users. The resolved domain is plumbed through `createQrCode` and persisted on the hidden tracking link.
- **fix(domains):** new `assertDomainAllowed(ctx, domain)` helper in `link/utils.ts`. Wired into `createQrCode`, `createLink`, and `updateLink` (the latter only when the domain is actually changing). Closes a pre-existing gap where the link create/update path trusted client-supplied `domain` values.
- **fix(ui):** `SelectContent` sets `w-[var(--radix-select-trigger-width)]` when `position="popper"` (the shadcn default) so every Select dropdown matches its trigger width.
- **UX cleanup on the QR create page:** saved presets are a Select with a delete button instead of a chip cluster; grid columns get `min-w-0` so a long selected domain in any nowrap child cannot force horizontal scroll.

## Type of Change

- [x] feat: New feature
- [x] fix: Bug fix

## Test plan

- [ ] Create a QR with the default platform domain — encoded URL uses `isht.ink`.
- [ ] Create a QR with a verified custom domain — encoded URL uses that host.
- [ ] Submit a domain the workspace does not own via a crafted request — rejected with `FORBIDDEN`.
- [ ] Edit a regular short link and change the domain to one the workspace does not own — rejected with `FORBIDDEN`.
- [ ] Open every Select on the QR create page — dropdown matches trigger width.
- [ ] Resize narrow viewport on the QR create page — no horizontal scroll.

Made with [Orca](https://github.com/stablyai/orca) 🐋


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added domain selection when creating QR codes (available with valid destination URL)
  * Refactored "Saved Presets" UI from multi-pill list to dropdown select with dedicated delete button

* **Bug Fixes**
  * Enhanced domain validation to ensure only eligible domains can be used for QR codes and links

* **UI Improvements**
  * Improved dropdown styling consistency across the application

<!-- end of auto-generated comment: release notes by coderabbit.ai -->