### PR TITLE
fix(pricing): align plan messaging with entitlements, wire CTAs, and enforce domain cap

### DIFF
--- a/content/changelogs/2025-12-18-utm-parameters.md
+++ b/content/changelogs/2025-12-18-utm-parameters.md
@@ -6,7 +6,7 @@ shortDesc: Track your marketing campaigns with built-in UTM parameter support
 category: new
 ---
 
-We're excited to introduce UTM parameter support, making it easier than ever to track the performance of your marketing campaigns directly within iShortn.
+We're excited to introduce UTM parameter support on the Ultra plan, making it easier than ever to track the performance of your marketing campaigns directly within iShortn.
 
 ## What are UTM parameters?
 
@@ -14,7 +14,7 @@ UTM parameters are tags you add to URLs to track where your traffic comes from. 
 
 ## Adding UTM parameters to links
 
-You can now add UTM parameters directly when creating or editing any link:
+On the Ultra plan, you can now add UTM parameters directly when creating or editing a link:
 
 - **utm_source** — Identify where your traffic comes from (e.g., `google`, `newsletter`, `twitter`)
 - **utm_medium** — Track the marketing medium (e.g., `cpc`, `email`, `social`)

--- a/src/app/(auth)/auth/sign-in/[[...sign-in]]/page.tsx
+++ b/src/app/(auth)/auth/sign-in/[[...sign-in]]/page.tsx
@@ -5,12 +5,17 @@ import { warmClerkAppearance } from "../../_shared/clerk-appearance";
 export default async function Page({
   searchParams,
 }: {
-  searchParams: Promise<{ url?: string }>;
+  searchParams: Promise<{ url?: string; next?: string }>;
 }) {
-  const { url } = await searchParams;
-  const afterSignInUrl = url
-    ? `/dashboard/link/new?url=${encodeURIComponent(url)}`
-    : "/dashboard";
+  const { url, next } = await searchParams;
+  // `next` is an internal destination to land on after auth (e.g. checkout).
+  // Restrict to same-origin paths to avoid open redirects.
+  const safeNext = next && /^\/(?![/\\])/.test(next) ? next : null;
+  const afterSignInUrl = safeNext
+    ? safeNext
+    : url
+      ? `/dashboard/link/new?url=${encodeURIComponent(url)}`
+      : "/dashboard";
 
   return (
     <SignIn

--- a/src/app/(auth)/auth/sign-up/[[...sign-up]]/page.tsx
+++ b/src/app/(auth)/auth/sign-up/[[...sign-up]]/page.tsx
@@ -5,12 +5,17 @@ import { warmClerkAppearance } from "../../_shared/clerk-appearance";
 export default async function Page({
   searchParams,
 }: {
-  searchParams: Promise<{ url?: string }>;
+  searchParams: Promise<{ url?: string; next?: string }>;
 }) {
-  const { url } = await searchParams;
-  const afterSignUpUrl = url
-    ? `/dashboard/link/new?url=${encodeURIComponent(url)}`
-    : "/dashboard";
+  const { url, next } = await searchParams;
+  // `next` is an internal destination to land on after auth (e.g. checkout).
+  // Restrict to same-origin paths to avoid open redirects.
+  const safeNext = next && /^\/(?![/\\])/.test(next) ? next : null;
+  const afterSignUpUrl = safeNext
+    ? safeNext
+    : url
+      ? `/dashboard/link/new?url=${encodeURIComponent(url)}`
+      : "/dashboard";
 
   return (
     <SignUp

--- a/src/app/(landing)/_components/features.tsx
+++ b/src/app/(landing)/_components/features.tsx
@@ -55,14 +55,14 @@ const items: FeatureItem[] = [
   {
     title: "Password-protect & cloak",
     body:
-      "Gate sensitive links behind a password, or keep your short URL visible while the destination loads. Both ship on every plan.",
+      "Gate sensitive links behind a password, or keep your short URL visible while the destination loads. Password protection comes with every paid plan; cloaking is an Ultra feature.",
     bg: "#F0E6CF",
     visual: "lock",
   },
   {
     title: "UTM templates that auto-apply",
     body:
-      "Save your UTM presets once, apply them to any link with a click. No more hand-typing utm_source on every campaign.",
+      "Save your UTM presets once, then apply them with a click on Ultra. No more hand-typing utm_source on every campaign.",
     bg: "var(--warm-paper)",
     visual: "utm",
   },

--- a/src/app/(landing)/_components/pricing.tsx
+++ b/src/app/(landing)/_components/pricing.tsx
@@ -1,11 +1,9 @@
-import { PLAN_CAPS } from "@/lib/billing/plans";
+import Link from "next/link";
+
+import { PLAN_FEATURES } from "@/lib/billing/plan-features";
 import { PLAN_PRICES_USD } from "@/lib/constants/plan-pricing";
 
 import { Icon } from "./warm-primitives";
-
-const fmt = (n: number) => n.toLocaleString();
-const free = PLAN_CAPS.free;
-const pro = PLAN_CAPS.pro;
 
 const buildPlans = (_annual: boolean) =>
   [
@@ -15,35 +13,21 @@ const buildPlans = (_annual: boolean) =>
       cadence: "forever",
       tagline: "For tinkering and side projects.",
       cta: "Start for free",
+      href: "/auth/sign-up?next=%2Fdashboard",
       style: "ghost" as const,
       featured: false,
-      features: [
-        `${fmt(free.linksLimit ?? 0)} links per month`,
-        `${fmt(free.eventsLimit ?? 0)} tracked events`,
-        `${free.analyticsRangeLimitDays}-day analytics window`,
-        "Standard QR codes",
-        "ishortn.ink links",
-      ],
+      features: PLAN_FEATURES.free.features,
     },
     {
       name: "Pro",
       price: PLAN_PRICES_USD.pro,
       cadence: "/month",
       tagline: "For creators, indie makers, and growing teams.",
-      cta: "Try Pro free",
+      cta: "Get Pro",
+      href: "/auth/sign-up?next=%2Fdashboard%2Fpricing%3Fplan%3Dpro",
       style: "accent" as const,
       featured: true,
-      features: [
-        `${fmt(pro.linksLimit ?? 0)} links per month`,
-        `${fmt(pro.eventsLimit ?? 0)} tracked events`,
-        "Unlimited analytics history",
-        `${pro.domainLimit} custom domains`,
-        "Branded + dynamic QR codes",
-        `Geotargeting (up to ${pro.geoRulesLimit} rules/link)`,
-        `Click milestone alerts (${pro.milestonesPerLinkLimit}/link)`,
-        "Link cloaking & password protection",
-        "REST API access",
-      ],
+      features: PLAN_FEATURES.pro.features,
     },
     {
       name: "Ultra",
@@ -51,17 +35,10 @@ const buildPlans = (_annual: boolean) =>
       cadence: "/month",
       tagline: "For studios, agencies, and whoever wants no ceilings.",
       cta: "Go Ultra",
+      href: "/auth/sign-up?next=%2Fdashboard%2Fpricing%3Fplan%3Dultra",
       style: "primary" as const,
       featured: false,
-      features: [
-        "Everything in Pro",
-        "Unlimited links & events",
-        "Unlimited custom domains",
-        "Unlimited geo rules & milestones",
-        "Team workspaces & shared library",
-        "Resource transfer between accounts",
-        "Priority support",
-      ],
+      features: PLAN_FEATURES.ultra.features,
     },
   ];
 
@@ -191,8 +168,8 @@ export const Pricing = () => {
                 </span>
                 <span style={{ fontSize: 13, opacity: 0.6 }}>{p.cadence}</span>
               </div>
-              <button
-                type="button"
+              <Link
+                href={p.href}
                 className={`warm-btn warm-btn-lg ${
                   p.style === "accent"
                     ? "warm-btn-accent"
@@ -207,7 +184,7 @@ export const Pricing = () => {
                 }}
               >
                 {p.cta} <Icon.Arrow />
-              </button>
+              </Link>
               <div
                 style={{
                   height: 1,

--- a/src/app/(landing)/compare/[slug]/page.tsx
+++ b/src/app/(landing)/compare/[slug]/page.tsx
@@ -52,7 +52,7 @@ const ishortn = {
   qrCodes: "All plans — branded + dynamic on Pro and Ultra",
   apiAccess: "Pro and Ultra",
   teamFeatures: "Ultra plan",
-  passwordProtection: "All plans",
+  passwordProtection: "Pro and Ultra",
   pricing: "Free forever, Pro $5/mo, Ultra $15/mo",
 };
 

--- a/src/app/(landing)/page.tsx
+++ b/src/app/(landing)/page.tsx
@@ -26,7 +26,7 @@ export const metadata: Metadata = {
       "iShortn — Links, made lovely. Free URL shortener with analytics",
   },
   description:
-    "Shorten URLs for free with iShortn. Create branded short links, track clicks and conversions, generate QR codes, and use custom domains. The best free URL shortener with powerful analytics.",
+    "Shorten URLs for free with iShortn. Create branded short links, track clicks and engagement, generate QR codes, and use custom domains. The best free URL shortener with powerful analytics.",
   keywords: [
     "url shortener",
     "free url shortener",
@@ -43,7 +43,7 @@ export const metadata: Metadata = {
     title:
       "iShortn — Links, made lovely. Free URL shortener with analytics",
     description:
-      "Shorten URLs for free with iShortn. Create branded short links, track clicks and conversions, generate QR codes, and use custom domains.",
+      "Shorten URLs for free with iShortn. Create branded short links, track clicks and engagement, generate QR codes, and use custom domains.",
     type: "website",
   },
   twitter: {
@@ -51,7 +51,7 @@ export const metadata: Metadata = {
     title:
       "iShortn — Links, made lovely. Free URL shortener with analytics",
     description:
-      "Shorten URLs for free with iShortn. Create branded short links, track clicks and conversions, generate QR codes, and use custom domains.",
+      "Shorten URLs for free with iShortn. Create branded short links, track clicks and engagement, generate QR codes, and use custom domains.",
   },
 };
 

--- a/src/app/(main)/dashboard/pricing/_components/pricing-cards.tsx
+++ b/src/app/(main)/dashboard/pricing/_components/pricing-cards.tsx
@@ -1,12 +1,14 @@
 "use client";
 
 import { Check, Loader2, Sparkles } from "lucide-react";
-import { useState } from "react";
+import { useSearchParams } from "next/navigation";
+import { useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
 
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { POSTHOG_EVENTS, trackEvent } from "@/lib/analytics/events";
+import { PLAN_FEATURES } from "@/lib/billing/plan-features";
 import { cn } from "@/lib/utils";
 import { api } from "@/trpc/react";
 
@@ -25,14 +27,7 @@ const plans = [
     description: "For personal use with basic features",
     price: 0,
     period: "forever",
-    features: [
-      "30 links per month",
-      "1,000 tracked events",
-      "7 days analytics history",
-      "30 days data retention",
-      "Basic link customization",
-      "Standard support",
-    ],
+    features: PLAN_FEATURES.free.features,
     limitations: [
       "No custom domains",
       "No folders",
@@ -46,16 +41,7 @@ const plans = [
     price: 5,
     period: "per month",
     popular: true,
-    features: [
-      "1,000 links per month",
-      "10,000 tracked events",
-      "Unlimited analytics history",
-      "1 year data retention",
-      "3 custom domains",
-      "5 folders",
-      "Priority support",
-      "API access",
-    ],
+    features: PLAN_FEATURES.pro.features,
   },
   {
     id: "ultra" as Plan,
@@ -63,29 +49,14 @@ const plans = [
     description: "For teams and power users",
     price: 15,
     period: "per month",
-    features: [
-      "Unlimited links",
-      "Unlimited tracked events",
-      "Unlimited custom domains",
-      "Unlimited folders",
-      "Unlimited data retention",
-      "Dedicated support",
-      "Full API access",
-      "Advanced analytics",
-      "UTM tracking",
-      "Team collaboration",
-    ],
-    comingSoon: [
-      "Customization of password protected pages",
-      "Device targeting",
-      "Geo targeting",
-      "Time-based routing",
-      "Conversion tracking",
-    ],
+    features: PLAN_FEATURES.ultra.features,
+    comingSoon: PLAN_FEATURES.ultra.comingSoon,
   },
 ];
 
 export function PricingCards({ currentPlan }: PricingCardsProps) {
+  const searchParams = useSearchParams();
+  const autoCheckoutFired = useRef(false);
   const [loadingPlan, setLoadingPlan] = useState<Plan | null>(null);
   const [downgradeModalOpen, setDowngradeModalOpen] = useState(false);
   const [targetDowngradePlan, setTargetDowngradePlan] = useState<Exclude<
@@ -149,6 +120,24 @@ export function PricingCards({ currentPlan }: PricingCardsProps) {
     setTargetDowngradePlan(targetPlan as Exclude<Plan, "ultra">);
     setDowngradeModalOpen(true);
   };
+
+  // Auto-start checkout when arriving with ?plan=pro|ultra (e.g. right after signup).
+  useEffect(() => {
+    if (autoCheckoutFired.current) return;
+
+    const requestedPlan = searchParams?.get("plan");
+    if (requestedPlan !== "pro" && requestedPlan !== "ultra") return;
+
+    const targetPlan = plans.find((p) => p.id === requestedPlan);
+    if (!targetPlan) return;
+
+    const canUpgrade =
+      getPlanOrder(targetPlan.id) > getPlanOrder(currentPlan);
+    if (!canUpgrade) return;
+
+    autoCheckoutFired.current = true;
+    handleUpgrade(targetPlan);
+  }, [searchParams, currentPlan]);
 
   return (
     <div className="space-y-8">

--- a/src/lib/billing/plan-features.ts
+++ b/src/lib/billing/plan-features.ts
@@ -1,0 +1,55 @@
+import { PLAN_CAPS, type Plan } from "@/lib/billing/plans";
+
+const fmt = (n: number) => n.toLocaleString();
+
+const free = PLAN_CAPS.free;
+const pro = PLAN_CAPS.pro;
+
+export const PLAN_FEATURES: Record<
+  Plan,
+  { tagline: string; features: string[]; comingSoon?: string[] }
+> = {
+  free: {
+    tagline: "For tinkering and side projects.",
+    features: [
+      `${fmt(free.linksLimit ?? 0)} links per month`,
+      `${fmt(free.eventsLimit ?? 0)} tracked events`,
+      `${free.analyticsRangeLimitDays}-day analytics window`,
+      "Standard QR codes",
+      "ishortn.ink links",
+    ],
+  },
+  pro: {
+    tagline: "For creators, indie makers, and growing teams.",
+    features: [
+      `${fmt(pro.linksLimit ?? 0)} links per month`,
+      `${fmt(pro.eventsLimit ?? 0)} tracked events`,
+      "Unlimited analytics history (1 year of raw events; daily summaries kept beyond that)",
+      `${pro.domainLimit} custom domains`,
+      "Branded + dynamic QR codes",
+      `Geotargeting (up to ${pro.geoRulesLimit} rules/link)`,
+      `Click milestone alerts (${pro.milestonesPerLinkLimit}/link)`,
+      "Password protection",
+      "REST API access",
+    ],
+  },
+  ultra: {
+    tagline: "For studios, agencies, and whoever wants no ceilings.",
+    features: [
+      "Everything in Pro",
+      "Unlimited links & events",
+      "Unlimited custom domains",
+      "Unlimited geo rules & milestones",
+      "Link cloaking",
+      "UTM parameters & templates",
+      "Team workspaces & resource transfer",
+      "Priority support",
+    ],
+    comingSoon: [
+      "Conversion tracking",
+      "Device targeting",
+      "Time-based routing",
+      "Customization of password-protected pages",
+    ],
+  },
+};

--- a/src/lib/seo/competitors.ts
+++ b/src/lib/seo/competitors.ts
@@ -17,7 +17,7 @@ export const competitors = {
       "Bitly's free plan only allows 5 links per month — iShortn gives you 30",
       "Bitly free links may show interstitial ad pages before redirecting",
       "Bitly charges $35/month for Core — iShortn Pro is just $5/month",
-      "iShortn includes full analytics, QR codes, and password protection on all plans",
+      "iShortn includes full analytics and QR codes on all plans, plus password protection on Pro and Ultra",
       "No API access on Bitly free — iShortn Pro includes full API for $5/month",
     ],
   },

--- a/src/server/api/routers/domains/domains.service.ts
+++ b/src/server/api/routers/domains/domains.service.ts
@@ -1,6 +1,7 @@
 import { TRPCError } from "@trpc/server";
 import { and, count, eq, inArray, ne } from "drizzle-orm";
 
+import { PLAN_CAPS, resolvePlan } from "@/lib/billing/plans";
 import { customDomain, link, linkVisit } from "@/server/db/schema";
 import {
   requirePermission,
@@ -29,6 +30,25 @@ export async function addDomainToUserAccount(
 
   if (!userSubscription || userSubscription.status !== "active") {
     throw new Error("You need to have an active subscription to add a custom domain");
+  }
+
+  // Enforce the per-plan custom-domain cap (workspace-scoped)
+  const plan = resolvePlan(userSubscription);
+  const domainLimit = PLAN_CAPS[plan].domainLimit;
+
+  if (domainLimit !== undefined) {
+    const existingDomainsCount = await ctx.db
+      .select({ count: count() })
+      .from(customDomain)
+      .where(workspaceFilter(ctx.workspace, customDomain.userId, customDomain.teamId));
+
+    const existingCount = existingDomainsCount[0]?.count ?? 0;
+
+    if (existingCount >= domainLimit) {
+      throw new Error(
+        `You've reached your plan's limit of ${domainLimit} custom domains. Upgrade to add more.`,
+      );
+    }
   }
 
   // remove http, https, and www. from the domain


### PR DESCRIPTION
## Summary

Aligns the public pricing/feature messaging with what the backend actually grants, makes the landing pricing CTAs functional (they previously did nothing), and enforces the Pro custom-domain cap server-side. Addresses an audit of pricing/entitlement mismatches.

## Changes

**Messaging — single source of truth**
- Add `PLAN_FEATURES` (`src/lib/billing/plan-features.ts`), derived from `PLAN_CAPS` so numbers can't drift; consumed by the landing and dashboard pricing surfaces.
- Cloaking & UTM are now correctly presented as **Ultra-only**; password protection as paid-plans; geotargeting as a **live** Pro/Ultra feature (no longer "coming soon").
- Clarify Pro analytics retention: unlimited history, 1 year of raw events, daily summaries preserved after.
- Remove the false **"Try Pro free"** CTA (no trial exists) and the unbuilt **"track conversions"** promise from homepage SEO. Fix the compare page and Bitly comparison copy.

**Checkout flow**
- Wire landing CTAs to a signup → checkout flow via a same-origin `next` param on the sign-in/sign-up pages (open-redirect-safe); dashboard pricing auto-starts checkout from `?plan=`.

**Enforcement**
- Enforce the per-plan custom-domain limit server-side in `domains.service.ts` (workspace-scoped, before any Vercel call).

## Type of Change

- [x] fix: Bug fix
- [x] refactor: Code refactoring (pricing source of truth)

## Testing

- `bun run typecheck` — passes
- `bun run lint` — clean for all changed files

## Notes / Out of scope

- Billing plan/variant-ID mapping (audit finding #9) was intentionally left as a **report only** — it needs real Lemon Squeezy production IDs and a fail-closed-vs-default decision. Tracked for a follow-up PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Auto-checkout on pricing page when landing with `?plan=pro` or `?plan=ultra` query parameters
  * Per-plan custom domain limits now enforced

* **Improvements**
  * UTM parameters repositioned as Ultra-plan feature
  * Enhanced sign-in/sign-up pages with improved redirect handling
  * Pricing cards now use unified feature data structure
  * Pricing page CTAs changed from buttons to navigation links
  * Marketing copy clarified to reflect plan availability for features
  * SEO descriptions updated for better accuracy

<!-- end of auto-generated comment: release notes by coderabbit.ai -->