### PR TITLE
feat(billing): self-serve plan changes from settings and pricing

### DIFF
--- a/src/app/(main)/dashboard/pricing/_components/plan-change-confirm-dialog.tsx
+++ b/src/app/(main)/dashboard/pricing/_components/plan-change-confirm-dialog.tsx
@@ -1,0 +1,119 @@
+"use client";
+
+import { Loader2 } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogBody,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { PLAN_PRICES_ANNUAL_USD, PLAN_PRICES_USD } from "@/lib/constants/plan-pricing";
+
+import type { BillingInterval, Plan } from "@/lib/billing/plans";
+
+type PlanChangeKind = "switch" | "upgrade";
+
+/**
+ * Copy for confirming an immediate-charge, in-place plan change. Only used for
+ * paths that bypass the Lemon Squeezy hosted checkout (interval switch and an
+ * upgrade from an existing paid plan) and so charge the card on click.
+ */
+export function buildPlanChangeCopy(
+  kind: PlanChangeKind,
+  targetPlan: Exclude<Plan, "free">,
+  interval: BillingInterval,
+): { title: string; description: string; note?: string; confirmLabel: string } {
+  const price =
+    interval === "annual" ? PLAN_PRICES_ANNUAL_USD[targetPlan] : PLAN_PRICES_USD[targetPlan];
+  const planName = targetPlan === "pro" ? "Pro" : "Ultra";
+
+  if (kind === "switch") {
+    if (interval === "annual") {
+      return {
+        title: "Switch to annual billing?",
+        description: `You'll be charged $${price} today, with credit for the unused part of your current month.`,
+        note: "That's 2 months free compared to paying monthly.",
+        confirmLabel: "Switch & save",
+      };
+    }
+    return {
+      title: "Switch to monthly billing?",
+      description: `You'll move to $${price}/month. Any unused time on your annual plan is credited to your account.`,
+      confirmLabel: "Switch to monthly",
+    };
+  }
+
+  return {
+    title: `Upgrade to ${planName}?`,
+    description: `You'll be charged $${price} today for ${planName} ${
+      interval === "annual" ? "annual" : "monthly"
+    }, with credit for the unused time on your current plan.`,
+    confirmLabel: `Upgrade to ${planName}`,
+  };
+}
+
+type PlanChangeConfirmDialogProps = {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  title: string;
+  description: string;
+  note?: string;
+  confirmLabel: string;
+  isLoading: boolean;
+  onConfirm: () => void;
+};
+
+export function PlanChangeConfirmDialog({
+  open,
+  onOpenChange,
+  title,
+  description,
+  note,
+  confirmLabel,
+  isLoading,
+  onConfirm,
+}: PlanChangeConfirmDialogProps) {
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-[440px]">
+        <DialogHeader>
+          <DialogTitle>{title}</DialogTitle>
+          <DialogDescription>{description}</DialogDescription>
+        </DialogHeader>
+
+        {note && (
+          <DialogBody>
+            <p className="text-sm font-medium text-emerald-600 dark:text-emerald-400">{note}</p>
+          </DialogBody>
+        )}
+
+        <DialogFooter>
+          <Button
+            type="button"
+            variant="ghost"
+            onClick={() => onOpenChange(false)}
+            disabled={isLoading}
+            className="h-9"
+          >
+            Not now
+          </Button>
+          <Button type="button" onClick={onConfirm} disabled={isLoading} className="h-9">
+            {isLoading ? (
+              <>
+                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                Processing...
+              </>
+            ) : (
+              confirmLabel
+            )}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/app/(main)/dashboard/pricing/_components/pricing-cards.tsx
+++ b/src/app/(main)/dashboard/pricing/_components/pricing-cards.tsx
@@ -14,11 +14,16 @@ import { cn } from "@/lib/utils";
 import { api } from "@/trpc/react";
 
 import { DowngradeFeedbackModal } from "./downgrade-feedback-modal";
+import {
+  buildPlanChangeCopy,
+  PlanChangeConfirmDialog,
+} from "./plan-change-confirm-dialog";
 
 import type { BillingInterval, Plan } from "@/lib/billing/plans";
 
 type PricingCardsProps = {
   currentPlan: Plan;
+  currentInterval: BillingInterval;
 };
 
 const plans = [
@@ -51,7 +56,7 @@ const plans = [
   },
 ];
 
-export function PricingCards({ currentPlan }: PricingCardsProps) {
+export function PricingCards({ currentPlan, currentInterval }: PricingCardsProps) {
   const searchParams = useSearchParams();
   const autoCheckoutFired = useRef(false);
   const [interval, setIntervalState] = useState<BillingInterval>(
@@ -62,6 +67,11 @@ export function PricingCards({ currentPlan }: PricingCardsProps) {
   const [targetDowngradePlan, setTargetDowngradePlan] = useState<Exclude<Plan, "ultra"> | null>(
     null,
   );
+  const [confirmOpen, setConfirmOpen] = useState(false);
+  const [pendingChange, setPendingChange] = useState<{
+    plan: (typeof plans)[number];
+    kind: "switch" | "upgrade";
+  } | null>(null);
 
   const createCheckoutOrUpdateMutation = api.lemonsqueezy.createCheckoutOrUpdate.useMutation({
     onSuccess: (data) => {
@@ -98,13 +108,26 @@ export function PricingCards({ currentPlan }: PricingCardsProps) {
     },
   });
 
-  const handleUpgrade = (plan: (typeof plans)[number]) => {
+  const runUpgrade = (plan: (typeof plans)[number]) => {
     if (plan.id === "free") return;
     setLoadingPlan(plan.id);
     createCheckoutOrUpdateMutation.mutate({
       plan: plan.id as Exclude<Plan, "free">,
       interval,
     });
+  };
+
+  const requestUpgrade = (plan: (typeof plans)[number], kind: "switch" | "upgrade") => {
+    if (plan.id === "free") return;
+    // Free → paid goes through the Lemon Squeezy hosted checkout (its own
+    // confirmation). In-place changes for an existing paid subscriber charge
+    // the card immediately, so confirm those first.
+    if (currentPlan === "free") {
+      runUpgrade(plan);
+      return;
+    }
+    setPendingChange({ plan, kind });
+    setConfirmOpen(true);
   };
 
   const handleManageSubscription = (planId: Plan) => {
@@ -137,8 +160,16 @@ export function PricingCards({ currentPlan }: PricingCardsProps) {
     if (!canUpgrade) return;
 
     autoCheckoutFired.current = true;
-    handleUpgrade(targetPlan);
+    requestUpgrade(targetPlan, "upgrade");
   }, [searchParams, currentPlan]);
+
+  const confirmCopy = pendingChange
+    ? buildPlanChangeCopy(
+        pendingChange.kind,
+        pendingChange.plan.id as Exclude<Plan, "free">,
+        interval,
+      )
+    : null;
 
   return (
     <div className="space-y-8">
@@ -182,6 +213,10 @@ export function PricingCards({ currentPlan }: PricingCardsProps) {
           const isCurrentPlan = plan.id === currentPlan;
           const canUpgrade = getPlanOrder(plan.id) > getPlanOrder(currentPlan);
           const canDowngrade = getPlanOrder(plan.id) < getPlanOrder(currentPlan);
+          // Same tier, but the toggle points at the other billing interval —
+          // offer a switch instead of "Manage Subscription".
+          const canSwitchInterval =
+            isCurrentPlan && plan.id !== "free" && interval !== currentInterval;
 
           return (
             <div
@@ -240,7 +275,16 @@ export function PricingCards({ currentPlan }: PricingCardsProps) {
 
               {/* CTA Button */}
               <div className="mb-6">
-                {isCurrentPlan ? (
+                {canSwitchInterval ? (
+                  <Button
+                    className="w-full"
+                    onClick={() => requestUpgrade(plan, "switch")}
+                    disabled={loadingPlan !== null}
+                  >
+                    {loadingPlan === plan.id && <Loader2 className="h-4 w-4 mr-2 animate-spin" />}
+                    Switch to {interval === "annual" ? "annual" : "monthly"} billing
+                  </Button>
+                ) : isCurrentPlan ? (
                   <Button
                     variant="outline"
                     className="w-full"
@@ -258,7 +302,7 @@ export function PricingCards({ currentPlan }: PricingCardsProps) {
                         ? "bg-gray-900 hover:bg-gray-800 dark:bg-muted dark:hover:bg-accent dark:text-foreground"
                         : "",
                     )}
-                    onClick={() => handleUpgrade(plan)}
+                    onClick={() => requestUpgrade(plan, "upgrade")}
                     disabled={loadingPlan !== null}
                   >
                     {loadingPlan === plan.id && <Loader2 className="h-4 w-4 mr-2 animate-spin" />}
@@ -350,6 +394,19 @@ export function PricingCards({ currentPlan }: PricingCardsProps) {
           targetPlanName={
             plans.find((p) => p.id === targetDowngradePlan)?.name ?? targetDowngradePlan
           }
+        />
+      )}
+
+      {pendingChange && confirmCopy && (
+        <PlanChangeConfirmDialog
+          open={confirmOpen}
+          onOpenChange={setConfirmOpen}
+          title={confirmCopy.title}
+          description={confirmCopy.description}
+          note={confirmCopy.note}
+          confirmLabel={confirmCopy.confirmLabel}
+          isLoading={createCheckoutOrUpdateMutation.isLoading}
+          onConfirm={() => runUpgrade(pendingChange.plan)}
         />
       )}
     </div>

--- a/src/app/(main)/dashboard/pricing/page.tsx
+++ b/src/app/(main)/dashboard/pricing/page.tsx
@@ -1,3 +1,4 @@
+import { getIntervalFromVariantId } from "@/lib/billing/plans";
 import { api } from "@/trpc/server";
 
 import { PricingCards } from "./_components/pricing-cards";
@@ -6,10 +7,11 @@ export const dynamic = "force-dynamic";
 
 async function PricingPage() {
   const subscriptions = await api.subscriptions.get.query();
+  const currentInterval = getIntervalFromVariantId(subscriptions.subscriptions?.variantId);
 
   return (
     <div className="p-6 max-w-6xl mx-auto">
-      <PricingCards currentPlan={subscriptions.plan} />
+      <PricingCards currentPlan={subscriptions.plan} currentInterval={currentInterval} />
     </div>
   );
 }

--- a/src/app/(main)/dashboard/settings/billing/billing.tsx
+++ b/src/app/(main)/dashboard/settings/billing/billing.tsx
@@ -1,13 +1,15 @@
 "use client";
 
 import { format } from "date-fns";
-import { IconArrowRight, IconLoader2 } from "@tabler/icons-react";
-import { useRouter } from "next/navigation";
+import { IconLoader2 } from "@tabler/icons-react";
 import { useState } from "react";
 import { toast } from "sonner";
 
 import { Button } from "@/components/ui/button";
+import { getIntervalFromVariantId } from "@/lib/billing/plans";
 import { api } from "@/trpc/react";
+
+import { PlanSwitcher } from "./plan-switcher";
 
 import type { RouterOutputs } from "@/trpc/shared";
 
@@ -16,10 +18,12 @@ type BillingProps = {
 };
 
 export default function Billing({ subscriptions }: BillingProps) {
-  const router = useRouter();
   const [isLoading, setIsLoading] = useState(false);
 
   const subscription = subscriptions?.subscriptions;
+  const currentPlan = subscriptions?.plan ?? "free";
+  const currentInterval = getIntervalFromVariantId(subscription?.variantId);
+  const isActive = subscription?.status === "active";
 
   const getSubscriptionDetails =
     api.lemonsqueezy.subscriptionDetails.useMutation({
@@ -44,89 +48,84 @@ export default function Billing({ subscriptions }: BillingProps) {
     getSubscriptionDetails.mutate();
   };
 
-  if (!subscription) {
-    return (
-      <div className="rounded-xl border border-neutral-200 dark:border-border p-5">
-        <p className="text-[14px] font-medium text-neutral-900 dark:text-foreground">Free Plan</p>
-        <p className="mt-1 text-[12px] text-neutral-400 dark:text-neutral-500">
-          Upgrade to Pro for unlimited links, custom domains, and advanced
-          analytics.
-        </p>
-        <button
-          type="button"
-          onClick={() => router.push("/dashboard/pricing")}
-          className="mt-4 inline-flex items-center gap-2 rounded-lg bg-blue-600 px-4 py-2 text-[13px] font-medium text-white transition-colors hover:bg-blue-700"
-        >
-          View Plans
-          <IconArrowRight size={14} stroke={1.5} />
-        </button>
-      </div>
-    );
-  }
-
-  const isActive = subscription.status === "active";
-
   return (
-    <div className="rounded-xl border border-neutral-200 dark:border-border p-5">
-      <div className="flex items-center gap-2">
-        <p className="text-[14px] font-medium capitalize text-neutral-900 dark:text-foreground">
-          {subscriptions?.plan ? `${subscriptions.plan} Plan` : "Free Plan"}
-        </p>
-        <span
-          className={`inline-flex items-center gap-1.5 text-[11px] font-medium ${
-            isActive ? "text-emerald-600 dark:text-emerald-400" : "text-red-600 dark:text-red-400"
-          }`}
-        >
-          <span
-            className={`inline-block h-1.5 w-1.5 rounded-full ${
-              isActive ? "bg-emerald-500" : "bg-red-500"
-            }`}
-          />
-          {subscription.status}
-        </span>
-      </div>
-
-      <div className="mt-2 flex flex-wrap items-center gap-x-1.5 gap-y-1 text-[12px]">
-        {subscription.renewsAt && (
-          <span className="text-neutral-400 dark:text-neutral-500">
-            Renews {format(new Date(subscription.renewsAt), "MMM d, yyyy")}
-          </span>
-        )}
-        {subscription.cardLastFour && (
-          <>
-            {subscription.renewsAt && (
-              <span className="text-neutral-300 dark:text-neutral-600">&middot;</span>
-            )}
-            <span className="capitalize text-neutral-500 dark:text-neutral-400">
-              {subscription.cardBrand} &bull;&bull;&bull;&bull;{" "}
-              {subscription.cardLastFour}
+    <div className="space-y-5 rounded-xl border border-neutral-200 dark:border-border p-5">
+      {/* Current plan summary */}
+      <div>
+        <div className="flex items-center gap-2">
+          <p className="text-[14px] font-medium capitalize text-neutral-900 dark:text-foreground">
+            {currentPlan} Plan
+          </p>
+          {subscription && (
+            <span
+              className={`inline-flex items-center gap-1.5 text-[11px] font-medium ${
+                isActive
+                  ? "text-emerald-600 dark:text-emerald-400"
+                  : "text-red-600 dark:text-red-400"
+              }`}
+            >
+              <span
+                className={`inline-block h-1.5 w-1.5 rounded-full ${
+                  isActive ? "bg-emerald-500" : "bg-red-500"
+                }`}
+              />
+              {subscription.status}
             </span>
-          </>
+          )}
+        </div>
+
+        {subscription ? (
+          <div className="mt-2 flex flex-wrap items-center gap-x-1.5 gap-y-1 text-[12px]">
+            {subscription.renewsAt && (
+              <span className="text-neutral-400 dark:text-neutral-500">
+                Renews {format(new Date(subscription.renewsAt), "MMM d, yyyy")}
+              </span>
+            )}
+            {subscription.cardLastFour && (
+              <>
+                {subscription.renewsAt && (
+                  <span className="text-neutral-300 dark:text-neutral-600">&middot;</span>
+                )}
+                <span className="capitalize text-neutral-500 dark:text-neutral-400">
+                  {subscription.cardBrand} &bull;&bull;&bull;&bull;{" "}
+                  {subscription.cardLastFour}
+                </span>
+              </>
+            )}
+          </div>
+        ) : (
+          <p className="mt-1 text-[12px] text-neutral-400 dark:text-neutral-500">
+            Upgrade for unlimited links, custom domains, and advanced analytics.
+          </p>
+        )}
+
+        {subscription && (
+          <div className="mt-3">
+            <Button
+              onClick={handleManageSubscription}
+              disabled={isLoading}
+              variant="outline"
+              className="h-8 border-neutral-200 dark:border-border text-[12px]"
+            >
+              {isLoading && (
+                <IconLoader2
+                  size={14}
+                  stroke={1.5}
+                  className="mr-1.5 animate-spin"
+                />
+              )}
+              Manage Subscription
+            </Button>
+          </div>
         )}
       </div>
 
-      <div className="mt-4 flex items-center gap-2 border-t border-neutral-100 dark:border-border/50 pt-4">
-        <Button
-          onClick={handleManageSubscription}
-          disabled={isLoading}
-          variant="outline"
-          className="h-9 border-neutral-200 dark:border-border text-[13px]"
-        >
-          {isLoading && (
-            <IconLoader2
-              size={14}
-              stroke={1.5}
-              className="mr-1.5 animate-spin"
-            />
-          )}
-          Manage Subscription
-        </Button>
-        <Button
-          onClick={() => router.push("/dashboard/pricing")}
-          className="h-9 bg-blue-600 text-[13px] hover:bg-blue-700"
-        >
-          Change Plan
-        </Button>
+      {/* Inline plan switcher */}
+      <div className="border-t border-neutral-100 dark:border-border/50 pt-5">
+        <PlanSwitcher
+          currentPlan={currentPlan}
+          currentInterval={currentInterval}
+        />
       </div>
     </div>
   );

--- a/src/app/(main)/dashboard/settings/billing/plan-switcher.tsx
+++ b/src/app/(main)/dashboard/settings/billing/plan-switcher.tsx
@@ -1,0 +1,227 @@
+"use client";
+
+import { Loader2 } from "lucide-react";
+import { useState } from "react";
+import { toast } from "sonner";
+
+import { Button } from "@/components/ui/button";
+import { POSTHOG_EVENTS, trackEvent } from "@/lib/analytics/events";
+import { PLAN_PRICES_ANNUAL_USD, PLAN_PRICES_USD } from "@/lib/constants/plan-pricing";
+import { cn } from "@/lib/utils";
+import { api } from "@/trpc/react";
+
+import { DowngradeFeedbackModal } from "../../pricing/_components/downgrade-feedback-modal";
+import {
+  buildPlanChangeCopy,
+  PlanChangeConfirmDialog,
+} from "../../pricing/_components/plan-change-confirm-dialog";
+
+import type { BillingInterval, Plan } from "@/lib/billing/plans";
+
+const PLANS: { id: Plan; name: string; monthly: number; annual: number }[] = [
+  { id: "free", name: "Free", monthly: PLAN_PRICES_USD.free, annual: 0 },
+  { id: "pro", name: "Pro", monthly: PLAN_PRICES_USD.pro, annual: PLAN_PRICES_ANNUAL_USD.pro },
+  { id: "ultra", name: "Ultra", monthly: PLAN_PRICES_USD.ultra, annual: PLAN_PRICES_ANNUAL_USD.ultra },
+];
+
+const planOrder: Record<Plan, number> = { free: 0, pro: 1, ultra: 2 };
+
+type PlanSwitcherProps = {
+  currentPlan: Plan;
+  currentInterval: BillingInterval;
+};
+
+export function PlanSwitcher({ currentPlan, currentInterval }: PlanSwitcherProps) {
+  const [interval, setIntervalState] = useState<BillingInterval>(currentInterval);
+  const [loadingPlan, setLoadingPlan] = useState<Plan | null>(null);
+  const [downgradeOpen, setDowngradeOpen] = useState(false);
+  const [targetDowngrade, setTargetDowngrade] = useState<Exclude<Plan, "ultra"> | null>(null);
+  const [confirmOpen, setConfirmOpen] = useState(false);
+  const [pendingChange, setPendingChange] = useState<{
+    plan: Exclude<Plan, "free">;
+    kind: "switch" | "upgrade";
+  } | null>(null);
+
+  const createCheckoutOrUpdate = api.lemonsqueezy.createCheckoutOrUpdate.useMutation({
+    onSuccess: (data) => {
+      if (data.status === "redirect" && data.url) {
+        window.location.href = data.url;
+        return;
+      }
+      if (data.status === "updated") {
+        trackEvent(POSTHOG_EVENTS.SUBSCRIPTION_UPGRADED, {
+          from_plan: currentPlan,
+          to_plan: loadingPlan,
+        });
+        toast.success(data.message);
+        window.location.reload();
+        return;
+      }
+      setLoadingPlan(null);
+    },
+    onError: (error) => {
+      toast.error(error.message);
+      setLoadingPlan(null);
+    },
+  });
+
+  const runUpgrade = (plan: Exclude<Plan, "free">) => {
+    setLoadingPlan(plan);
+    createCheckoutOrUpdate.mutate({ plan, interval });
+  };
+
+  const requestUpgrade = (plan: Plan, kind: "switch" | "upgrade") => {
+    if (plan === "free") return;
+    const target = plan as Exclude<Plan, "free">;
+    // Free → paid goes through the Lemon Squeezy hosted checkout (its own
+    // confirmation). In-place changes for an existing paid subscriber charge
+    // the card immediately, so confirm those first.
+    if (currentPlan === "free") {
+      runUpgrade(target);
+      return;
+    }
+    setPendingChange({ plan: target, kind });
+    setConfirmOpen(true);
+  };
+
+  const handleDowngrade = (plan: Plan) => {
+    if (plan === "ultra") return;
+    setTargetDowngrade(plan as Exclude<Plan, "ultra">);
+    setDowngradeOpen(true);
+  };
+
+  const currentPlanName = PLANS.find((p) => p.id === currentPlan)?.name ?? currentPlan;
+  const confirmCopy = pendingChange
+    ? buildPlanChangeCopy(pendingChange.kind, pendingChange.plan, interval)
+    : null;
+
+  return (
+    <div>
+      <div className="flex items-center justify-between gap-3">
+        <p className="text-[13px] font-medium text-neutral-900 dark:text-foreground">Change plan</p>
+        <div className="flex items-center gap-2">
+          <span className="text-[11px] font-medium text-emerald-600 dark:text-emerald-400">
+            Save 2 months
+          </span>
+          <div className="inline-flex items-center gap-0.5 rounded-full border border-neutral-200 dark:border-border p-0.5">
+            {(["monthly", "annual"] as const).map((value) => (
+              <button
+                key={value}
+                type="button"
+                onClick={() => setIntervalState(value)}
+                className={cn(
+                  "rounded-full px-2.5 py-1 text-[11px] font-medium transition-colors",
+                  interval === value
+                    ? "bg-neutral-900 text-white dark:bg-muted dark:text-foreground"
+                    : "text-neutral-500 dark:text-neutral-400 hover:text-neutral-900 dark:hover:text-foreground",
+                )}
+              >
+                {value === "monthly" ? "Monthly" : "Annual"}
+              </button>
+            ))}
+          </div>
+        </div>
+      </div>
+
+      <div className="mt-3 divide-y divide-neutral-100 dark:divide-border/50 overflow-hidden rounded-lg border border-neutral-200 dark:border-border">
+        {PLANS.map((plan) => {
+          const isCurrentTier = plan.id === currentPlan;
+          const matchesCurrent =
+            isCurrentTier && (plan.id === "free" || interval === currentInterval);
+          const canSwitchInterval =
+            isCurrentTier && plan.id !== "free" && interval !== currentInterval;
+          const isUpgrade = planOrder[plan.id] > planOrder[currentPlan];
+          const isDowngrade = planOrder[plan.id] < planOrder[currentPlan];
+
+          const priceLabel =
+            plan.id === "free"
+              ? "Free forever"
+              : interval === "annual"
+                ? `$${plan.annual}/yr`
+                : `$${plan.monthly}/mo`;
+
+          return (
+            <div
+              key={plan.id}
+              className={cn(
+                "flex items-center justify-between gap-3 px-4 py-3",
+                isCurrentTier && "bg-neutral-50/70 dark:bg-muted/20",
+              )}
+            >
+              <div className="min-w-0">
+                <p className="text-[13px] font-medium text-neutral-900 dark:text-foreground">
+                  {plan.name}
+                </p>
+                <p className="text-[12px] text-neutral-400 dark:text-neutral-500">{priceLabel}</p>
+              </div>
+
+              {matchesCurrent ? (
+                <span className="shrink-0 rounded-full border border-neutral-200 dark:border-border px-2.5 py-1 text-[11px] font-medium text-neutral-400 dark:text-neutral-500">
+                  Current
+                </span>
+              ) : canSwitchInterval ? (
+                <Button
+                  size="sm"
+                  variant="outline"
+                  className="h-8 shrink-0 text-[12px]"
+                  onClick={() => requestUpgrade(plan.id, "switch")}
+                  disabled={loadingPlan !== null}
+                >
+                  {loadingPlan === plan.id && (
+                    <Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" />
+                  )}
+                  Switch to {interval === "annual" ? "annual" : "monthly"}
+                </Button>
+              ) : isUpgrade ? (
+                <Button
+                  size="sm"
+                  className="h-8 shrink-0 bg-blue-600 text-[12px] text-white hover:bg-blue-700"
+                  onClick={() => requestUpgrade(plan.id, "upgrade")}
+                  disabled={loadingPlan !== null}
+                >
+                  {loadingPlan === plan.id && (
+                    <Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" />
+                  )}
+                  Upgrade
+                </Button>
+              ) : isDowngrade ? (
+                <Button
+                  size="sm"
+                  variant="outline"
+                  className="h-8 shrink-0 text-[12px]"
+                  onClick={() => handleDowngrade(plan.id)}
+                  disabled={loadingPlan !== null}
+                >
+                  {plan.id === "free" ? "Cancel plan" : "Downgrade"}
+                </Button>
+              ) : null}
+            </div>
+          );
+        })}
+      </div>
+
+      {targetDowngrade && (
+        <DowngradeFeedbackModal
+          open={downgradeOpen}
+          onOpenChange={setDowngradeOpen}
+          targetPlan={targetDowngrade}
+          currentPlanName={currentPlanName}
+          targetPlanName={PLANS.find((p) => p.id === targetDowngrade)?.name ?? targetDowngrade}
+        />
+      )}
+
+      {pendingChange && confirmCopy && (
+        <PlanChangeConfirmDialog
+          open={confirmOpen}
+          onOpenChange={setConfirmOpen}
+          title={confirmCopy.title}
+          description={confirmCopy.description}
+          note={confirmCopy.note}
+          confirmLabel={confirmCopy.confirmLabel}
+          isLoading={createCheckoutOrUpdate.isLoading}
+          onConfirm={() => runUpgrade(pendingChange.plan)}
+        />
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Lets subscribers upgrade, downgrade, and switch billing interval without leaving the app — directly from Settings and the dashboard pricing page — with a confirmation step before any immediate charge.

## Changes

- **Interval switching on the pricing cards.** The dashboard pricing cards are now interval-aware. A subscriber on one cadence sees "Switch to annual/monthly billing" on their current tier instead of only "Manage Subscription". The current-tier badge and styling are unchanged; only the CTA adapts.
- **Inline plan switcher in Settings > Billing.** A compact, settings-styled switcher (monthly/annual toggle + a Free/Pro/Ultra list with per-tier Upgrade / Downgrade / Cancel actions) replaces the old "Change Plan" redirect. "Manage Subscription" (Lemon Squeezy customer portal) is kept for payment-method and invoice management.
- **Confirmation before immediate charges.** Interval switches and upgrades from an existing paid plan call `updateSubscription` and charge the card on click, bypassing the hosted checkout. These now show a value-framed confirmation (charge amount + proration note + savings) before charging. Free to paid is unchanged — it still routes to the Lemon Squeezy hosted checkout, which is its own confirmation.

All three surfaces reuse the existing `createCheckoutOrUpdate` / `downgradeWithFeedback` tRPC mutations and the existing downgrade-feedback modal, so plan-change logic stays in one place. No new env vars, no schema changes.

## Type of Change

- [x] feat: New feature

## Testing

- `bun run typecheck` passes (0 errors).
- Not exercised live: the Settings page is behind Clerk auth. The buttons call the same Lemon Squeezy-backed procedures the pricing page already uses; the interval switch / in-place upgrade move real money on click, so verify against a test subscription before relying on it.

## Notes / follow-ups (unchanged from prior work)

- Set Lemon Squeezy annual variant `1809620` to $80 to match the displayed price.
- Confirm the variant IDs are Live-store.

https://claude.ai/code/session_01Daryf8BdFGVMmKLJuTURXc


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added confirmation dialogs when changing subscription plans.
  * Users can now switch between monthly and annual billing intervals for paid tiers.
  * Redesigned plan management interface with inline plan switching capability.
  * Added feedback modal for plan downgrades.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->