### PR TITLE
feat: trust & safety improvements, annual pricing, and entitlement fixes

### DIFF
--- a/drizzle/0061_tan_supreme_intelligence.sql
+++ b/drizzle/0061_tan_supreme_intelligence.sql
@@ -1,0 +1,2 @@
+ALTER TABLE `FlaggedLink` ADD `reporterEmail` varchar(320);--> statement-breakpoint
+ALTER TABLE `FlaggedLink` ADD `details` text;

--- a/drizzle/0062_abnormal_stranger.sql
+++ b/drizzle/0062_abnormal_stranger.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `Subscription` ADD `billingInterval` enum('monthly','annual') DEFAULT 'monthly';

--- a/drizzle/meta/0061_snapshot.json
+++ b/drizzle/meta/0061_snapshot.json
@@ -1,0 +1,2891 @@
+{
+  "version": "5",
+  "dialect": "mysql",
+  "id": "95f402cd-86b8-4840-8fca-63152f163b8e",
+  "prevId": "e7372b66-4164-454d-8706-5db2a693f115",
+  "tables": {
+    "AccountTransfer": {
+      "name": "AccountTransfer",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "fromUserId": {
+          "name": "fromUserId",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "toEmail": {
+          "name": "toEmail",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "toUserId": {
+          "name": "toUserId",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "enum('pending','accepted','cancelled','expired','declined')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "linksCount": {
+          "name": "linksCount",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "customDomainsCount": {
+          "name": "customDomainsCount",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "qrCodesCount": {
+          "name": "qrCodesCount",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "foldersCount": {
+          "name": "foldersCount",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "tagsCount": {
+          "name": "tagsCount",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "utmTemplatesCount": {
+          "name": "utmTemplatesCount",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "qrPresetsCount": {
+          "name": "qrPresetsCount",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "acceptedAt": {
+          "name": "acceptedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "fromUser_idx": {
+          "name": "fromUser_idx",
+          "columns": [
+            "fromUserId"
+          ],
+          "isUnique": false
+        },
+        "toEmail_idx": {
+          "name": "toEmail_idx",
+          "columns": [
+            "toEmail"
+          ],
+          "isUnique": false
+        },
+        "status_idx": {
+          "name": "status_idx",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "AccountTransfer_id": {
+          "name": "AccountTransfer_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "AccountTransfer_token_unique": {
+          "name": "AccountTransfer_token_unique",
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "checkConstraint": {}
+    },
+    "AudienceFeedback": {
+      "name": "AudienceFeedback",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "useCase": {
+          "name": "useCase",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "monthlyVolume": {
+          "name": "monthlyVolume",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "acquisitionChannel": {
+          "name": "acquisitionChannel",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "acquisitionDetail": {
+          "name": "acquisitionDetail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "priorTool": {
+          "name": "priorTool",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "switchReason": {
+          "name": "switchReason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "magicFeature": {
+          "name": "magicFeature",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "upgradeReason": {
+          "name": "upgradeReason",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "upgradeBlocker": {
+          "name": "upgradeBlocker",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "improvementWish": {
+          "name": "improvementWish",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "planSnapshot": {
+          "name": "planSnapshot",
+          "type": "enum('free','pro','ultra')",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "submittedAt": {
+          "name": "submittedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "dismissedAt": {
+          "name": "dismissedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "dismissCount": {
+          "name": "dismissCount",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "onUpdate": true
+        }
+      },
+      "indexes": {
+        "userId_idx": {
+          "name": "userId_idx",
+          "columns": [
+            "userId"
+          ],
+          "isUnique": false
+        },
+        "submittedAt_idx": {
+          "name": "submittedAt_idx",
+          "columns": [
+            "submittedAt"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "AudienceFeedback_id": {
+          "name": "AudienceFeedback_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "AudienceFeedback_userId_unique": {
+          "name": "AudienceFeedback_userId_unique",
+          "columns": [
+            "userId"
+          ]
+        }
+      },
+      "checkConstraint": {}
+    },
+    "BlockedDomain": {
+      "name": "BlockedDomain",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "domain": {
+          "name": "domain",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "createdByUserId": {
+          "name": "createdByUserId",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "BlockedDomain_id": {
+          "name": "BlockedDomain_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "BlockedDomain_domain_unique": {
+          "name": "BlockedDomain_domain_unique",
+          "columns": [
+            "domain"
+          ]
+        }
+      },
+      "checkConstraint": {}
+    },
+    "CustomDomain": {
+      "name": "CustomDomain",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "domain": {
+          "name": "domain",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "teamId": {
+          "name": "teamId",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "status": {
+          "name": "status",
+          "type": "enum('pending','active','invalid')",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "verificationDetails": {
+          "name": "verificationDetails",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "lastReminderSentAt": {
+          "name": "lastReminderSentAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "teamIdForUnique": {
+          "name": "teamIdForUnique",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "generated": {
+            "as": "COALESCE(`teamId`, 0)",
+            "type": "stored"
+          }
+        }
+      },
+      "indexes": {
+        "userId_idx": {
+          "name": "userId_idx",
+          "columns": [
+            "userId"
+          ],
+          "isUnique": false
+        },
+        "teamId_idx": {
+          "name": "teamId_idx",
+          "columns": [
+            "teamId"
+          ],
+          "isUnique": false
+        },
+        "status_createdAt_idx": {
+          "name": "status_createdAt_idx",
+          "columns": [
+            "status",
+            "createdAt"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "CustomDomain_id": {
+          "name": "CustomDomain_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "domain_workspace_unique": {
+          "name": "domain_workspace_unique",
+          "columns": [
+            "domain",
+            "userId",
+            "teamIdForUnique"
+          ]
+        }
+      },
+      "checkConstraint": {}
+    },
+    "Feedback": {
+      "name": "Feedback",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "feedbackType": {
+          "name": "feedbackType",
+          "type": "enum('bug','feature','question')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "imageUrls": {
+          "name": "imageUrls",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "('[]')"
+        },
+        "feedbackStatus": {
+          "name": "feedbackStatus",
+          "type": "enum('open','resolved','dismissed')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'open'"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "userId_idx": {
+          "name": "userId_idx",
+          "columns": [
+            "userId"
+          ],
+          "isUnique": false
+        },
+        "status_idx": {
+          "name": "status_idx",
+          "columns": [
+            "feedbackStatus"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "Feedback_id": {
+          "name": "Feedback_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "FlaggedLink": {
+      "name": "FlaggedLink",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "linkId": {
+          "name": "linkId",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reporterEmail": {
+          "name": "reporterEmail",
+          "type": "varchar(320)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "details": {
+          "name": "details",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "flagStatus": {
+          "name": "flagStatus",
+          "type": "enum('pending','blocked','dismissed')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "flaggedAt": {
+          "name": "flaggedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "resolvedAt": {
+          "name": "resolvedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "resolvedByUserId": {
+          "name": "resolvedByUserId",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "linkId_idx": {
+          "name": "linkId_idx",
+          "columns": [
+            "linkId"
+          ],
+          "isUnique": false
+        },
+        "status_idx": {
+          "name": "status_idx",
+          "columns": [
+            "flagStatus"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "FlaggedLink_id": {
+          "name": "FlaggedLink_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "Folder": {
+      "name": "Folder",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "teamId": {
+          "name": "teamId",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "isRestricted": {
+          "name": "isRestricted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "onUpdate": true
+        }
+      },
+      "indexes": {
+        "userId_idx": {
+          "name": "userId_idx",
+          "columns": [
+            "userId"
+          ],
+          "isUnique": false
+        },
+        "teamId_idx": {
+          "name": "teamId_idx",
+          "columns": [
+            "teamId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "Folder_id": {
+          "name": "Folder_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "FolderPermission": {
+      "name": "FolderPermission",
+      "columns": {
+        "folderId": {
+          "name": "folderId",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "userId_idx": {
+          "name": "userId_idx",
+          "columns": [
+            "userId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "FolderPermission_folderId_userId_pk": {
+          "name": "FolderPermission_folderId_userId_pk",
+          "columns": [
+            "folderId",
+            "userId"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "GeoRule": {
+      "name": "GeoRule",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "linkId": {
+          "name": "linkId",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "enum('country','continent')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "condition": {
+          "name": "condition",
+          "type": "enum('in','not_in')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'in'"
+        },
+        "values": {
+          "name": "values",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "action": {
+          "name": "action",
+          "type": "enum('redirect','block')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "destination": {
+          "name": "destination",
+          "type": "varchar(2048)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "blockMessage": {
+          "name": "blockMessage",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "priority": {
+          "name": "priority",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "linkId_idx": {
+          "name": "linkId_idx",
+          "columns": [
+            "linkId"
+          ],
+          "isUnique": false
+        },
+        "priority_idx": {
+          "name": "priority_idx",
+          "columns": [
+            "linkId",
+            "priority"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "GeoRule_id": {
+          "name": "GeoRule_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "Link": {
+      "name": "Link",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "alias": {
+          "name": "alias",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "domain": {
+          "name": "domain",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'ishortn.ink'"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "disableLinkAfterClicks": {
+          "name": "disableLinkAfterClicks",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "disableLinkAfterDate": {
+          "name": "disableLinkAfterDate",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "disabled": {
+          "name": "disabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "publicStats": {
+          "name": "publicStats",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "teamId": {
+          "name": "teamId",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdByUserId": {
+          "name": "createdByUserId",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "passwordHash": {
+          "name": "passwordHash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "note": {
+          "name": "note",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "utmParams": {
+          "name": "utmParams",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "('[]')"
+        },
+        "archived": {
+          "name": "archived",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "folderId": {
+          "name": "folderId",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cloaking": {
+          "name": "cloaking",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "verifiedClicksEnabled": {
+          "name": "verifiedClicksEnabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "isQrCode": {
+          "name": "isQrCode",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "blocked": {
+          "name": "blocked",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "blockedAt": {
+          "name": "blockedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "blockedReason": {
+          "name": "blockedReason",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "userId_idx": {
+          "name": "userId_idx",
+          "columns": [
+            "userId"
+          ],
+          "isUnique": false
+        },
+        "teamId_idx": {
+          "name": "teamId_idx",
+          "columns": [
+            "teamId"
+          ],
+          "isUnique": false
+        },
+        "aliasDomain_idx": {
+          "name": "aliasDomain_idx",
+          "columns": [
+            "alias",
+            "domain"
+          ],
+          "isUnique": false
+        },
+        "folderId_idx": {
+          "name": "folderId_idx",
+          "columns": [
+            "folderId"
+          ],
+          "isUnique": false
+        },
+        "createdAt_idx": {
+          "name": "createdAt_idx",
+          "columns": [
+            "createdAt"
+          ],
+          "isUnique": false
+        },
+        "blocked_blockedAt_idx": {
+          "name": "blocked_blockedAt_idx",
+          "columns": [
+            "blocked",
+            "blockedAt"
+          ],
+          "isUnique": false
+        },
+        "domain_idx": {
+          "name": "domain_idx",
+          "columns": [
+            "domain"
+          ],
+          "isUnique": false
+        },
+        "listing_idx": {
+          "name": "listing_idx",
+          "columns": [
+            "userId",
+            "teamId",
+            "isQrCode",
+            "archived"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "Link_id": {
+          "name": "Link_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "unique_alias_domain": {
+          "name": "unique_alias_domain",
+          "columns": [
+            "alias",
+            "domain"
+          ]
+        }
+      },
+      "checkConstraint": {}
+    },
+    "LinkMilestone": {
+      "name": "LinkMilestone",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "linkId": {
+          "name": "linkId",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "threshold": {
+          "name": "threshold",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "notifiedAt": {
+          "name": "notifiedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "linkId_idx": {
+          "name": "linkId_idx",
+          "columns": [
+            "linkId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "LinkMilestone_id": {
+          "name": "LinkMilestone_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "link_threshold_unique": {
+          "name": "link_threshold_unique",
+          "columns": [
+            "linkId",
+            "threshold"
+          ]
+        }
+      },
+      "checkConstraint": {}
+    },
+    "LinkTag": {
+      "name": "LinkTag",
+      "columns": {
+        "linkId": {
+          "name": "linkId",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tagId": {
+          "name": "tagId",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "tagId_idx": {
+          "name": "tagId_idx",
+          "columns": [
+            "tagId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "LinkTag_linkId_tagId_pk": {
+          "name": "LinkTag_linkId_tagId_pk",
+          "columns": [
+            "linkId",
+            "tagId"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "LinkVisit": {
+      "name": "LinkVisit",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "linkId": {
+          "name": "linkId",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "device": {
+          "name": "device",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "browser": {
+          "name": "browser",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "os": {
+          "name": "os",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "referer": {
+          "name": "referer",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "country": {
+          "name": "country",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "city": {
+          "name": "city",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "continent": {
+          "name": "continent",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'N/A'"
+        },
+        "matchedGeoRuleId": {
+          "name": "matchedGeoRuleId",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "visitId": {
+          "name": "visitId",
+          "type": "char(36)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "verifiedAt": {
+          "name": "verifiedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "linkId_idx": {
+          "name": "linkId_idx",
+          "columns": [
+            "linkId"
+          ],
+          "isUnique": false
+        },
+        "geoRuleId_idx": {
+          "name": "geoRuleId_idx",
+          "columns": [
+            "matchedGeoRuleId"
+          ],
+          "isUnique": false
+        },
+        "linkId_createdAt_idx": {
+          "name": "linkId_createdAt_idx",
+          "columns": [
+            "linkId",
+            "createdAt"
+          ],
+          "isUnique": false
+        },
+        "createdAt_idx": {
+          "name": "createdAt_idx",
+          "columns": [
+            "createdAt"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "LinkVisit_id": {
+          "name": "LinkVisit_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "visitId_idx": {
+          "name": "visitId_idx",
+          "columns": [
+            "visitId"
+          ]
+        }
+      },
+      "checkConstraint": {}
+    },
+    "LinkVisitDailySummary": {
+      "name": "LinkVisitDailySummary",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "linkId": {
+          "name": "linkId",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "clicks": {
+          "name": "clicks",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "uniqueClicks": {
+          "name": "uniqueClicks",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "LinkVisitDailySummary_id": {
+          "name": "LinkVisitDailySummary_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "link_date_unique": {
+          "name": "link_date_unique",
+          "columns": [
+            "linkId",
+            "date"
+          ]
+        }
+      },
+      "checkConstraint": {}
+    },
+    "QrPreset": {
+      "name": "QrPreset",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "teamId": {
+          "name": "teamId",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pixelStyle": {
+          "name": "pixelStyle",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'rounded'"
+        },
+        "markerShape": {
+          "name": "markerShape",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'square'"
+        },
+        "markerInnerShape": {
+          "name": "markerInnerShape",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'auto'"
+        },
+        "darkColor": {
+          "name": "darkColor",
+          "type": "varchar(9)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'#000000'"
+        },
+        "lightColor": {
+          "name": "lightColor",
+          "type": "varchar(9)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'#ffffff'"
+        },
+        "effect": {
+          "name": "effect",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'none'"
+        },
+        "effectRadius": {
+          "name": "effectRadius",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 12
+        },
+        "marginNoise": {
+          "name": "marginNoise",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "marginNoiseRate": {
+          "name": "marginNoiseRate",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'0.5'"
+        },
+        "logoImage": {
+          "name": "logoImage",
+          "type": "longtext",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "logoSize": {
+          "name": "logoSize",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 25
+        },
+        "logoMargin": {
+          "name": "logoMargin",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 4
+        },
+        "logoBorderRadius": {
+          "name": "logoBorderRadius",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 8
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "onUpdate": true
+        }
+      },
+      "indexes": {
+        "userId_idx": {
+          "name": "userId_idx",
+          "columns": [
+            "userId"
+          ],
+          "isUnique": false
+        },
+        "teamId_idx": {
+          "name": "teamId_idx",
+          "columns": [
+            "teamId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "QrPreset_id": {
+          "name": "QrPreset_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "QrCode": {
+      "name": "QrCode",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "qrCode": {
+          "name": "qrCode",
+          "type": "longtext",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "teamId": {
+          "name": "teamId",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "linkId": {
+          "name": "linkId",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "contentType": {
+          "name": "contentType",
+          "type": "enum('link','text')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "patternStyle": {
+          "name": "patternStyle",
+          "type": "enum('square','diamond','star','fluid','rounded','tile','stripe','fluid-line','stripe-column')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "cornerStyle": {
+          "name": "cornerStyle",
+          "type": "enum('circle','circle-diamond','square','square-diamond','rounded-circle','rounded','circle-star')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "color": {
+          "name": "color",
+          "type": "varchar(7)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "userId_idx": {
+          "name": "userId_idx",
+          "columns": [
+            "userId"
+          ],
+          "isUnique": false
+        },
+        "teamId_idx": {
+          "name": "teamId_idx",
+          "columns": [
+            "teamId"
+          ],
+          "isUnique": false
+        },
+        "linkId_idx": {
+          "name": "linkId_idx",
+          "columns": [
+            "linkId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "QrCode_id": {
+          "name": "QrCode_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "SiteSettings": {
+      "name": "SiteSettings",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "teamId": {
+          "name": "teamId",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "defaultDomain": {
+          "name": "defaultDomain",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'ishortn.ink'"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "onUpdate": true
+        }
+      },
+      "indexes": {
+        "userId_idx": {
+          "name": "userId_idx",
+          "columns": [
+            "userId"
+          ],
+          "isUnique": false
+        },
+        "teamId_idx": {
+          "name": "teamId_idx",
+          "columns": [
+            "teamId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "SiteSettings_id": {
+          "name": "SiteSettings_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "Subscription": {
+      "name": "Subscription",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "orderId": {
+          "name": "orderId",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "subscriptionId": {
+          "name": "subscriptionId",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "customerId": {
+          "name": "customerId",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "renewsAt": {
+          "name": "renewsAt",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "endsAt": {
+          "name": "endsAt",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "plan": {
+          "name": "plan",
+          "type": "enum('free','pro','ultra')",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'free'"
+        },
+        "variantId": {
+          "name": "variantId",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "productId": {
+          "name": "productId",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "cardBrand": {
+          "name": "cardBrand",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "cardLastFour": {
+          "name": "cardLastFour",
+          "type": "varchar(4)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "''"
+        }
+      },
+      "indexes": {
+        "userId_idx": {
+          "name": "userId_idx",
+          "columns": [
+            "userId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "Subscription_id": {
+          "name": "Subscription_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "Subscription_userId_unique": {
+          "name": "Subscription_userId_unique",
+          "columns": [
+            "userId"
+          ]
+        }
+      },
+      "checkConstraint": {}
+    },
+    "Tag": {
+      "name": "Tag",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "teamId": {
+          "name": "teamId",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "name_idx": {
+          "name": "name_idx",
+          "columns": [
+            "name"
+          ],
+          "isUnique": false
+        },
+        "userId_idx": {
+          "name": "userId_idx",
+          "columns": [
+            "userId"
+          ],
+          "isUnique": false
+        },
+        "teamId_idx": {
+          "name": "teamId_idx",
+          "columns": [
+            "teamId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "Tag_id": {
+          "name": "Tag_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "unique_tag_team": {
+          "name": "unique_tag_team",
+          "columns": [
+            "name",
+            "teamId"
+          ]
+        }
+      },
+      "checkConstraint": {}
+    },
+    "Team": {
+      "name": "Team",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "avatarUrl": {
+          "name": "avatarUrl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "defaultDomain": {
+          "name": "defaultDomain",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'ishortn.ink'"
+        },
+        "ownerId": {
+          "name": "ownerId",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "onUpdate": true
+        },
+        "deletedAt": {
+          "name": "deletedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "ownerId_idx": {
+          "name": "ownerId_idx",
+          "columns": [
+            "ownerId"
+          ],
+          "isUnique": false
+        },
+        "deletedAt_idx": {
+          "name": "deletedAt_idx",
+          "columns": [
+            "deletedAt"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "Team_id": {
+          "name": "Team_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "Team_slug_unique": {
+          "name": "Team_slug_unique",
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "checkConstraint": {}
+    },
+    "TeamInvite": {
+      "name": "TeamInvite",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "teamId": {
+          "name": "teamId",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "inviteRole": {
+          "name": "inviteRole",
+          "type": "enum('admin','member')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'member'"
+        },
+        "token": {
+          "name": "token",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "invitedBy": {
+          "name": "invitedBy",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "acceptedAt": {
+          "name": "acceptedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "team_idx": {
+          "name": "team_idx",
+          "columns": [
+            "teamId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "TeamInvite_id": {
+          "name": "TeamInvite_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "TeamInvite_token_unique": {
+          "name": "TeamInvite_token_unique",
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "checkConstraint": {}
+    },
+    "TeamMember": {
+      "name": "TeamMember",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "teamId": {
+          "name": "teamId",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "enum('owner','admin','member')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "onUpdate": true
+        }
+      },
+      "indexes": {
+        "team_user_idx": {
+          "name": "team_user_idx",
+          "columns": [
+            "teamId",
+            "userId"
+          ],
+          "isUnique": false
+        },
+        "user_idx": {
+          "name": "user_idx",
+          "columns": [
+            "userId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "TeamMember_id": {
+          "name": "TeamMember_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "unique_team_user": {
+          "name": "unique_team_user",
+          "columns": [
+            "teamId",
+            "userId"
+          ]
+        }
+      },
+      "checkConstraint": {}
+    },
+    "Token": {
+      "name": "Token",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "token": {
+          "name": "token",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "userId_idx": {
+          "name": "userId_idx",
+          "columns": [
+            "userId"
+          ],
+          "isUnique": false
+        },
+        "token_idx": {
+          "name": "token_idx",
+          "columns": [
+            "token"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "Token_id": {
+          "name": "Token_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "UniqueLinkVisit": {
+      "name": "UniqueLinkVisit",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "linkId": {
+          "name": "linkId",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ipHash": {
+          "name": "ipHash",
+          "type": "char(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "linkId_idx": {
+          "name": "linkId_idx",
+          "columns": [
+            "linkId"
+          ],
+          "isUnique": false
+        },
+        "ipHash_idx": {
+          "name": "ipHash_idx",
+          "columns": [
+            "ipHash"
+          ],
+          "isUnique": false
+        },
+        "linkId_createdAt_idx": {
+          "name": "linkId_createdAt_idx",
+          "columns": [
+            "linkId",
+            "createdAt"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "UniqueLinkVisit_id": {
+          "name": "UniqueLinkVisit_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "unique_visit_idx": {
+          "name": "unique_visit_idx",
+          "columns": [
+            "linkId",
+            "ipHash"
+          ]
+        }
+      },
+      "checkConstraint": {}
+    },
+    "User": {
+      "name": "User",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "imageUrl": {
+          "name": "imageUrl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "qrCodeCount": {
+          "name": "qrCodeCount",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "monthlyLinkCount": {
+          "name": "monthlyLinkCount",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "lastLinkCountReset": {
+          "name": "lastLinkCountReset",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "monthlyEventCount": {
+          "name": "monthlyEventCount",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "lastEventCountReset": {
+          "name": "lastEventCountReset",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "eventUsageAlertLevel": {
+          "name": "eventUsageAlertLevel",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "lastViewedChangelogSlug": {
+          "name": "lastViewedChangelogSlug",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "deletedAt": {
+          "name": "deletedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "isAdmin": {
+          "name": "isAdmin",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "banned": {
+          "name": "banned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "bannedAt": {
+          "name": "bannedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "bannedReason": {
+          "name": "bannedReason",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "deletedAt_idx": {
+          "name": "deletedAt_idx",
+          "columns": [
+            "deletedAt"
+          ],
+          "isUnique": false
+        },
+        "createdAt_idx": {
+          "name": "createdAt_idx",
+          "columns": [
+            "createdAt"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "User_id": {
+          "name": "User_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "User_email_unique": {
+          "name": "User_email_unique",
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "checkConstraint": {}
+    },
+    "UtmTemplate": {
+      "name": "UtmTemplate",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "utmSource": {
+          "name": "utmSource",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "utmMedium": {
+          "name": "utmMedium",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "utmCampaign": {
+          "name": "utmCampaign",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "utmTerm": {
+          "name": "utmTerm",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "utmContent": {
+          "name": "utmContent",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "teamId": {
+          "name": "teamId",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "onUpdate": true
+        }
+      },
+      "indexes": {
+        "userId_idx": {
+          "name": "userId_idx",
+          "columns": [
+            "userId"
+          ],
+          "isUnique": false
+        },
+        "teamId_idx": {
+          "name": "teamId_idx",
+          "columns": [
+            "teamId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "UtmTemplate_id": {
+          "name": "UtmTemplate_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    }
+  },
+  "views": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "tables": {},
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/0062_snapshot.json
+++ b/drizzle/meta/0062_snapshot.json
@@ -1,0 +1,2899 @@
+{
+  "version": "5",
+  "dialect": "mysql",
+  "id": "70e4dbfc-78bc-4c1c-ad9a-3d11b3674ee2",
+  "prevId": "95f402cd-86b8-4840-8fca-63152f163b8e",
+  "tables": {
+    "AccountTransfer": {
+      "name": "AccountTransfer",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "fromUserId": {
+          "name": "fromUserId",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "toEmail": {
+          "name": "toEmail",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "toUserId": {
+          "name": "toUserId",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "enum('pending','accepted','cancelled','expired','declined')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "linksCount": {
+          "name": "linksCount",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "customDomainsCount": {
+          "name": "customDomainsCount",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "qrCodesCount": {
+          "name": "qrCodesCount",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "foldersCount": {
+          "name": "foldersCount",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "tagsCount": {
+          "name": "tagsCount",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "utmTemplatesCount": {
+          "name": "utmTemplatesCount",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "qrPresetsCount": {
+          "name": "qrPresetsCount",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "acceptedAt": {
+          "name": "acceptedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "fromUser_idx": {
+          "name": "fromUser_idx",
+          "columns": [
+            "fromUserId"
+          ],
+          "isUnique": false
+        },
+        "toEmail_idx": {
+          "name": "toEmail_idx",
+          "columns": [
+            "toEmail"
+          ],
+          "isUnique": false
+        },
+        "status_idx": {
+          "name": "status_idx",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "AccountTransfer_id": {
+          "name": "AccountTransfer_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "AccountTransfer_token_unique": {
+          "name": "AccountTransfer_token_unique",
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "checkConstraint": {}
+    },
+    "AudienceFeedback": {
+      "name": "AudienceFeedback",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "useCase": {
+          "name": "useCase",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "monthlyVolume": {
+          "name": "monthlyVolume",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "acquisitionChannel": {
+          "name": "acquisitionChannel",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "acquisitionDetail": {
+          "name": "acquisitionDetail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "priorTool": {
+          "name": "priorTool",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "switchReason": {
+          "name": "switchReason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "magicFeature": {
+          "name": "magicFeature",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "upgradeReason": {
+          "name": "upgradeReason",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "upgradeBlocker": {
+          "name": "upgradeBlocker",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "improvementWish": {
+          "name": "improvementWish",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "planSnapshot": {
+          "name": "planSnapshot",
+          "type": "enum('free','pro','ultra')",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "submittedAt": {
+          "name": "submittedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "dismissedAt": {
+          "name": "dismissedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "dismissCount": {
+          "name": "dismissCount",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "onUpdate": true
+        }
+      },
+      "indexes": {
+        "userId_idx": {
+          "name": "userId_idx",
+          "columns": [
+            "userId"
+          ],
+          "isUnique": false
+        },
+        "submittedAt_idx": {
+          "name": "submittedAt_idx",
+          "columns": [
+            "submittedAt"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "AudienceFeedback_id": {
+          "name": "AudienceFeedback_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "AudienceFeedback_userId_unique": {
+          "name": "AudienceFeedback_userId_unique",
+          "columns": [
+            "userId"
+          ]
+        }
+      },
+      "checkConstraint": {}
+    },
+    "BlockedDomain": {
+      "name": "BlockedDomain",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "domain": {
+          "name": "domain",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "createdByUserId": {
+          "name": "createdByUserId",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "BlockedDomain_id": {
+          "name": "BlockedDomain_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "BlockedDomain_domain_unique": {
+          "name": "BlockedDomain_domain_unique",
+          "columns": [
+            "domain"
+          ]
+        }
+      },
+      "checkConstraint": {}
+    },
+    "CustomDomain": {
+      "name": "CustomDomain",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "domain": {
+          "name": "domain",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "teamId": {
+          "name": "teamId",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "status": {
+          "name": "status",
+          "type": "enum('pending','active','invalid')",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "verificationDetails": {
+          "name": "verificationDetails",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "lastReminderSentAt": {
+          "name": "lastReminderSentAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "teamIdForUnique": {
+          "name": "teamIdForUnique",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "generated": {
+            "as": "COALESCE(`teamId`, 0)",
+            "type": "stored"
+          }
+        }
+      },
+      "indexes": {
+        "userId_idx": {
+          "name": "userId_idx",
+          "columns": [
+            "userId"
+          ],
+          "isUnique": false
+        },
+        "teamId_idx": {
+          "name": "teamId_idx",
+          "columns": [
+            "teamId"
+          ],
+          "isUnique": false
+        },
+        "status_createdAt_idx": {
+          "name": "status_createdAt_idx",
+          "columns": [
+            "status",
+            "createdAt"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "CustomDomain_id": {
+          "name": "CustomDomain_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "domain_workspace_unique": {
+          "name": "domain_workspace_unique",
+          "columns": [
+            "domain",
+            "userId",
+            "teamIdForUnique"
+          ]
+        }
+      },
+      "checkConstraint": {}
+    },
+    "Feedback": {
+      "name": "Feedback",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "feedbackType": {
+          "name": "feedbackType",
+          "type": "enum('bug','feature','question')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "imageUrls": {
+          "name": "imageUrls",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "('[]')"
+        },
+        "feedbackStatus": {
+          "name": "feedbackStatus",
+          "type": "enum('open','resolved','dismissed')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'open'"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "userId_idx": {
+          "name": "userId_idx",
+          "columns": [
+            "userId"
+          ],
+          "isUnique": false
+        },
+        "status_idx": {
+          "name": "status_idx",
+          "columns": [
+            "feedbackStatus"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "Feedback_id": {
+          "name": "Feedback_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "FlaggedLink": {
+      "name": "FlaggedLink",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "linkId": {
+          "name": "linkId",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reporterEmail": {
+          "name": "reporterEmail",
+          "type": "varchar(320)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "details": {
+          "name": "details",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "flagStatus": {
+          "name": "flagStatus",
+          "type": "enum('pending','blocked','dismissed')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "flaggedAt": {
+          "name": "flaggedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "resolvedAt": {
+          "name": "resolvedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "resolvedByUserId": {
+          "name": "resolvedByUserId",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "linkId_idx": {
+          "name": "linkId_idx",
+          "columns": [
+            "linkId"
+          ],
+          "isUnique": false
+        },
+        "status_idx": {
+          "name": "status_idx",
+          "columns": [
+            "flagStatus"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "FlaggedLink_id": {
+          "name": "FlaggedLink_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "Folder": {
+      "name": "Folder",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "teamId": {
+          "name": "teamId",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "isRestricted": {
+          "name": "isRestricted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "onUpdate": true
+        }
+      },
+      "indexes": {
+        "userId_idx": {
+          "name": "userId_idx",
+          "columns": [
+            "userId"
+          ],
+          "isUnique": false
+        },
+        "teamId_idx": {
+          "name": "teamId_idx",
+          "columns": [
+            "teamId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "Folder_id": {
+          "name": "Folder_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "FolderPermission": {
+      "name": "FolderPermission",
+      "columns": {
+        "folderId": {
+          "name": "folderId",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "userId_idx": {
+          "name": "userId_idx",
+          "columns": [
+            "userId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "FolderPermission_folderId_userId_pk": {
+          "name": "FolderPermission_folderId_userId_pk",
+          "columns": [
+            "folderId",
+            "userId"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "GeoRule": {
+      "name": "GeoRule",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "linkId": {
+          "name": "linkId",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "enum('country','continent')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "condition": {
+          "name": "condition",
+          "type": "enum('in','not_in')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'in'"
+        },
+        "values": {
+          "name": "values",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "action": {
+          "name": "action",
+          "type": "enum('redirect','block')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "destination": {
+          "name": "destination",
+          "type": "varchar(2048)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "blockMessage": {
+          "name": "blockMessage",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "priority": {
+          "name": "priority",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "linkId_idx": {
+          "name": "linkId_idx",
+          "columns": [
+            "linkId"
+          ],
+          "isUnique": false
+        },
+        "priority_idx": {
+          "name": "priority_idx",
+          "columns": [
+            "linkId",
+            "priority"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "GeoRule_id": {
+          "name": "GeoRule_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "Link": {
+      "name": "Link",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "alias": {
+          "name": "alias",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "domain": {
+          "name": "domain",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'ishortn.ink'"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "disableLinkAfterClicks": {
+          "name": "disableLinkAfterClicks",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "disableLinkAfterDate": {
+          "name": "disableLinkAfterDate",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "disabled": {
+          "name": "disabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "publicStats": {
+          "name": "publicStats",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "teamId": {
+          "name": "teamId",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdByUserId": {
+          "name": "createdByUserId",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "passwordHash": {
+          "name": "passwordHash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "note": {
+          "name": "note",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "utmParams": {
+          "name": "utmParams",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "('[]')"
+        },
+        "archived": {
+          "name": "archived",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "folderId": {
+          "name": "folderId",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cloaking": {
+          "name": "cloaking",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "verifiedClicksEnabled": {
+          "name": "verifiedClicksEnabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "isQrCode": {
+          "name": "isQrCode",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "blocked": {
+          "name": "blocked",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "blockedAt": {
+          "name": "blockedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "blockedReason": {
+          "name": "blockedReason",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "userId_idx": {
+          "name": "userId_idx",
+          "columns": [
+            "userId"
+          ],
+          "isUnique": false
+        },
+        "teamId_idx": {
+          "name": "teamId_idx",
+          "columns": [
+            "teamId"
+          ],
+          "isUnique": false
+        },
+        "aliasDomain_idx": {
+          "name": "aliasDomain_idx",
+          "columns": [
+            "alias",
+            "domain"
+          ],
+          "isUnique": false
+        },
+        "folderId_idx": {
+          "name": "folderId_idx",
+          "columns": [
+            "folderId"
+          ],
+          "isUnique": false
+        },
+        "createdAt_idx": {
+          "name": "createdAt_idx",
+          "columns": [
+            "createdAt"
+          ],
+          "isUnique": false
+        },
+        "blocked_blockedAt_idx": {
+          "name": "blocked_blockedAt_idx",
+          "columns": [
+            "blocked",
+            "blockedAt"
+          ],
+          "isUnique": false
+        },
+        "domain_idx": {
+          "name": "domain_idx",
+          "columns": [
+            "domain"
+          ],
+          "isUnique": false
+        },
+        "listing_idx": {
+          "name": "listing_idx",
+          "columns": [
+            "userId",
+            "teamId",
+            "isQrCode",
+            "archived"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "Link_id": {
+          "name": "Link_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "unique_alias_domain": {
+          "name": "unique_alias_domain",
+          "columns": [
+            "alias",
+            "domain"
+          ]
+        }
+      },
+      "checkConstraint": {}
+    },
+    "LinkMilestone": {
+      "name": "LinkMilestone",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "linkId": {
+          "name": "linkId",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "threshold": {
+          "name": "threshold",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "notifiedAt": {
+          "name": "notifiedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "linkId_idx": {
+          "name": "linkId_idx",
+          "columns": [
+            "linkId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "LinkMilestone_id": {
+          "name": "LinkMilestone_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "link_threshold_unique": {
+          "name": "link_threshold_unique",
+          "columns": [
+            "linkId",
+            "threshold"
+          ]
+        }
+      },
+      "checkConstraint": {}
+    },
+    "LinkTag": {
+      "name": "LinkTag",
+      "columns": {
+        "linkId": {
+          "name": "linkId",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tagId": {
+          "name": "tagId",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "tagId_idx": {
+          "name": "tagId_idx",
+          "columns": [
+            "tagId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "LinkTag_linkId_tagId_pk": {
+          "name": "LinkTag_linkId_tagId_pk",
+          "columns": [
+            "linkId",
+            "tagId"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "LinkVisit": {
+      "name": "LinkVisit",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "linkId": {
+          "name": "linkId",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "device": {
+          "name": "device",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "browser": {
+          "name": "browser",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "os": {
+          "name": "os",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "referer": {
+          "name": "referer",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "country": {
+          "name": "country",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "city": {
+          "name": "city",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "continent": {
+          "name": "continent",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'N/A'"
+        },
+        "matchedGeoRuleId": {
+          "name": "matchedGeoRuleId",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "visitId": {
+          "name": "visitId",
+          "type": "char(36)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "verifiedAt": {
+          "name": "verifiedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "linkId_idx": {
+          "name": "linkId_idx",
+          "columns": [
+            "linkId"
+          ],
+          "isUnique": false
+        },
+        "geoRuleId_idx": {
+          "name": "geoRuleId_idx",
+          "columns": [
+            "matchedGeoRuleId"
+          ],
+          "isUnique": false
+        },
+        "linkId_createdAt_idx": {
+          "name": "linkId_createdAt_idx",
+          "columns": [
+            "linkId",
+            "createdAt"
+          ],
+          "isUnique": false
+        },
+        "createdAt_idx": {
+          "name": "createdAt_idx",
+          "columns": [
+            "createdAt"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "LinkVisit_id": {
+          "name": "LinkVisit_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "visitId_idx": {
+          "name": "visitId_idx",
+          "columns": [
+            "visitId"
+          ]
+        }
+      },
+      "checkConstraint": {}
+    },
+    "LinkVisitDailySummary": {
+      "name": "LinkVisitDailySummary",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "linkId": {
+          "name": "linkId",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "clicks": {
+          "name": "clicks",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "uniqueClicks": {
+          "name": "uniqueClicks",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "LinkVisitDailySummary_id": {
+          "name": "LinkVisitDailySummary_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "link_date_unique": {
+          "name": "link_date_unique",
+          "columns": [
+            "linkId",
+            "date"
+          ]
+        }
+      },
+      "checkConstraint": {}
+    },
+    "QrPreset": {
+      "name": "QrPreset",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "teamId": {
+          "name": "teamId",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pixelStyle": {
+          "name": "pixelStyle",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'rounded'"
+        },
+        "markerShape": {
+          "name": "markerShape",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'square'"
+        },
+        "markerInnerShape": {
+          "name": "markerInnerShape",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'auto'"
+        },
+        "darkColor": {
+          "name": "darkColor",
+          "type": "varchar(9)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'#000000'"
+        },
+        "lightColor": {
+          "name": "lightColor",
+          "type": "varchar(9)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'#ffffff'"
+        },
+        "effect": {
+          "name": "effect",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'none'"
+        },
+        "effectRadius": {
+          "name": "effectRadius",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 12
+        },
+        "marginNoise": {
+          "name": "marginNoise",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "marginNoiseRate": {
+          "name": "marginNoiseRate",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'0.5'"
+        },
+        "logoImage": {
+          "name": "logoImage",
+          "type": "longtext",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "logoSize": {
+          "name": "logoSize",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 25
+        },
+        "logoMargin": {
+          "name": "logoMargin",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 4
+        },
+        "logoBorderRadius": {
+          "name": "logoBorderRadius",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 8
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "onUpdate": true
+        }
+      },
+      "indexes": {
+        "userId_idx": {
+          "name": "userId_idx",
+          "columns": [
+            "userId"
+          ],
+          "isUnique": false
+        },
+        "teamId_idx": {
+          "name": "teamId_idx",
+          "columns": [
+            "teamId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "QrPreset_id": {
+          "name": "QrPreset_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "QrCode": {
+      "name": "QrCode",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "qrCode": {
+          "name": "qrCode",
+          "type": "longtext",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "teamId": {
+          "name": "teamId",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "linkId": {
+          "name": "linkId",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "contentType": {
+          "name": "contentType",
+          "type": "enum('link','text')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "patternStyle": {
+          "name": "patternStyle",
+          "type": "enum('square','diamond','star','fluid','rounded','tile','stripe','fluid-line','stripe-column')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "cornerStyle": {
+          "name": "cornerStyle",
+          "type": "enum('circle','circle-diamond','square','square-diamond','rounded-circle','rounded','circle-star')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "color": {
+          "name": "color",
+          "type": "varchar(7)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "userId_idx": {
+          "name": "userId_idx",
+          "columns": [
+            "userId"
+          ],
+          "isUnique": false
+        },
+        "teamId_idx": {
+          "name": "teamId_idx",
+          "columns": [
+            "teamId"
+          ],
+          "isUnique": false
+        },
+        "linkId_idx": {
+          "name": "linkId_idx",
+          "columns": [
+            "linkId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "QrCode_id": {
+          "name": "QrCode_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "SiteSettings": {
+      "name": "SiteSettings",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "teamId": {
+          "name": "teamId",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "defaultDomain": {
+          "name": "defaultDomain",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'ishortn.ink'"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "onUpdate": true
+        }
+      },
+      "indexes": {
+        "userId_idx": {
+          "name": "userId_idx",
+          "columns": [
+            "userId"
+          ],
+          "isUnique": false
+        },
+        "teamId_idx": {
+          "name": "teamId_idx",
+          "columns": [
+            "teamId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "SiteSettings_id": {
+          "name": "SiteSettings_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "Subscription": {
+      "name": "Subscription",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "orderId": {
+          "name": "orderId",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "subscriptionId": {
+          "name": "subscriptionId",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "customerId": {
+          "name": "customerId",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "renewsAt": {
+          "name": "renewsAt",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "endsAt": {
+          "name": "endsAt",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "plan": {
+          "name": "plan",
+          "type": "enum('free','pro','ultra')",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'free'"
+        },
+        "billingInterval": {
+          "name": "billingInterval",
+          "type": "enum('monthly','annual')",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'monthly'"
+        },
+        "variantId": {
+          "name": "variantId",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "productId": {
+          "name": "productId",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "cardBrand": {
+          "name": "cardBrand",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "cardLastFour": {
+          "name": "cardLastFour",
+          "type": "varchar(4)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "''"
+        }
+      },
+      "indexes": {
+        "userId_idx": {
+          "name": "userId_idx",
+          "columns": [
+            "userId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "Subscription_id": {
+          "name": "Subscription_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "Subscription_userId_unique": {
+          "name": "Subscription_userId_unique",
+          "columns": [
+            "userId"
+          ]
+        }
+      },
+      "checkConstraint": {}
+    },
+    "Tag": {
+      "name": "Tag",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "teamId": {
+          "name": "teamId",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "name_idx": {
+          "name": "name_idx",
+          "columns": [
+            "name"
+          ],
+          "isUnique": false
+        },
+        "userId_idx": {
+          "name": "userId_idx",
+          "columns": [
+            "userId"
+          ],
+          "isUnique": false
+        },
+        "teamId_idx": {
+          "name": "teamId_idx",
+          "columns": [
+            "teamId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "Tag_id": {
+          "name": "Tag_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "unique_tag_team": {
+          "name": "unique_tag_team",
+          "columns": [
+            "name",
+            "teamId"
+          ]
+        }
+      },
+      "checkConstraint": {}
+    },
+    "Team": {
+      "name": "Team",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "avatarUrl": {
+          "name": "avatarUrl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "defaultDomain": {
+          "name": "defaultDomain",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'ishortn.ink'"
+        },
+        "ownerId": {
+          "name": "ownerId",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "onUpdate": true
+        },
+        "deletedAt": {
+          "name": "deletedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "ownerId_idx": {
+          "name": "ownerId_idx",
+          "columns": [
+            "ownerId"
+          ],
+          "isUnique": false
+        },
+        "deletedAt_idx": {
+          "name": "deletedAt_idx",
+          "columns": [
+            "deletedAt"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "Team_id": {
+          "name": "Team_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "Team_slug_unique": {
+          "name": "Team_slug_unique",
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "checkConstraint": {}
+    },
+    "TeamInvite": {
+      "name": "TeamInvite",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "teamId": {
+          "name": "teamId",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "inviteRole": {
+          "name": "inviteRole",
+          "type": "enum('admin','member')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'member'"
+        },
+        "token": {
+          "name": "token",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "invitedBy": {
+          "name": "invitedBy",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "acceptedAt": {
+          "name": "acceptedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "team_idx": {
+          "name": "team_idx",
+          "columns": [
+            "teamId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "TeamInvite_id": {
+          "name": "TeamInvite_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "TeamInvite_token_unique": {
+          "name": "TeamInvite_token_unique",
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "checkConstraint": {}
+    },
+    "TeamMember": {
+      "name": "TeamMember",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "teamId": {
+          "name": "teamId",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "enum('owner','admin','member')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "onUpdate": true
+        }
+      },
+      "indexes": {
+        "team_user_idx": {
+          "name": "team_user_idx",
+          "columns": [
+            "teamId",
+            "userId"
+          ],
+          "isUnique": false
+        },
+        "user_idx": {
+          "name": "user_idx",
+          "columns": [
+            "userId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "TeamMember_id": {
+          "name": "TeamMember_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "unique_team_user": {
+          "name": "unique_team_user",
+          "columns": [
+            "teamId",
+            "userId"
+          ]
+        }
+      },
+      "checkConstraint": {}
+    },
+    "Token": {
+      "name": "Token",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "token": {
+          "name": "token",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "userId_idx": {
+          "name": "userId_idx",
+          "columns": [
+            "userId"
+          ],
+          "isUnique": false
+        },
+        "token_idx": {
+          "name": "token_idx",
+          "columns": [
+            "token"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "Token_id": {
+          "name": "Token_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "UniqueLinkVisit": {
+      "name": "UniqueLinkVisit",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "linkId": {
+          "name": "linkId",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ipHash": {
+          "name": "ipHash",
+          "type": "char(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "linkId_idx": {
+          "name": "linkId_idx",
+          "columns": [
+            "linkId"
+          ],
+          "isUnique": false
+        },
+        "ipHash_idx": {
+          "name": "ipHash_idx",
+          "columns": [
+            "ipHash"
+          ],
+          "isUnique": false
+        },
+        "linkId_createdAt_idx": {
+          "name": "linkId_createdAt_idx",
+          "columns": [
+            "linkId",
+            "createdAt"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "UniqueLinkVisit_id": {
+          "name": "UniqueLinkVisit_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "unique_visit_idx": {
+          "name": "unique_visit_idx",
+          "columns": [
+            "linkId",
+            "ipHash"
+          ]
+        }
+      },
+      "checkConstraint": {}
+    },
+    "User": {
+      "name": "User",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "imageUrl": {
+          "name": "imageUrl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "qrCodeCount": {
+          "name": "qrCodeCount",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "monthlyLinkCount": {
+          "name": "monthlyLinkCount",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "lastLinkCountReset": {
+          "name": "lastLinkCountReset",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "monthlyEventCount": {
+          "name": "monthlyEventCount",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "lastEventCountReset": {
+          "name": "lastEventCountReset",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "eventUsageAlertLevel": {
+          "name": "eventUsageAlertLevel",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "lastViewedChangelogSlug": {
+          "name": "lastViewedChangelogSlug",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "deletedAt": {
+          "name": "deletedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "isAdmin": {
+          "name": "isAdmin",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "banned": {
+          "name": "banned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "bannedAt": {
+          "name": "bannedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "bannedReason": {
+          "name": "bannedReason",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "deletedAt_idx": {
+          "name": "deletedAt_idx",
+          "columns": [
+            "deletedAt"
+          ],
+          "isUnique": false
+        },
+        "createdAt_idx": {
+          "name": "createdAt_idx",
+          "columns": [
+            "createdAt"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "User_id": {
+          "name": "User_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "User_email_unique": {
+          "name": "User_email_unique",
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "checkConstraint": {}
+    },
+    "UtmTemplate": {
+      "name": "UtmTemplate",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "utmSource": {
+          "name": "utmSource",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "utmMedium": {
+          "name": "utmMedium",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "utmCampaign": {
+          "name": "utmCampaign",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "utmTerm": {
+          "name": "utmTerm",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "utmContent": {
+          "name": "utmContent",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "teamId": {
+          "name": "teamId",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "onUpdate": true
+        }
+      },
+      "indexes": {
+        "userId_idx": {
+          "name": "userId_idx",
+          "columns": [
+            "userId"
+          ],
+          "isUnique": false
+        },
+        "teamId_idx": {
+          "name": "teamId_idx",
+          "columns": [
+            "teamId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "UtmTemplate_id": {
+          "name": "UtmTemplate_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    }
+  },
+  "views": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "tables": {},
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -428,6 +428,20 @@
       "when": 1777891200000,
       "tag": "0060_fix_audience_feedback_collation",
       "breakpoints": true
+    },
+    {
+      "idx": 61,
+      "version": "5",
+      "when": 1781808197767,
+      "tag": "0061_tan_supreme_intelligence",
+      "breakpoints": true
+    },
+    {
+      "idx": 62,
+      "version": "5",
+      "when": 1781810597825,
+      "tag": "0062_abnormal_stranger",
+      "breakpoints": true
     }
   ]
 }

--- a/src/app/(landing)/_components/footer.tsx
+++ b/src/app/(landing)/_components/footer.tsx
@@ -37,6 +37,7 @@ const columns = [
     links: [
       { label: "Privacy", href: "/privacy" },
       { label: "Terms", href: "/terms" },
+      { label: "Report abuse", href: "/abuse" },
     ],
   },
 ];

--- a/src/app/(landing)/_components/pricing.tsx
+++ b/src/app/(landing)/_components/pricing.tsx
@@ -1,56 +1,57 @@
+"use client";
+
 import Link from "next/link";
+import { useState } from "react";
 
 import { PLAN_FEATURES } from "@/lib/billing/plan-features";
-import { PLAN_PRICES_USD } from "@/lib/constants/plan-pricing";
+import { PLAN_PRICES_ANNUAL_USD, PLAN_PRICES_USD } from "@/lib/constants/plan-pricing";
 
 import { Icon } from "./warm-primitives";
 
-const buildPlans = (_annual: boolean) =>
-  [
-    {
-      name: "Free",
-      price: PLAN_PRICES_USD.free,
-      cadence: "forever",
-      tagline: "For tinkering and side projects.",
-      cta: "Start for free",
-      href: "/auth/sign-up?next=%2Fdashboard",
-      style: "ghost" as const,
-      featured: false,
-      features: PLAN_FEATURES.free.features,
-    },
-    {
-      name: "Pro",
-      price: PLAN_PRICES_USD.pro,
-      cadence: "/month",
-      tagline: "For creators, indie makers, and growing teams.",
-      cta: "Get Pro",
-      href: "/auth/sign-up?next=%2Fdashboard%2Fpricing%3Fplan%3Dpro",
-      style: "accent" as const,
-      featured: true,
-      features: PLAN_FEATURES.pro.features,
-    },
-    {
-      name: "Ultra",
-      price: PLAN_PRICES_USD.ultra,
-      cadence: "/month",
-      tagline: "For studios, agencies, and whoever wants no ceilings.",
-      cta: "Go Ultra",
-      href: "/auth/sign-up?next=%2Fdashboard%2Fpricing%3Fplan%3Dultra",
-      style: "primary" as const,
-      featured: false,
-      features: PLAN_FEATURES.ultra.features,
-    },
-  ];
+const signupHref = (next: string) => `/auth/sign-up?next=${encodeURIComponent(next)}`;
+
+const buildPlans = (annual: boolean) => [
+  {
+    name: "Free",
+    price: PLAN_PRICES_USD.free,
+    cadence: "forever",
+    tagline: "For tinkering and side projects.",
+    cta: "Start for free",
+    href: signupHref("/dashboard"),
+    style: "ghost" as const,
+    featured: false,
+    features: PLAN_FEATURES.free.features,
+  },
+  {
+    name: "Pro",
+    price: annual ? PLAN_PRICES_ANNUAL_USD.pro : PLAN_PRICES_USD.pro,
+    cadence: annual ? "/year" : "/month",
+    tagline: "For creators, indie makers, and growing teams.",
+    cta: "Get Pro",
+    href: signupHref(`/dashboard/pricing?plan=pro${annual ? "&interval=annual" : ""}`),
+    style: "accent" as const,
+    featured: true,
+    features: PLAN_FEATURES.pro.features,
+  },
+  {
+    name: "Ultra",
+    price: annual ? PLAN_PRICES_ANNUAL_USD.ultra : PLAN_PRICES_USD.ultra,
+    cadence: annual ? "/year" : "/month",
+    tagline: "For studios, agencies, and whoever wants no ceilings.",
+    cta: "Go Ultra",
+    href: signupHref(`/dashboard/pricing?plan=ultra${annual ? "&interval=annual" : ""}`),
+    style: "primary" as const,
+    featured: false,
+    features: PLAN_FEATURES.ultra.features,
+  },
+];
 
 export const Pricing = () => {
-  const plans = buildPlans(false);
+  const [annual, setAnnual] = useState(false);
+  const plans = buildPlans(annual);
 
   return (
-    <section
-      id="pricing"
-      className="warm-section"
-      style={{ background: "var(--warm-bg)" }}
-    >
+    <section id="pricing" className="warm-section" style={{ background: "var(--warm-bg)" }}>
       <div className="warm-container">
         <div
           style={{
@@ -59,10 +60,7 @@ export const Pricing = () => {
             margin: "0 auto 56px",
           }}
         >
-          <div
-            className="warm-eyebrow"
-            style={{ marginBottom: 20, justifyContent: "center" }}
-          >
+          <div className="warm-eyebrow" style={{ marginBottom: 20, justifyContent: "center" }}>
             <Icon.Heart
               style={{
                 width: 12,
@@ -72,10 +70,7 @@ export const Pricing = () => {
             />
             Fair pricing
           </div>
-          <h2
-            className="warm-display"
-            style={{ margin: 0, fontSize: "clamp(44px, 7vw, 80px)" }}
-          >
+          <h2 className="warm-display" style={{ margin: 0, fontSize: "clamp(44px, 7vw, 80px)" }}>
             Simple prices,
             <br />
             <em style={{ fontStyle: "italic" }}>no surprises.</em>
@@ -90,12 +85,55 @@ export const Pricing = () => {
           >
             Start free forever. Upgrade when you're ready. Cancel in one click.
           </p>
+
+          <div
+            style={{
+              display: "inline-flex",
+              alignItems: "center",
+              gap: 12,
+              marginTop: 28,
+            }}
+          >
+            <div
+              className="warm-card"
+              style={{
+                display: "inline-flex",
+                padding: 4,
+                borderRadius: 999,
+                gap: 4,
+              }}
+            >
+              {([false, true] as const).map((value) => (
+                <button
+                  key={String(value)}
+                  type="button"
+                  onClick={() => setAnnual(value)}
+                  className="warm-btn"
+                  style={{
+                    padding: "8px 18px",
+                    borderRadius: 999,
+                    fontSize: 13,
+                    background: annual === value ? "var(--warm-ink)" : "transparent",
+                    color: annual === value ? "var(--warm-paper)" : "var(--warm-mute)",
+                  }}
+                >
+                  {value ? "Annual" : "Monthly"}
+                </button>
+              ))}
+            </div>
+            <span
+              style={{
+                fontSize: 12,
+                fontWeight: 500,
+                color: "var(--warm-sage-deep)",
+              }}
+            >
+              Save 2 months
+            </span>
+          </div>
         </div>
 
-        <div
-          className="warm-pricing-grid"
-          style={{ display: "grid", gap: 20 }}
-        >
+        <div className="warm-pricing-grid" style={{ display: "grid", gap: 20 }}>
           {plans.map((p) => (
             <div
               key={p.name}
@@ -217,9 +255,7 @@ export const Pricing = () => {
                       style={{
                         width: 14,
                         height: 14,
-                        color: p.featured
-                          ? "var(--warm-accent)"
-                          : "var(--warm-sage-deep)",
+                        color: p.featured ? "var(--warm-accent)" : "var(--warm-sage-deep)",
                         flexShrink: 0,
                         marginTop: 3,
                       }}

--- a/src/app/(landing)/abuse/abuse-report-form.tsx
+++ b/src/app/(landing)/abuse/abuse-report-form.tsx
@@ -1,0 +1,163 @@
+"use client";
+
+import { useState } from "react";
+import { toast } from "sonner";
+
+import { ABUSE_CATEGORY_LABELS, abuseCategoryValues } from "@/server/api/routers/abuse/abuse.input";
+import { api } from "@/trpc/react";
+
+const fieldStyle: React.CSSProperties = {
+  width: "100%",
+  padding: "12px 14px",
+  borderRadius: "var(--warm-radius-sm)",
+  border: "1px solid var(--warm-line)",
+  background: "var(--warm-paper)",
+  color: "var(--warm-ink)",
+  fontSize: 14,
+  fontFamily: "var(--font-warm-ui)",
+  outline: "none",
+};
+
+const labelStyle: React.CSSProperties = {
+  display: "block",
+  marginBottom: 8,
+  fontSize: 13,
+  fontWeight: 500,
+  color: "var(--warm-ink-soft)",
+};
+
+export function AbuseReportForm() {
+  const [shortUrl, setShortUrl] = useState("");
+  const [category, setCategory] = useState<(typeof abuseCategoryValues)[number]>("phishing");
+  const [reporterEmail, setReporterEmail] = useState("");
+  const [details, setDetails] = useState("");
+  const [submitted, setSubmitted] = useState(false);
+
+  const reportMutation = api.abuse.report.useMutation({
+    onSuccess: () => setSubmitted(true),
+    onError: (error) => toast.error(error.message),
+  });
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    reportMutation.mutate({
+      shortUrl: shortUrl.trim(),
+      category,
+      reporterEmail: reporterEmail.trim() || undefined,
+      details: details.trim() || undefined,
+    });
+  };
+
+  if (submitted) {
+    return (
+      <div className="warm-card" style={{ padding: 32, textAlign: "center" }}>
+        <h2 style={{ margin: 0, fontSize: 20, fontWeight: 700 }}>Report received</h2>
+        <p
+          style={{
+            marginTop: 12,
+            fontSize: 14,
+            color: "var(--warm-mute)",
+            lineHeight: 1.6,
+          }}
+        >
+          Thank you. Our team reviews every report and takes action on links that violate our
+          policies. If you left an email, we may reach out for more detail.
+        </p>
+        <button
+          type="button"
+          className="warm-btn warm-btn-ghost"
+          style={{ marginTop: 24 }}
+          onClick={() => {
+            setShortUrl("");
+            setCategory("phishing");
+            setReporterEmail("");
+            setDetails("");
+            setSubmitted(false);
+          }}
+        >
+          Report another link
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <form
+      className="warm-card"
+      style={{ padding: 32, display: "grid", gap: 20 }}
+      onSubmit={handleSubmit}
+    >
+      <div>
+        <label htmlFor="shortUrl" style={labelStyle}>
+          Short link <span style={{ color: "var(--warm-accent)" }}>*</span>
+        </label>
+        <input
+          id="shortUrl"
+          type="text"
+          required
+          placeholder="ishortn.ink/abc"
+          value={shortUrl}
+          onChange={(e) => setShortUrl(e.target.value)}
+          style={fieldStyle}
+        />
+      </div>
+
+      <div>
+        <label htmlFor="category" style={labelStyle}>
+          Reason <span style={{ color: "var(--warm-accent)" }}>*</span>
+        </label>
+        <select
+          id="category"
+          required
+          value={category}
+          onChange={(e) => setCategory(e.target.value as (typeof abuseCategoryValues)[number])}
+          style={fieldStyle}
+        >
+          {abuseCategoryValues.map((value) => (
+            <option key={value} value={value}>
+              {ABUSE_CATEGORY_LABELS[value]}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      <div>
+        <label htmlFor="reporterEmail" style={labelStyle}>
+          Your email <span style={{ color: "var(--warm-mute)", fontWeight: 400 }}>(optional)</span>
+        </label>
+        <input
+          id="reporterEmail"
+          type="email"
+          placeholder="you@example.com"
+          value={reporterEmail}
+          onChange={(e) => setReporterEmail(e.target.value)}
+          style={fieldStyle}
+        />
+      </div>
+
+      <div>
+        <label htmlFor="details" style={labelStyle}>
+          Additional details{" "}
+          <span style={{ color: "var(--warm-mute)", fontWeight: 400 }}>(optional)</span>
+        </label>
+        <textarea
+          id="details"
+          rows={4}
+          placeholder="Tell us what's wrong with this link."
+          value={details}
+          onChange={(e) => setDetails(e.target.value)}
+          style={{ ...fieldStyle, resize: "vertical" }}
+        />
+      </div>
+
+      <button
+        type="submit"
+        className="warm-btn warm-btn-accent warm-btn-lg"
+        disabled={reportMutation.isLoading}
+        style={{ justifyContent: "center" }}
+      >
+        {reportMutation.isLoading ? "Submitting..." : "Submit report"}
+      </button>
+    </form>
+  );
+}

--- a/src/app/(landing)/abuse/page.tsx
+++ b/src/app/(landing)/abuse/page.tsx
@@ -1,0 +1,78 @@
+import type { Metadata } from "next";
+
+import { Footer } from "../_components/footer";
+import { Header } from "../_components/header";
+import { AbuseReportForm } from "./abuse-report-form";
+
+export const metadata: Metadata = {
+  title: "Report Abuse - iShortn",
+  description:
+    "Report a short link that is being used for phishing, malware, spam, or other abuse. iShortn reviews every report and acts on links that violate our policies.",
+  openGraph: {
+    title: "Report Abuse - iShortn",
+    description:
+      "Report a short link that is being used for phishing, malware, spam, or other abuse.",
+    type: "website",
+  },
+};
+
+export default function AbusePage() {
+  return (
+    <main style={{ background: "var(--warm-bg)", color: "var(--warm-ink)" }}>
+      <Header />
+
+      <section className="warm-subhero">
+        <div className="warm-container">
+          <div className="warm-eyebrow" style={{ marginBottom: 24 }}>
+            <span className="warm-eyebrow-dot" />
+            Trust &amp; Safety
+          </div>
+          <h1 className="warm-display" style={{ margin: 0, fontSize: "clamp(44px, 11vw, 104px)" }}>
+            Report <em style={{ fontStyle: "italic", color: "var(--warm-accent)" }}>abuse</em>.
+          </h1>
+          <p
+            style={{
+              marginTop: 20,
+              maxWidth: 560,
+              fontSize: 15,
+              lineHeight: 1.6,
+              color: "var(--warm-mute)",
+            }}
+          >
+            Found a short link being used for phishing, malware, spam, or impersonation? Let us
+            know. We review every report and disable links that violate our policies.
+          </p>
+        </div>
+      </section>
+
+      <section style={{ padding: "16px 0 120px" }}>
+        <div className="warm-container" style={{ maxWidth: 620 }}>
+          <AbuseReportForm />
+          <p
+            style={{
+              marginTop: 20,
+              fontSize: 13,
+              color: "var(--warm-mute)",
+              lineHeight: 1.6,
+            }}
+          >
+            For urgent legal matters, you can also reach us at{" "}
+            <a
+              href="mailto:support@ishortn.ink"
+              style={{
+                color: "var(--warm-ink-soft)",
+                textDecoration: "underline",
+                textUnderlineOffset: 2,
+              }}
+            >
+              support@ishortn.ink
+            </a>
+            .
+          </p>
+        </div>
+      </section>
+
+      <Footer />
+    </main>
+  );
+}

--- a/src/app/(main)/[linkAlias]/page.tsx
+++ b/src/app/(main)/[linkAlias]/page.tsx
@@ -33,13 +33,10 @@ const getDomain = (incomingDomain: string | null): string => {
   return DEFAULT_DOMAIN;
 };
 
-export async function generateMetadata(
-  props: LinkRedirectionPageProps
-): Promise<Metadata> {
+export async function generateMetadata(props: LinkRedirectionPageProps): Promise<Metadata> {
   const params = await props.params;
   const headersList = await headers();
-  const incomingDomain =
-    headersList.get("x-forwarded-host") ?? headersList.get("host");
+  const incomingDomain = headersList.get("x-forwarded-host") ?? headersList.get("host");
   const domain = getDomain(incomingDomain);
 
   if (params.linkAlias.toLowerCase().endsWith(".png")) {
@@ -82,8 +79,7 @@ const cleanAlias = (incomingAlias: string): string => {
 const LinkRedirectionPage = async (props: LinkRedirectionPageProps) => {
   const params = await props.params;
   const headersList = await headers();
-  const incomingDomain =
-    headersList.get("x-forwarded-host") ?? headersList.get("host");
+  const incomingDomain = headersList.get("x-forwarded-host") ?? headersList.get("host");
   const userAgent = headersList.get("user-agent");
   const domain = getDomain(incomingDomain);
 
@@ -98,6 +94,11 @@ const LinkRedirectionPage = async (props: LinkRedirectionPageProps) => {
   });
 
   if (!link) return notFound();
+
+  // Blocked links must never resolve, preview, or redirect.
+  if (link.blocked) {
+    redirect(`/blocked/${link.id}`);
+  }
 
   // Check link expiration (disabled flag and date-based)
   if (link.disabled) {

--- a/src/app/(main)/dashboard/_components/bulk-actions/bulk-actions.tsx
+++ b/src/app/(main)/dashboard/_components/bulk-actions/bulk-actions.tsx
@@ -141,7 +141,7 @@ export function BulkLinkActions() {
       <BulkLinkUploadDialog
         open={isUploadModalOpen && !isDropdownOpen}
         setOpen={setIsUploadModalOpen}
-        proMembership={subStatus?.subscriptions?.status === "active"}
+        proMembership={(subStatus?.plan ?? "free") !== "free"}
       />
     </>
   );

--- a/src/app/(main)/dashboard/_components/links/link-card/edit-link-drawer.tsx
+++ b/src/app/(main)/dashboard/_components/links/link-card/edit-link-drawer.tsx
@@ -216,7 +216,7 @@ export function EditLinkDrawer({ link, open, onClose }: EditLinkDrawerProps) {
               : POSTHOG_EVENTS.VERIFIED_CLICKS_DISABLED,
             {
               linkId: link.id,
-              plan: subscriptionStatus?.plan ?? "free",
+              plan: userSubscription?.data?.plan ?? "free",
               source: "edit",
             },
           );
@@ -231,9 +231,9 @@ export function EditLinkDrawer({ link, open, onClose }: EditLinkDrawerProps) {
     );
   }
 
-  const subscriptionStatus = userSubscription?.data?.subscriptions;
-  const isUltraUser = subscriptionStatus?.plan === "ultra";
-  const isProOrUltraUser = subscriptionStatus?.status === "active";
+  const resolvedPlan = userSubscription?.data?.plan ?? "free";
+  const isUltraUser = resolvedPlan === "ultra";
+  const isProOrUltraUser = resolvedPlan !== "free";
 
   // Watch the URL field for debouncing
   const watchedUrl = form.watch("url");

--- a/src/app/(main)/dashboard/_components/navigation/sidebar-stats.tsx
+++ b/src/app/(main)/dashboard/_components/navigation/sidebar-stats.tsx
@@ -3,6 +3,7 @@
 import { IconArrowUpRight } from "@tabler/icons-react";
 import { Link } from "next-view-transitions";
 
+import { trackUpgradeClick } from "@/lib/analytics/upgrade-prompt";
 import { cn } from "@/lib/utils";
 
 type SidebarStatsProps = {
@@ -87,6 +88,7 @@ export function SidebarStats({
         {plan === "pro" && (
           <Link
             href="/dashboard/pricing"
+            onClick={() => trackUpgradeClick("sidebar_pro")}
             className="flex items-center gap-1 px-1 text-[12px] font-medium text-neutral-400 dark:text-neutral-500 transition-colors hover:text-neutral-900 dark:hover:text-foreground"
           >
             Upgrade to Ultra
@@ -141,6 +143,7 @@ export function SidebarStats({
 
       <Link
         href="/dashboard/pricing"
+        onClick={() => trackUpgradeClick(isAtLimit ? "sidebar_free_at_limit" : "sidebar_free")}
         className="flex items-center justify-center gap-1.5 rounded-lg bg-blue-600 px-3 py-2 text-[12px] font-medium text-white transition-colors hover:bg-blue-700"
       >
         Upgrade to Pro

--- a/src/app/(main)/dashboard/admin/flagged/page.tsx
+++ b/src/app/(main)/dashboard/admin/flagged/page.tsx
@@ -148,6 +148,18 @@ export default function AdminFlaggedLinksPage() {
                         {f.reason}
                       </p>
                     )}
+                    {f.details && (
+                      <p className="mt-1 text-[12px] text-neutral-500 dark:text-neutral-400">
+                        <span className="font-medium text-neutral-600 dark:text-neutral-400">Details:</span>{" "}
+                        {f.details}
+                      </p>
+                    )}
+                    {f.reporterEmail && (
+                      <p className="mt-1 text-[12px] text-neutral-500 dark:text-neutral-400">
+                        <span className="font-medium text-neutral-600 dark:text-neutral-400">Reporter:</span>{" "}
+                        {f.reporterEmail}
+                      </p>
+                    )}
                     <p className="mt-1 text-[11px] text-neutral-400 dark:text-neutral-500">
                       Flagged{" "}
                       {f.flaggedAt

--- a/src/app/(main)/dashboard/domains/_components/add-domain-modal.tsx
+++ b/src/app/(main)/dashboard/domains/_components/add-domain-modal.tsx
@@ -72,7 +72,7 @@ export function AddCustomDomainModal() {
     });
   };
 
-  const isProUser = userSubscription?.subscriptions?.status === "active";
+  const isProUser = (userSubscription?.plan ?? "free") !== "free";
 
   const canAddDomains =
     workspace?.type === "personal" ||

--- a/src/app/(main)/dashboard/folders/page.tsx
+++ b/src/app/(main)/dashboard/folders/page.tsx
@@ -10,7 +10,7 @@ export default async function FoldersPage() {
     api.subscriptions.get.query(),
   ]);
 
-  const isProUser = subDetails?.subscriptions?.status === "active";
+  const isProUser = (subDetails?.plan ?? "free") !== "free";
 
   return <FoldersView initialFolders={folders} isProUser={isProUser} />;
 }

--- a/src/app/(main)/dashboard/link/new/page.tsx
+++ b/src/app/(main)/dashboard/link/new/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { POSTHOG_EVENTS, trackEvent } from "@/lib/analytics/events";
+import { notifyPlanLimit } from "@/lib/analytics/upgrade-prompt";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { AnimatePresence, motion } from "framer-motion";
 import {
@@ -199,7 +200,11 @@ export default function CreateLinkPage() {
       router.push("/dashboard");
     },
     onError: (error) => {
-      toast.error(error.message);
+      if (error.data?.code === "FORBIDDEN" || /upgrade/i.test(error.message)) {
+        notifyPlanLimit(error.message, "link_create");
+      } else {
+        toast.error(error.message);
+      }
     },
   });
 
@@ -339,7 +344,7 @@ export default function CreateLinkPage() {
           favicon: fetchedMetadata.favicon,
         }));
 
-        if (userSubscription?.data?.subscriptions?.status === "active") {
+        if ((userSubscription?.data?.plan ?? "free") !== "free") {
           generateAliasMutation.mutate({
             url: debouncedUrl,
             title: customTitle || fetchedMetadata.title,
@@ -422,8 +427,8 @@ export default function CreateLinkPage() {
     };
   }, [cloakingEnabled, debouncedUrl, form]);
 
-  const isProUser = userSubscription?.data?.subscriptions?.status === "active";
-  const isUltraUser = userSubscription?.data?.subscriptions?.plan === "ultra";
+  const isProUser = (userSubscription?.data?.plan ?? "free") !== "free";
+  const isUltraUser = userSubscription?.data?.plan === "ultra";
 
   return (
     <section className="grid grid-cols-1 gap-5 md:grid-cols-11">

--- a/src/app/(main)/dashboard/pricing/_components/pricing-cards.tsx
+++ b/src/app/(main)/dashboard/pricing/_components/pricing-cards.tsx
@@ -9,12 +9,13 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { POSTHOG_EVENTS, trackEvent } from "@/lib/analytics/events";
 import { PLAN_FEATURES } from "@/lib/billing/plan-features";
+import { PLAN_PRICES_ANNUAL_USD, PLAN_PRICES_USD } from "@/lib/constants/plan-pricing";
 import { cn } from "@/lib/utils";
 import { api } from "@/trpc/react";
 
 import { DowngradeFeedbackModal } from "./downgrade-feedback-modal";
 
-import type { Plan } from "@/lib/billing/plans";
+import type { BillingInterval, Plan } from "@/lib/billing/plans";
 
 type PricingCardsProps = {
   currentPlan: Plan;
@@ -25,21 +26,17 @@ const plans = [
     id: "free" as Plan,
     name: "Free",
     description: "For personal use with basic features",
-    price: 0,
-    period: "forever",
+    monthlyPrice: PLAN_PRICES_USD.free,
+    annualPrice: PLAN_PRICES_USD.free,
     features: PLAN_FEATURES.free.features,
-    limitations: [
-      "No custom domains",
-      "No folders",
-      "Limited analytics",
-    ],
+    limitations: ["No custom domains", "No folders", "Limited analytics"],
   },
   {
     id: "pro" as Plan,
     name: "Pro",
     description: "For creators and small businesses",
-    price: 5,
-    period: "per month",
+    monthlyPrice: PLAN_PRICES_USD.pro,
+    annualPrice: PLAN_PRICES_ANNUAL_USD.pro,
     popular: true,
     features: PLAN_FEATURES.pro.features,
   },
@@ -47,8 +44,8 @@ const plans = [
     id: "ultra" as Plan,
     name: "Ultra",
     description: "For teams and power users",
-    price: 15,
-    period: "per month",
+    monthlyPrice: PLAN_PRICES_USD.ultra,
+    annualPrice: PLAN_PRICES_ANNUAL_USD.ultra,
     features: PLAN_FEATURES.ultra.features,
     comingSoon: PLAN_FEATURES.ultra.comingSoon,
   },
@@ -57,12 +54,14 @@ const plans = [
 export function PricingCards({ currentPlan }: PricingCardsProps) {
   const searchParams = useSearchParams();
   const autoCheckoutFired = useRef(false);
+  const [interval, setIntervalState] = useState<BillingInterval>(
+    searchParams?.get("interval") === "annual" ? "annual" : "monthly",
+  );
   const [loadingPlan, setLoadingPlan] = useState<Plan | null>(null);
   const [downgradeModalOpen, setDowngradeModalOpen] = useState(false);
-  const [targetDowngradePlan, setTargetDowngradePlan] = useState<Exclude<
-    Plan,
-    "ultra"
-  > | null>(null);
+  const [targetDowngradePlan, setTargetDowngradePlan] = useState<Exclude<Plan, "ultra"> | null>(
+    null,
+  );
 
   const createCheckoutOrUpdateMutation = api.lemonsqueezy.createCheckoutOrUpdate.useMutation({
     onSuccess: (data) => {
@@ -99,10 +98,13 @@ export function PricingCards({ currentPlan }: PricingCardsProps) {
     },
   });
 
-  const handleUpgrade = (plan: typeof plans[number]) => {
+  const handleUpgrade = (plan: (typeof plans)[number]) => {
     if (plan.id === "free") return;
     setLoadingPlan(plan.id);
-    createCheckoutOrUpdateMutation.mutate({ plan: plan.id });
+    createCheckoutOrUpdateMutation.mutate({
+      plan: plan.id as Exclude<Plan, "free">,
+      interval,
+    });
   };
 
   const handleManageSubscription = (planId: Plan) => {
@@ -131,8 +133,7 @@ export function PricingCards({ currentPlan }: PricingCardsProps) {
     const targetPlan = plans.find((p) => p.id === requestedPlan);
     if (!targetPlan) return;
 
-    const canUpgrade =
-      getPlanOrder(targetPlan.id) > getPlanOrder(currentPlan);
+    const canUpgrade = getPlanOrder(targetPlan.id) > getPlanOrder(currentPlan);
     if (!canUpgrade) return;
 
     autoCheckoutFired.current = true;
@@ -151,6 +152,30 @@ export function PricingCards({ currentPlan }: PricingCardsProps) {
         </p>
       </div>
 
+      {/* Billing interval toggle */}
+      <div className="flex items-center justify-center gap-3">
+        <div className="inline-flex items-center gap-1 rounded-full border border-gray-200 dark:border-border bg-white dark:bg-card p-1">
+          {(["monthly", "annual"] as const).map((value) => (
+            <button
+              key={value}
+              type="button"
+              onClick={() => setIntervalState(value)}
+              className={cn(
+                "rounded-full px-4 py-1.5 text-sm font-medium transition-colors",
+                interval === value
+                  ? "bg-gray-900 text-white dark:bg-muted dark:text-foreground"
+                  : "text-gray-500 dark:text-neutral-400 hover:text-gray-900 dark:hover:text-foreground",
+              )}
+            >
+              {value === "monthly" ? "Monthly" : "Annual"}
+            </button>
+          ))}
+        </div>
+        <Badge className="bg-green-100 text-green-700 dark:bg-green-500/10 dark:text-green-400 hover:bg-green-100">
+          Save 2 months
+        </Badge>
+      </div>
+
       {/* Pricing Cards */}
       <div className="grid gap-6 lg:grid-cols-3">
         {plans.map((plan) => {
@@ -163,8 +188,10 @@ export function PricingCards({ currentPlan }: PricingCardsProps) {
               key={plan.id}
               className={cn(
                 "relative flex flex-col rounded-2xl border bg-white dark:bg-card p-6 shadow-sm transition-shadow hover:shadow-md",
-                plan.popular && currentPlan === "free" && "border-gray-900 dark:border-border ring-1 ring-gray-900 dark:ring-border",
-                isCurrentPlan && "border-blue-500 ring-1 ring-blue-500"
+                plan.popular &&
+                  currentPlan === "free" &&
+                  "border-gray-900 dark:border-border ring-1 ring-gray-900 dark:ring-border",
+                isCurrentPlan && "border-blue-500 ring-1 ring-blue-500",
               )}
             >
               {/* Popular Badge */}
@@ -180,9 +207,7 @@ export function PricingCards({ currentPlan }: PricingCardsProps) {
               {/* Current Plan Badge */}
               {isCurrentPlan && (
                 <div className="absolute -top-3 left-1/2 -translate-x-1/2">
-                  <Badge className="bg-blue-600 text-white px-3 py-1">
-                    Current Plan
-                  </Badge>
+                  <Badge className="bg-blue-600 text-white px-3 py-1">Current Plan</Badge>
                 </div>
               )}
 
@@ -201,11 +226,15 @@ export function PricingCards({ currentPlan }: PricingCardsProps) {
                 <div className="flex items-baseline">
                   <span className="text-sm font-medium text-gray-500 dark:text-neutral-400">$</span>
                   <span className="text-5xl font-bold tracking-tight text-gray-900 dark:text-foreground">
-                    {plan.price}
+                    {interval === "annual" ? plan.annualPrice : plan.monthlyPrice}
                   </span>
                 </div>
                 <p className="mt-1 text-sm text-gray-500 dark:text-neutral-400">
-                  {plan.period}
+                  {plan.id === "free"
+                    ? "forever"
+                    : interval === "annual"
+                      ? "per year"
+                      : "per month"}
                 </p>
               </div>
 
@@ -227,7 +256,7 @@ export function PricingCards({ currentPlan }: PricingCardsProps) {
                       "w-full",
                       plan.popular
                         ? "bg-gray-900 hover:bg-gray-800 dark:bg-muted dark:hover:bg-accent dark:text-foreground"
-                        : ""
+                        : "",
                     )}
                     onClick={() => handleUpgrade(plan)}
                     disabled={loadingPlan !== null}
@@ -247,20 +276,18 @@ export function PricingCards({ currentPlan }: PricingCardsProps) {
                 ) : null}
               </div>
 
-
-
               {/* Features */}
               <div className="flex-1">
                 <p className="text-sm font-medium text-gray-900 dark:text-foreground mb-4">
-                  {plan.id === "free" ? "Features" : `Everything in ${plan.id === "pro" ? "Free" : "Pro"}, plus:`}
+                  {plan.id === "free"
+                    ? "Features"
+                    : `Everything in ${plan.id === "pro" ? "Free" : "Pro"}, plus:`}
                 </p>
                 <ul className="space-y-3">
                   {plan.features.map((feature) => (
                     <li key={feature} className="flex items-start gap-3">
                       <Check className="h-4 w-4 text-gray-600 dark:text-neutral-400 mt-0.5 shrink-0" />
-                      <span className="text-sm text-gray-600 dark:text-neutral-400">
-                        {feature}
-                      </span>
+                      <span className="text-sm text-gray-600 dark:text-neutral-400">{feature}</span>
                     </li>
                   ))}
                 </ul>
@@ -293,10 +320,15 @@ export function PricingCards({ currentPlan }: PricingCardsProps) {
                 {/* Limitations for free plan */}
                 {plan.limitations && (
                   <div className="mt-6 pt-4 border-t border-gray-100 dark:border-border/50">
-                    <p className="text-xs font-medium text-gray-500 dark:text-neutral-400 mb-2">Limitations:</p>
+                    <p className="text-xs font-medium text-gray-500 dark:text-neutral-400 mb-2">
+                      Limitations:
+                    </p>
                     <ul className="space-y-1">
                       {plan.limitations.map((limitation) => (
-                        <li key={limitation} className="text-xs text-gray-400 dark:text-neutral-500">
+                        <li
+                          key={limitation}
+                          className="text-xs text-gray-400 dark:text-neutral-500"
+                        >
                           • {limitation}
                         </li>
                       ))}
@@ -314,12 +346,9 @@ export function PricingCards({ currentPlan }: PricingCardsProps) {
           open={downgradeModalOpen}
           onOpenChange={setDowngradeModalOpen}
           targetPlan={targetDowngradePlan}
-          currentPlanName={
-            plans.find((p) => p.id === currentPlan)?.name ?? currentPlan
-          }
+          currentPlanName={plans.find((p) => p.id === currentPlan)?.name ?? currentPlan}
           targetPlanName={
-            plans.find((p) => p.id === targetDowngradePlan)?.name ??
-            targetDowngradePlan
+            plans.find((p) => p.id === targetDowngradePlan)?.name ?? targetDowngradePlan
           }
         />
       )}

--- a/src/app/(main)/dashboard/qrcodes/_components/edit-qrcode-drawer.tsx
+++ b/src/app/(main)/dashboard/qrcodes/_components/edit-qrcode-drawer.tsx
@@ -174,9 +174,9 @@ export function EditQRCodeDrawer({ qr, open, onClose }: EditQRCodeDrawerProps) {
     });
   }
 
-  const subscriptionStatus = userSubscription?.data?.subscriptions;
-  const isUltraUser = subscriptionStatus?.plan === "ultra";
-  const isProOrUltraUser = subscriptionStatus?.status === "active";
+  const resolvedPlan = userSubscription?.data?.plan ?? "free";
+  const isUltraUser = resolvedPlan === "ultra";
+  const isProOrUltraUser = resolvedPlan !== "free";
 
   const scans = qr.visitCount ?? 0;
 

--- a/src/app/(main)/dashboard/qrcodes/utils.ts
+++ b/src/app/(main)/dashboard/qrcodes/utils.ts
@@ -1,13 +1,13 @@
 import type { RouterOutputs } from "@/trpc/shared";
 
 export function checkIfUserCanCreateMoreQRCodes(
-  subDetails: RouterOutputs["subscriptions"]["get"] | undefined
+  subDetails: RouterOutputs["subscriptions"]["get"] | undefined,
 ) {
   if (!subDetails) {
     return false;
   }
 
-  if (subDetails?.subscriptions && subDetails.subscriptions.status === "active") {
+  if (subDetails.plan !== "free") {
     return true;
   }
 

--- a/src/app/api/webhooks/lemonsqueezy/route.ts
+++ b/src/app/api/webhooks/lemonsqueezy/route.ts
@@ -1,9 +1,9 @@
-import { eq } from "drizzle-orm";
 import crypto from "node:crypto";
+import { eq } from "drizzle-orm";
 import { Resend } from "resend";
 
 import WelcomeEmail from "@/emails/welcome-to-pro";
-import { getPlanFromIds } from "@/lib/billing/plans";
+import { getIntervalFromVariantId, getPlanFromIds } from "@/lib/billing/plans";
 import { logger } from "@/lib/logger";
 import { webhookHasMeta } from "@/lib/typeguards";
 import { runBackgroundTask } from "@/lib/utils/background";
@@ -67,6 +67,7 @@ async function processWebhook(webhookEvent: LemonsqueezyWebhookPayload) {
     const productId = lemonsqueezySubscription.product_id;
     const variantId = lemonsqueezySubscription.variant_id;
     const plan = getPlanFromIds(variantId, productId) ?? "pro";
+    const billingInterval = getIntervalFromVariantId(variantId);
 
     // payment data
     const cardBrand = lemonsqueezySubscription.card_brand;
@@ -94,6 +95,7 @@ async function processWebhook(webhookEvent: LemonsqueezyWebhookPayload) {
           orderId,
           status,
           plan,
+          billingInterval,
           variantId,
           productId,
           cardBrand,
@@ -103,8 +105,18 @@ async function processWebhook(webhookEvent: LemonsqueezyWebhookPayload) {
           endsAt: endsAt ? new Date(endsAt) : null,
         })
         .onDuplicateKeyUpdate({
+          // A returning customer already has a row, so refresh the full
+          // subscription state — not just status/dates — or their plan,
+          // interval, and subscriptionId would stay stale.
           set: {
+            subscriptionId,
+            customerId,
+            orderId,
             status,
+            plan,
+            billingInterval,
+            variantId,
+            productId,
             cardBrand,
             cardLastFour,
             renewsAt: new Date(renewsAt),
@@ -117,10 +129,7 @@ async function processWebhook(webhookEvent: LemonsqueezyWebhookPayload) {
       const emailPlan = plan === "ultra" ? "ultra" : "pro";
 
       if (!email) {
-        log.error(
-          { event: event_name, subscriptionId, userId },
-          "user has no email for welcome",
-        );
+        log.error({ event: event_name, subscriptionId, userId }, "user has no email for welcome");
         return;
       }
 
@@ -138,6 +147,7 @@ async function processWebhook(webhookEvent: LemonsqueezyWebhookPayload) {
         .set({
           status,
           plan,
+          billingInterval,
           variantId,
           productId,
           renewsAt: renewsAt ? new Date(renewsAt) : null,
@@ -147,13 +157,12 @@ async function processWebhook(webhookEvent: LemonsqueezyWebhookPayload) {
         })
         .where(eq(subscription.userId, userId));
     } else if (event_name === "subscription_cancelled") {
+      // Keep the plan/variant intact — a cancelled subscription stays entitled
+      // until endsAt. resolvePlan() drops it to free once that date passes.
       await db
         .update(subscription)
         .set({
           status,
-          plan: "free",
-          variantId: 0,
-          productId: 0,
           endsAt: endsAt ? new Date(endsAt) : null,
         })
         .where(eq(subscription.userId, userId));
@@ -175,9 +184,6 @@ async function processWebhook(webhookEvent: LemonsqueezyWebhookPayload) {
     // Catch-and-log here (rather than letting runBackgroundTask's generic
     // handler do it) so prod logs include the webhook context needed to
     // triage failures on money-moving events.
-    log.error(
-      { err, event: event_name, subscriptionId, userId },
-      "processing failed",
-    );
+    log.error({ err, event: event_name, subscriptionId, userId }, "processing failed");
   }
 }

--- a/src/components/upgrade-to-pro.tsx
+++ b/src/components/upgrade-to-pro.tsx
@@ -1,8 +1,9 @@
 "use client";
 
 import { ArrowUpRightIcon, CheckIcon, Loader2 } from "lucide-react";
-import posthog from "posthog-js";
 
+import { trackUpgradeClick } from "@/lib/analytics/upgrade-prompt";
+import { PLAN_FEATURES } from "@/lib/billing/plan-features";
 import { clientLogger } from "@/lib/logger/client";
 import { Button } from "@/components/ui/button";
 import {
@@ -17,18 +18,7 @@ import {
 import { satoshi } from "@/styles/fonts";
 import { api } from "@/trpc/react";
 
-const proPlanBenefits = [
-  "Custom domains for link shortening",
-  "Unlimited advanced QR codes",
-  "Advanced analytics",
-  "Unlimited tracked links",
-  "1 year of analytics data retention",
-  "Password-protected links",
-  "Bulk link creation via CSV",
-  "API access",
-  "Geotargeting",
-  "Priority support",
-];
+const proPlanBenefits = PLAN_FEATURES.pro.features;
 
 export function UpgradeToPro() {
   const upgradeMutation = api.lemonsqueezy.createCheckoutOrUpdate.useMutation();
@@ -53,7 +43,7 @@ export function UpgradeToPro() {
           className="flex justify-between py-6"
           variant="outline"
           onClick={() => {
-            posthog.capture("upgrade_to_pro_clicked");
+            trackUpgradeClick("upgrade_modal");
           }}
         >
           <div>

--- a/src/lib/analytics/events.ts
+++ b/src/lib/analytics/events.ts
@@ -41,6 +41,10 @@ export const POSTHOG_EVENTS = {
   // Subscription events
   SUBSCRIPTION_UPGRADED: "subscription_upgraded",
   SUBSCRIPTION_DOWNGRADED: "subscription_downgraded",
+
+  // Upgrade prompt events
+  PLAN_LIMIT_REACHED: "plan_limit_reached",
+  UPGRADE_PROMPT_CLICKED: "upgrade_prompt_clicked",
 } as const;
 
 type PostHogEventName = (typeof POSTHOG_EVENTS)[keyof typeof POSTHOG_EVENTS];
@@ -48,10 +52,7 @@ type PostHogEventName = (typeof POSTHOG_EVENTS)[keyof typeof POSTHOG_EVENTS];
 /**
  * Track an event in PostHog
  */
-export function trackEvent(
-  eventName: PostHogEventName,
-  properties?: Record<string, unknown>
-) {
+export function trackEvent(eventName: PostHogEventName, properties?: Record<string, unknown>) {
   if (typeof window !== "undefined") {
     posthog.capture(eventName, properties);
   }

--- a/src/lib/analytics/upgrade-prompt.ts
+++ b/src/lib/analytics/upgrade-prompt.ts
@@ -1,0 +1,26 @@
+import { toast } from "sonner";
+
+import { POSTHOG_EVENTS, trackEvent } from "./events";
+
+/**
+ * Surface an actionable upgrade prompt at a real plan-limit moment.
+ * Tracks that the limit was hit, and tracks the click if the user follows
+ * the upgrade CTA.
+ */
+export function notifyPlanLimit(message: string, source: string) {
+  trackEvent(POSTHOG_EVENTS.PLAN_LIMIT_REACHED, { source });
+  toast.error(message, {
+    action: {
+      label: "Upgrade",
+      onClick: () => {
+        trackEvent(POSTHOG_EVENTS.UPGRADE_PROMPT_CLICKED, { source });
+        window.location.href = "/dashboard/pricing";
+      },
+    },
+  });
+}
+
+/** Track a click on a standing upgrade CTA (sidebar, modal, etc.). */
+export function trackUpgradeClick(source: string) {
+  trackEvent(POSTHOG_EVENTS.UPGRADE_PROMPT_CLICKED, { source });
+}

--- a/src/lib/billing/plans.ts
+++ b/src/lib/billing/plans.ts
@@ -1,6 +1,7 @@
 import type { Subscription } from "@/server/db/schema";
 
 export type Plan = "free" | "pro" | "ultra";
+export type BillingInterval = "monthly" | "annual";
 
 type PlanCaps = {
   eventsLimit?: number; // undefined => unlimited
@@ -12,20 +13,40 @@ type PlanCaps = {
   milestonesPerLinkLimit?: number; // Max milestones per link (undefined => unlimited)
 };
 
-const PRO_VARIANT_IDS = new Set([441105, 415248]);
+// Lemon Squeezy variant IDs per plan + billing interval.
+// NOTE: these are hardcoded live IDs. The recommended hardening is to move them
+// to env vars so Live/Test never drift (see billing follow-up).
+const PRO_MONTHLY_VARIANT_ID = 1811616; // $8/mo — new signups
+const PRO_LEGACY_MONTHLY_VARIANT_ID = 441105; // $5/mo — grandfathered subscribers
+const PRO_ANNUAL_VARIANT_ID = 1809620;
+const ULTRA_MONTHLY_VARIANT_ID = 1108002;
+const ULTRA_ANNUAL_VARIANT_ID = 1809627;
+
+// Recognition sets for getPlanFromIds (include legacy/test-mode variant ids).
+const PRO_VARIANT_IDS = new Set([
+  PRO_MONTHLY_VARIANT_ID,
+  PRO_LEGACY_MONTHLY_VARIANT_ID,
+  PRO_ANNUAL_VARIANT_ID,
+  415248,
+]);
 const PRO_PRODUCT_IDS = new Set([441105, 306137]); // include known sample payload product_id
-const ULTRA_VARIANT_IDS = new Set([1108002, 1134595]);
+const ULTRA_VARIANT_IDS = new Set([ULTRA_MONTHLY_VARIANT_ID, ULTRA_ANNUAL_VARIANT_ID, 1134595]);
 const ULTRA_PRODUCT_IDS = new Set([1108002]);
 
-export const PLAN_VARIANT_IDS: Record<Exclude<Plan, "free">, number> = {
-  // todo: make sure you change these back before pushing
-  pro: 441105,
-  ultra: 1108002,
+const ANNUAL_VARIANT_IDS = new Set([PRO_ANNUAL_VARIANT_ID, ULTRA_ANNUAL_VARIANT_ID]);
 
-  // test mode ids
-  // pro: 415248,
-  // ultra: 1134595,
+export const PLAN_VARIANT_IDS: Record<Exclude<Plan, "free">, Record<BillingInterval, number>> = {
+  pro: { monthly: PRO_MONTHLY_VARIANT_ID, annual: PRO_ANNUAL_VARIANT_ID },
+  ultra: { monthly: ULTRA_MONTHLY_VARIANT_ID, annual: ULTRA_ANNUAL_VARIANT_ID },
 };
+
+export function getVariantId(plan: Exclude<Plan, "free">, interval: BillingInterval): number {
+  return PLAN_VARIANT_IDS[plan][interval];
+}
+
+export function getIntervalFromVariantId(variantId?: number | null): BillingInterval {
+  return variantId && ANNUAL_VARIANT_IDS.has(variantId) ? "annual" : "monthly";
+}
 
 export const PLAN_CAPS: Record<Plan, PlanCaps> = {
   free: {
@@ -49,10 +70,7 @@ export const PLAN_CAPS: Record<Plan, PlanCaps> = {
   },
 };
 
-export function getPlanFromIds(
-  variantId?: number | null,
-  productId?: number | null
-): Plan | null {
+export function getPlanFromIds(variantId?: number | null, productId?: number | null): Plan | null {
   if (variantId && ULTRA_VARIANT_IDS.has(variantId)) return "ultra";
   if (productId && ULTRA_PRODUCT_IDS.has(productId)) return "ultra";
   if (variantId && PRO_VARIANT_IDS.has(variantId)) return "pro";
@@ -60,20 +78,41 @@ export function getPlanFromIds(
   return null;
 }
 
+// Lemon Squeezy statuses that grant paid access outright.
+const ENTITLED_STATUSES = new Set(["active", "on_trial", "past_due"]);
+
+/**
+ * Whether a subscription currently grants paid access. Honors the paid period:
+ * active/on_trial/past_due are entitled, and a `cancelled` subscription stays
+ * entitled until its `endsAt` passes (users keep access until the end of the
+ * period they already paid for).
+ */
+export function isSubscriptionEntitled(subscription?: Subscription | null): boolean {
+  if (!subscription) return false;
+
+  const status = subscription.status ?? "";
+  if (ENTITLED_STATUSES.has(status)) return true;
+
+  if (status === "cancelled" && subscription.endsAt) {
+    return subscription.endsAt.getTime() > Date.now();
+  }
+
+  return false;
+}
+
 export function resolvePlan(subscription?: Subscription | null): Plan {
-  if (!subscription || subscription.status !== "active") {
+  if (!subscription || !isSubscriptionEntitled(subscription)) {
     return "free";
   }
 
   const mappedPlan =
-    getPlanFromIds(subscription.variantId, subscription.productId) ??
-    subscription.plan;
+    getPlanFromIds(subscription.variantId, subscription.productId) ?? subscription.plan;
 
   if (mappedPlan === "ultra" || mappedPlan === "pro") {
     return mappedPlan;
   }
 
-  return "pro"; // active subscription without recognized plan defaults to pro
+  return "pro"; // entitled subscription without recognized plan defaults to pro
 }
 
 export function getPlanCaps(plan: Plan): PlanCaps {

--- a/src/lib/constants/plan-pricing.ts
+++ b/src/lib/constants/plan-pricing.ts
@@ -1,7 +1,13 @@
 export const PLAN_PRICES_USD = {
   free: 0,
-  pro: 5,
+  pro: 8,
   ultra: 15,
+} as const;
+
+// Annual prices = 10x monthly, i.e. "2 months free".
+export const PLAN_PRICES_ANNUAL_USD = {
+  pro: 80,
+  ultra: 150,
 } as const;
 
 export type PaidPlan = "pro" | "ultra";

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -16,7 +16,7 @@ async function resolveLinkAndLogAnalytics(request: NextRequest) {
 
   const { pathname, host, origin } = new URL(request.url);
 
-  const staticRoutes = ["/blog", "/changelog", "/privacy", "/terms", "/auth", "/features", "/pricing", "/compare"];
+  const staticRoutes = ["/blog", "/changelog", "/privacy", "/terms", "/abuse", "/auth", "/features", "/pricing", "/compare"];
 
   const shouldSkip =
     pathname === "/" ||

--- a/src/server/api/root.ts
+++ b/src/server/api/root.ts
@@ -1,3 +1,4 @@
+import { abuseRouter } from "./routers/abuse/abuse.procedure";
 import { accountTransferRouter } from "./routers/account-transfer/account-transfer.procedure";
 import { adminRouter } from "./routers/admin/admin.procedure";
 import { aiRouter } from "./routers/ai/ai.procedure";
@@ -21,6 +22,7 @@ import { utmTemplateRouter } from "./routers/utm-template/utm-template.router";
 import { createTRPCRouter } from "./trpc";
 
 export const appRouter = createTRPCRouter({
+  abuse: abuseRouter,
   accountTransfer: accountTransferRouter,
   admin: adminRouter,
   link: linkRouter,

--- a/src/server/api/routers/abuse/abuse.input.ts
+++ b/src/server/api/routers/abuse/abuse.input.ts
@@ -1,0 +1,36 @@
+import { z } from "zod";
+
+export const abuseCategoryValues = [
+  "phishing",
+  "malware",
+  "spam",
+  "impersonation",
+  "illegal",
+  "privacy",
+  "other",
+] as const;
+
+export const ABUSE_CATEGORY_LABELS: Record<(typeof abuseCategoryValues)[number], string> = {
+  phishing: "Phishing",
+  malware: "Malware",
+  spam: "Spam",
+  impersonation: "Impersonation",
+  illegal: "Illegal content",
+  privacy: "Privacy violation",
+  other: "Other",
+};
+
+export const reportAbuseSchema = z.object({
+  shortUrl: z.string().trim().min(1, "Enter the short link you want to report.").max(2048),
+  category: z.enum(abuseCategoryValues),
+  reporterEmail: z
+    .string()
+    .trim()
+    .email("Enter a valid email address.")
+    .max(320)
+    .optional()
+    .or(z.literal("")),
+  details: z.string().trim().max(2000).optional(),
+});
+
+export type ReportAbuseInput = z.infer<typeof reportAbuseSchema>;

--- a/src/server/api/routers/abuse/abuse.procedure.ts
+++ b/src/server/api/routers/abuse/abuse.procedure.ts
@@ -1,0 +1,80 @@
+import { TRPCError } from "@trpc/server";
+import { and, eq, sql } from "drizzle-orm";
+
+import { runBackgroundTask } from "@/lib/utils/background";
+import { flaggedLink, link } from "@/server/db/schema";
+import { sendAbuseReportNotification } from "@/server/lib/notifications/discord";
+
+import { createTRPCRouter, publicProcedure } from "../../trpc";
+import { ABUSE_CATEGORY_LABELS, reportAbuseSchema } from "./abuse.input";
+
+/**
+ * Parse a user-submitted short link into a domain + alias pair.
+ * Accepts forms like `https://ishortn.ink/abc`, `ishortn.ink/abc`,
+ * `www.ishortn.ink/abc!`, with optional query/fragment.
+ */
+function parseShortUrl(raw: string): { domain: string; alias: string } | null {
+  let s = raw.trim().replace(/^(https?:\/\/)?(www\.)?/i, "");
+  s = s.split(/[?#]/)[0] ?? "";
+
+  const slashIndex = s.indexOf("/");
+  if (slashIndex === -1) return null;
+
+  const domain = s.slice(0, slashIndex).toLowerCase();
+  let alias = s.slice(slashIndex + 1).split("/")[0] ?? "";
+  if (alias.endsWith("!")) alias = alias.slice(0, -1);
+
+  if (!domain || !alias) return null;
+  return { domain, alias: alias.toLowerCase() };
+}
+
+export const abuseRouter = createTRPCRouter({
+  report: publicProcedure.input(reportAbuseSchema).mutation(async ({ ctx, input }) => {
+    const parsed = parseShortUrl(input.shortUrl);
+    if (!parsed) {
+      throw new TRPCError({
+        code: "BAD_REQUEST",
+        message: "That doesn't look like a valid short link. Use a format like ishortn.ink/abc.",
+      });
+    }
+
+    const reportedLink = await ctx.db.query.link.findFirst({
+      where: and(
+        sql`lower(${link.alias}) = lower(${parsed.alias})`,
+        eq(link.domain, parsed.domain),
+      ),
+      columns: { id: true, url: true, domain: true, alias: true },
+    });
+
+    if (!reportedLink) {
+      throw new TRPCError({
+        code: "NOT_FOUND",
+        message: "We couldn't find that short link. Double-check the address and try again.",
+      });
+    }
+
+    const reporterEmail = input.reporterEmail?.trim() || null;
+    const details = input.details?.trim() || null;
+    const categoryLabel = ABUSE_CATEGORY_LABELS[input.category];
+
+    await ctx.db.insert(flaggedLink).values({
+      linkId: reportedLink.id,
+      reason: categoryLabel,
+      reporterEmail,
+      details,
+      status: "pending",
+    });
+
+    void runBackgroundTask(
+      sendAbuseReportNotification({
+        shortUrl: `${reportedLink.domain}/${reportedLink.alias}`,
+        destinationUrl: reportedLink.url,
+        category: categoryLabel,
+        reporterEmail,
+        details,
+      }),
+    );
+
+    return { success: true };
+  }),
+});

--- a/src/server/api/routers/admin/admin.service.ts
+++ b/src/server/api/routers/admin/admin.service.ts
@@ -499,6 +499,8 @@ export async function getFlaggedLinks(
         id: flaggedLink.id,
         linkId: flaggedLink.linkId,
         reason: flaggedLink.reason,
+        reporterEmail: flaggedLink.reporterEmail,
+        details: flaggedLink.details,
         status: flaggedLink.status,
         flaggedAt: flaggedLink.flaggedAt,
         resolvedAt: flaggedLink.resolvedAt,

--- a/src/server/api/routers/ai/ai.procedure.ts
+++ b/src/server/api/routers/ai/ai.procedure.ts
@@ -1,4 +1,7 @@
 import { z } from "zod";
+
+import { isSubscriptionEntitled } from "@/lib/billing/plans";
+
 import { createTRPCRouter, protectedProcedure } from "../../trpc";
 import { generateAliasFromMetadata } from "./ai.service";
 
@@ -14,7 +17,7 @@ export const aiRouter = createTRPCRouter({
       where: (table, { eq }) => eq(table.userId, ctx.auth.userId),
     });
 
-    if (!userSubscription || userSubscription.status !== "active") {
+    if (!isSubscriptionEntitled(userSubscription)) {
       throw new Error("You need an active subscription to use AI features");
     }
     const alias = await generateAliasFromMetadata(input);

--- a/src/server/api/routers/domains/domains.service.ts
+++ b/src/server/api/routers/domains/domains.service.ts
@@ -1,7 +1,7 @@
 import { TRPCError } from "@trpc/server";
 import { and, count, eq, inArray, ne } from "drizzle-orm";
 
-import { PLAN_CAPS, resolvePlan } from "@/lib/billing/plans";
+import { isSubscriptionEntitled, PLAN_CAPS, resolvePlan } from "@/lib/billing/plans";
 import { customDomain, link, linkVisit } from "@/server/db/schema";
 import {
   requirePermission,
@@ -28,7 +28,7 @@ export async function addDomainToUserAccount(
     where: (table, { eq }) => eq(table.userId, userId),
   });
 
-  if (!userSubscription || userSubscription.status !== "active") {
+  if (!isSubscriptionEntitled(userSubscription)) {
     throw new Error("You need to have an active subscription to add a custom domain");
   }
 

--- a/src/server/api/routers/lemonsqueezy/lemonsqueezy.procedure.ts
+++ b/src/server/api/routers/lemonsqueezy/lemonsqueezy.procedure.ts
@@ -8,7 +8,11 @@ import {
 import { eq } from "drizzle-orm";
 import { z } from "zod";
 
-import { PLAN_VARIANT_IDS, resolvePlan } from "@/lib/billing/plans";
+import {
+  getIntervalFromVariantId,
+  getVariantId,
+  resolvePlan,
+} from "@/lib/billing/plans";
 import { configureLemonSqueezy } from "@/lib/config/lemonsqueezy";
 import { logger } from "@/lib/logger";
 import { runBackgroundTask } from "@/lib/utils/background";
@@ -28,13 +32,14 @@ export const lemonsqueezyRouter = createTRPCRouter({
     .input(
       z.object({
         plan: z.enum(["pro", "ultra"]),
+        interval: z.enum(["monthly", "annual"]).default("monthly"),
       })
     )
     .mutation(async ({ ctx, input }) => {
       configureLemonSqueezy();
 
       const userId = ctx.auth.userId;
-      const variantId = PLAN_VARIANT_IDS[input.plan];
+      const variantId = getVariantId(input.plan, input.interval);
 
       const user = await ctx.db.query.user.findFirst({
         where: (table, { eq }) => eq(table.id, userId),
@@ -77,6 +82,7 @@ export const lemonsqueezyRouter = createTRPCRouter({
             .update(subscription)
             .set({
               plan: input.plan,
+              billingInterval: input.interval,
               variantId: variantId,
               status: updatedSub.data.data.attributes.status,
               endsAt: updatedSub.data.data.attributes.ends_at
@@ -151,10 +157,9 @@ export const lemonsqueezyRouter = createTRPCRouter({
       await ctx.db
         .update(subscription)
         .set({
+          // Keep plan/variant — access is retained until endsAt; resolvePlan()
+          // drops the user to free once that date passes.
           status: cancelledSub.data?.data.attributes.status,
-          plan: "free",
-          variantId: 0,
-          productId: 0,
           endsAt: cancelledSub.data?.data.attributes.ends_at
             ? new Date(cancelledSub.data?.data.attributes.ends_at)
             : null,
@@ -268,10 +273,9 @@ export const lemonsqueezyRouter = createTRPCRouter({
         await ctx.db
           .update(subscription)
           .set({
+            // Keep plan/variant — access is retained until endsAt, matching the
+            // message below; resolvePlan() drops to free once that date passes.
             status: cancelledSub.data?.data.attributes.status,
-            plan: "free",
-            variantId: 0,
-            productId: 0,
             endsAt: cancelledSub.data?.data.attributes.ends_at
               ? new Date(cancelledSub.data?.data.attributes.ends_at)
               : null,
@@ -285,8 +289,9 @@ export const lemonsqueezyRouter = createTRPCRouter({
         };
       }
 
-      // Handle downgrade to pro (from ultra)
-      const variantId = PLAN_VARIANT_IDS[targetPlan];
+      // Handle downgrade to pro (from ultra) — preserve the current interval.
+      const interval = getIntervalFromVariantId(userSubscription.variantId);
+      const variantId = getVariantId(targetPlan, interval);
 
       const updatedSub = await updateSubscription(
         userSubscription.subscriptionId!,
@@ -304,6 +309,7 @@ export const lemonsqueezyRouter = createTRPCRouter({
         .update(subscription)
         .set({
           plan: targetPlan,
+          billingInterval: interval,
           variantId: variantId,
           status: updatedSub.data.data.attributes.status,
           endsAt: updatedSub.data.data.attributes.ends_at

--- a/src/server/db/schema.ts
+++ b/src/server/db/schema.ts
@@ -189,6 +189,7 @@ export const subscription = mysqlTable(
     endsAt: datetime("endsAt"),
     status: varchar("status", { length: 255 }).default(""),
     plan: mysqlEnum("plan", ["free", "pro", "ultra"]).default("free"),
+    billingInterval: mysqlEnum("billingInterval", ["monthly", "annual"]).default("monthly"),
     variantId: int("variantId").default(0),
     productId: int("productId").default(0),
 
@@ -586,6 +587,8 @@ export const flaggedLink = mysqlTable(
     id: serial("id").primaryKey(),
     linkId: int("linkId").notNull(),
     reason: varchar("reason", { length: 255 }),
+    reporterEmail: varchar("reporterEmail", { length: 320 }),
+    details: text("details"),
     status: mysqlEnum("flagStatus", ["pending", "blocked", "dismissed"])
       .notNull()
       .default("pending"),

--- a/src/server/lib/notifications/discord.ts
+++ b/src/server/lib/notifications/discord.ts
@@ -1,5 +1,5 @@
-import { formatAudienceFeedbackLabel } from "@/lib/audience-feedback/labels";
 import { env } from "@/env.mjs";
+import { formatAudienceFeedbackLabel } from "@/lib/audience-feedback/labels";
 import { logger } from "@/lib/logger";
 
 const log = logger.child({ notification: "discord" });
@@ -182,6 +182,43 @@ function formatOptionalDiscordValue(value?: string | null): string {
   return truncateDiscordField(value);
 }
 
+export async function sendAbuseReportNotification(params: {
+  shortUrl: string;
+  destinationUrl?: string | null;
+  category: string;
+  reporterEmail?: string | null;
+  details?: string | null;
+}): Promise<boolean> {
+  const embed: DiscordEmbed = {
+    title: "Abuse Report",
+    color: DISCORD_COLORS.error,
+    fields: [
+      { name: "Short Link", value: truncateDiscordField(params.shortUrl), inline: true },
+      { name: "Category", value: params.category, inline: true },
+      {
+        name: "Destination",
+        value: formatOptionalDiscordValue(params.destinationUrl),
+        inline: false,
+      },
+      {
+        name: "Reporter Email",
+        value: formatOptionalDiscordValue(params.reporterEmail),
+        inline: true,
+      },
+      {
+        name: "Details",
+        value: formatOptionalDiscordValue(params.details),
+        inline: false,
+      },
+    ],
+    timestamp: new Date().toISOString(),
+    footer: {
+      text: "iShortn Abuse Report",
+    },
+  };
+
+  return sendDiscordNotification({ embeds: [embed] });
+}
 
 export async function sendAudienceFeedbackNotification(params: {
   userEmail: string;


### PR DESCRIPTION
## Summary

Trust & safety hardening plus subscription billing/entitlement correctness.

## Trust & Safety

- Blocked links now resolve to the blocked page instead of forwarding visitors to the destination.
- New public `/abuse` reporting page that feeds the existing admin moderation queue (with Discord alerts).

## Billing & Entitlements

- Annual pricing with a "Save 2 months" toggle (Pro $80/yr, Ultra $150/yr); Pro monthly raised to $8, existing $5 subscribers grandfathered.
- Usage-driven upgrade prompts.
- Subscription entitlement fixes: returning customers are fully refreshed by the webhook; cancelled/past_due/on_trial users keep access until the end of the paid period; UI gates now read the resolved plan.

## Notes

- Requires running the new migrations (`0061`, `0062`). No new environment variables.

https://claude.ai/code/session_01APWHJhtuvEhRJhqJcTwa4t