### PR TITLE
fix: respect saved default domain in v1 api

### DIFF
--- a/src/app/api/v1/analytics/[alias]/route.ts
+++ b/src/app/api/v1/analytics/[alias]/route.ts
@@ -1,8 +1,11 @@
-import { DEFAULT_PLATFORM_DOMAIN } from "@/lib/constants/domains";
 import { aggregateVisits } from "@/lib/core/analytics";
 import { db } from "@/server/db";
 
-import { validateAndGetToken } from "../../utils";
+import {
+  getApiDomainParamsFromSearchParams,
+  resolveApiDomainForUser,
+  validateAndGetToken,
+} from "../../utils";
 
 import type { NextRequest } from "next/server";
 export async function GET(request: NextRequest, props: { params: Promise<{ alias: string }> }) {
@@ -10,14 +13,15 @@ export async function GET(request: NextRequest, props: { params: Promise<{ alias
   const alias = params.alias;
   const apiKey = request.headers.get("x-api-key");
 
-  const searchParams = request.nextUrl.searchParams
-  const query = searchParams.get('domain')
-  const domain = query?.trim() || DEFAULT_PLATFORM_DOMAIN
-
   const token = await validateAndGetToken(apiKey);
   if (!token) {
     return new Response("Invalid or missing API key", { status: 401 });
   }
+
+  const domain = await resolveApiDomainForUser(
+    token.userId,
+    getApiDomainParamsFromSearchParams(request.nextUrl.searchParams),
+  );
 
   const link = await db.query.link.findFirst({
     where: (table, { eq, and }) => and(eq(table.alias, alias), eq(table.domain, domain)),

--- a/src/app/api/v1/links/[alias]/route.ts
+++ b/src/app/api/v1/links/[alias]/route.ts
@@ -1,11 +1,14 @@
 import { and, eq } from "drizzle-orm";
 
-import { DEFAULT_PLATFORM_DOMAIN } from "@/lib/constants/domains";
 import { logger } from "@/lib/logger";
 import { db } from "@/server/db";
 import { link } from "@/server/db/schema";
 
-import { validateAndGetToken } from "../../utils";
+import {
+  getApiDomainParamsFromSearchParams,
+  resolveApiDomainForUser,
+  validateAndGetToken,
+} from "../../utils";
 
 import type { NextRequest } from "next/server";
 
@@ -16,14 +19,15 @@ export async function GET(request: NextRequest, props: { params: Promise<{ alias
   const alias = params.alias;
   const apiKey = request.headers.get("x-api-key");
 
-  const searchParams = request.nextUrl.searchParams;
-  const query = searchParams.get("domain");
-  const domain = query?.trim() || DEFAULT_PLATFORM_DOMAIN;
-
   const token = await validateAndGetToken(apiKey);
   if (!token) {
     return new Response("Invalid or missing API key", { status: 401 });
   }
+
+  const domain = await resolveApiDomainForUser(
+    token.userId,
+    getApiDomainParamsFromSearchParams(request.nextUrl.searchParams),
+  );
 
   const retrievedLink = await getLinkByAlias(alias, domain);
   if (!retrievedLink) {
@@ -38,14 +42,15 @@ export async function PATCH(request: NextRequest, props: { params: Promise<{ ali
   const alias = params.alias;
   const apiKey = request.headers.get("x-api-key");
 
-  const searchParams = request.nextUrl.searchParams;
-  const query = searchParams.get("domain");
-  const domain = query?.trim() || DEFAULT_PLATFORM_DOMAIN;
-
   const token = await validateAndGetToken(apiKey);
   if (!token) {
     return new Response("Invalid or missing API key", { status: 401 });
   }
+
+  const domain = await resolveApiDomainForUser(
+    token.userId,
+    getApiDomainParamsFromSearchParams(request.nextUrl.searchParams),
+  );
 
   let updateData: {
     url?: string;
@@ -73,7 +78,7 @@ export async function PATCH(request: NextRequest, props: { params: Promise<{ ali
       }
       return acc;
     },
-    {} as typeof updateData
+    {} as typeof updateData,
   );
 
   if (Object.keys(filteredUpdateData).length === 0) {

--- a/src/app/api/v1/links/route.ts
+++ b/src/app/api/v1/links/route.ts
@@ -2,13 +2,12 @@ import bcrypt from "bcryptjs";
 import { and, eq } from "drizzle-orm";
 import { z } from "zod";
 
-import { DEFAULT_PLATFORM_DOMAIN } from "@/lib/constants/domains";
 import { generateShortLink } from "@/lib/core/links";
 import { db } from "@/server/db";
 import { link } from "@/server/db/schema";
 import { assertUrlSafe } from "@/server/lib/phishing";
 
-import { validateAndGetToken } from "../utils";
+import { resolveApiDomainForUser, validateAndGetToken } from "../utils";
 
 export async function POST(request: Request) {
   const apiKey = request.headers.get("x-api-key");
@@ -26,7 +25,8 @@ export async function POST(request: Request) {
   }
 
   const parsedData = input.data as ShortenLinkInput;
-  if (parsedData.alias && (await checkLinkAliasCollision(parsedData.alias, parsedData.domain?.trim() || DEFAULT_PLATFORM_DOMAIN))) {
+  const requestedDomain = await resolveApiDomainForUser(token.userId, parsedData);
+  if (parsedData.alias && (await checkLinkAliasCollision(parsedData.alias, requestedDomain))) {
     return new Response("Alias already exists", { status: 400 });
   }
 
@@ -35,7 +35,8 @@ export async function POST(request: Request) {
       parsedData,
       token.userId,
       token.subscription?.status,
-      token.subscription?.plan
+      token.subscription?.plan,
+      requestedDomain,
     );
     return new Response(JSON.stringify(newLink), {
       status: 201,
@@ -84,11 +85,10 @@ type ShortenLinkInput = {
 };
 
 async function checkLinkAliasCollision(alias: string, domain: string) {
-  const domainToUse = domain;
   const existingLink = await db
     .select()
     .from(link)
-    .where(and(eq(link.alias, alias), eq(link.domain, domainToUse)));
+    .where(and(eq(link.alias, alias), eq(link.domain, domain)));
   return existingLink.length > 0;
 }
 
@@ -96,7 +96,8 @@ async function createNewLink(
   data: ShortenLinkInput,
   userId: string,
   subStatus: string | undefined | null,
-  plan: string | undefined | null
+  plan: string | undefined | null,
+  domain: string,
 ) {
   if (data.password) {
     if (subStatus !== "active" || subStatus === undefined) {
@@ -111,11 +112,11 @@ async function createNewLink(
   if (data.utmParams) {
     const utmParamsValues = Object.values(data.utmParams);
     const hasUtmParams = utmParamsValues.some(
-      (value) => value !== undefined && value !== null && value !== ""
+      (value) => value !== undefined && value !== null && value !== "",
     );
     if (hasUtmParams && plan !== "ultra") {
       throw new Error(
-        "UTM parameters are only available on the Ultra plan. Please upgrade to use this feature."
+        "UTM parameters are only available on the Ultra plan. Please upgrade to use this feature.",
       );
     }
   }
@@ -133,7 +134,7 @@ async function createNewLink(
     disableLinkAfterClicks: data.expiresAfter,
     disableLinkAfterDate: data.expiresAt ? new Date(data.expiresAt) : null,
     passwordHash: data.password,
-    domain: data.domain?.trim() || DEFAULT_PLATFORM_DOMAIN,
+    domain,
     userId,
     utmParams: data.utmParams ?? null,
   };

--- a/src/app/api/v1/utils.ts
+++ b/src/app/api/v1/utils.ts
@@ -1,8 +1,9 @@
 import { eq } from "drizzle-orm";
 import crypto from "node:crypto";
 
+import { DEFAULT_PLATFORM_DOMAIN } from "@/lib/constants/domains";
 import { db } from "@/server/db";
-import { subscription, token, user } from "@/server/db/schema";
+import { siteSettings, subscription, token, user } from "@/server/db/schema";
 
 export async function validateAndGetToken(apiKey: string | null) {
   if (!apiKey) return null;
@@ -27,4 +28,41 @@ export async function validateAndGetToken(apiKey: string | null) {
   }
 
   return { ...existingToken[0]!, subscription: userSubscription[0] };
+}
+
+function normalizeApiDomain(domain: string | null | undefined) {
+  const normalized = domain?.trim().replace(/\.$/, "").toLowerCase();
+  return normalized || null;
+}
+
+async function getUserDefaultDomain(userId: string) {
+  const settings = await db.query.siteSettings.findFirst({
+    where: eq(siteSettings.userId, userId),
+    columns: {
+      defaultDomain: true,
+    },
+  });
+
+  return normalizeApiDomain(settings?.defaultDomain) ?? DEFAULT_PLATFORM_DOMAIN;
+}
+
+export async function resolveApiDomainForUser(
+  userId: string,
+  input: {
+    domain?: string | null;
+  },
+) {
+  const explicitDomain = normalizeApiDomain(input.domain);
+
+  if (explicitDomain) {
+    return explicitDomain;
+  }
+
+  return getUserDefaultDomain(userId);
+}
+
+export function getApiDomainParamsFromSearchParams(searchParams: URLSearchParams) {
+  return {
+    domain: searchParams.get("domain"),
+  };
 }


### PR DESCRIPTION
## Summary
- Resolve v1 API link domains through the authenticated user's saved default domain when no explicit domain is provided.
- Keep `domain` as the only explicit API override for create, lookup, update, and analytics routes.
- Share domain normalization across v1 API handlers.

## Validation
- `bun run typecheck`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * API now supports per-user default domain configuration across link management and analytics endpoints. When no domain is explicitly specified, the API uses the user's configured default instead of a platform default, providing better multi-domain support.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/AmoabaKelvin/ishortn.ink/pull/306)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->