### PR TITLE
fix(domains): pin authenticated team URLs to ishortn.ink

### DIFF
--- a/src/app/(main)/dashboard/teams/new/page.tsx
+++ b/src/app/(main)/dashboard/teams/new/page.tsx
@@ -23,7 +23,7 @@ import {
   FormMessage,
 } from "@/components/ui/form";
 import { Input } from "@/components/ui/input";
-import { DEFAULT_PLATFORM_DOMAIN, getAppBaseDomain } from "@/lib/constants/domains";
+import { APP_BASE_DOMAIN, getAppBaseDomain } from "@/lib/constants/domains";
 import { api } from "@/trpc/react";
 
 const slugRegex = /^[a-z0-9][a-z0-9-]*[a-z0-9]$|^[a-z0-9]$/;
@@ -190,7 +190,7 @@ export default function CreateTeamPage() {
                         }}
                       />
                       <span className="inline-flex h-9 items-center rounded-r-lg border border-l-0 border-neutral-200 dark:border-border bg-neutral-50 dark:bg-accent/50 px-3 text-[13px] text-neutral-400 dark:text-neutral-500">
-                        .{DEFAULT_PLATFORM_DOMAIN}
+                        .{APP_BASE_DOMAIN}
                       </span>
                     </div>
                   </FormControl>
@@ -249,7 +249,7 @@ export default function CreateTeamPage() {
           <p className="text-[12px] leading-relaxed text-neutral-400 dark:text-neutral-500">
             Your team will have its own workspace at{" "}
             <span className="font-mono text-neutral-600 dark:text-neutral-400">
-              {slug || "your-team"}.{DEFAULT_PLATFORM_DOMAIN}
+              {slug || "your-team"}.{APP_BASE_DOMAIN}
             </span>
             . You&apos;ll be the owner with full access and can invite members after setup.
           </p>

--- a/src/app/(main)/dashboard/teams/settings/page.tsx
+++ b/src/app/(main)/dashboard/teams/settings/page.tsx
@@ -33,7 +33,7 @@ import {
   FormMessage,
 } from "@/components/ui/form";
 import { Input } from "@/components/ui/input";
-import { DEFAULT_PLATFORM_DOMAIN, getAppBaseDomain } from "@/lib/constants/domains";
+import { APP_BASE_DOMAIN, getAppBaseDomain } from "@/lib/constants/domains";
 import { api } from "@/trpc/react";
 
 const slugRegex = /^[a-z0-9][a-z0-9-]*[a-z0-9]$|^[a-z0-9]$/;
@@ -303,7 +303,7 @@ export default function TeamSettingsPage() {
                               }
                             />
                             <span className="inline-flex h-9 items-center rounded-r-lg border border-l-0 border-neutral-200 dark:border-border bg-neutral-50 dark:bg-accent/50 px-3 text-[13px] text-neutral-400 dark:text-neutral-500">
-                              .{DEFAULT_PLATFORM_DOMAIN}
+                              .{APP_BASE_DOMAIN}
                             </span>
                           </div>
                         </FormControl>

--- a/src/lib/constants/domains.ts
+++ b/src/lib/constants/domains.ts
@@ -18,9 +18,12 @@ export function isPlatformDomain(domain: string | null | undefined): domain is P
 
 // Base host for authenticated app URLs (team invites, workspace switching,
 // accept-invite redirects). Keep this separate from DEFAULT_PLATFORM_DOMAIN so
-// Clerk-authenticated pages stay on the domain configured in Clerk.
+// Clerk-authenticated pages stay on the domain configured in Clerk. Honor
+// NEXT_PUBLIC_APP_DOMAIN so staging/dev can point email and absolute-URL flows
+// at a non-prod host instead of baking ishortn.ink into outbound links.
 export function getAppBaseDomain(): string {
-  return APP_BASE_DOMAIN;
+  const configured = process.env.NEXT_PUBLIC_APP_DOMAIN?.trim();
+  return configured || APP_BASE_DOMAIN;
 }
 
 // Returns the leading label when `host` is a team subdomain of a platform

--- a/src/lib/constants/domains.ts
+++ b/src/lib/constants/domains.ts
@@ -1,5 +1,5 @@
 // Platform-provided short-link domains. First entry is the default for new
-// links and the preferred host for marketing/team subdomain previews. All
+// links and the preferred host for short-link previews. All
 // entries must be wired at the infrastructure layer (DNS + SSL + host) and
 // resolve to this Next.js app.
 export const PLATFORM_DOMAINS = ["isht.ink", "ishortn.ink"] as const;
@@ -8,14 +8,19 @@ export type PlatformDomain = (typeof PLATFORM_DOMAINS)[number];
 
 export const DEFAULT_PLATFORM_DOMAIN: PlatformDomain = PLATFORM_DOMAINS[0];
 
+// Clerk is configured on the full iShortn domain, so authenticated app/team
+// navigation must stay on this host instead of the shorter link domain.
+export const APP_BASE_DOMAIN = "ishortn.ink";
+
 export function isPlatformDomain(domain: string | null | undefined): domain is PlatformDomain {
   return !!domain && (PLATFORM_DOMAINS as readonly string[]).includes(domain);
 }
 
-// Base host for user-facing app URLs (team invites, workspace switching,
-// accept-invite redirects). Respects NEXT_PUBLIC_APP_DOMAIN override.
+// Base host for authenticated app URLs (team invites, workspace switching,
+// accept-invite redirects). Keep this separate from DEFAULT_PLATFORM_DOMAIN so
+// Clerk-authenticated pages stay on the domain configured in Clerk.
 export function getAppBaseDomain(): string {
-  return process.env.NEXT_PUBLIC_APP_DOMAIN || DEFAULT_PLATFORM_DOMAIN;
+  return APP_BASE_DOMAIN;
 }
 
 // Returns the leading label when `host` is a team subdomain of a platform


### PR DESCRIPTION
## Summary

Team navigation from `isht.ink` was breaking because every team URL was built from `DEFAULT_PLATFORM_DOMAIN` (`isht.ink`), but Clerk is configured on `ishortn.ink`. Cross-parent-domain hops dropped the session, so users landed on team subdomains logged out.

## Changes

- Add `APP_BASE_DOMAIN = "ishortn.ink"` to make the authenticated host explicit and decoupled from the short-link platform default.
- `getAppBaseDomain()` now returns `APP_BASE_DOMAIN` (no longer falls through to `DEFAULT_PLATFORM_DOMAIN` or reads `NEXT_PUBLIC_APP_DOMAIN`), so workspace switcher, team create/settings/leave/delete redirects, accept-invite redirects, and invite URLs all stay on `ishortn.ink`.
- Update the team create and settings slug previews to render `slug.ishortn.ink` instead of `slug.isht.ink`, so the hint matches where the user actually lands.

Short-link resolution is unchanged — `isht.ink` and `ishortn.ink` both still resolve links via `PLATFORM_DOMAINS`, and `extractPlatformSubdomain` still accepts team subdomains under either suffix.

## Type of Change

- [x] fix: Bug fix

## Testing

- Manual: from `isht.ink/dashboard`, switch to a team workspace and confirm it navigates to `<slug>.ishortn.ink/dashboard` with the Clerk session intact.
- Manual: create a team and verify the preview reads `<slug>.ishortn.ink`.
- Manual: accept a team invite and confirm the post-accept redirect lands on `<slug>.ishortn.ink/dashboard`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated domain configuration throughout the application to ensure consistent handling of the app's base domain across team creation and settings pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->