### PR TITLE
feat(bio-pages): accept handles and emails for social links

### DIFF
--- a/src/app/(main)/dashboard/bio-pages/[id]/_components/block-form-dialog.tsx
+++ b/src/app/(main)/dashboard/bio-pages/[id]/_components/block-form-dialog.tsx
@@ -246,7 +246,13 @@ export function BlockFormDialog({
                               prev.map((s, idx) => (idx === i ? { ...s, url: e.target.value } : s)),
                             )
                           }
-                          placeholder="https://…"
+                          placeholder={
+                            social.platform === "email"
+                              ? "you@example.com"
+                              : social.platform === "website"
+                                ? "https://yoursite.com"
+                                : "@handle or URL"
+                          }
                           className="flex-1"
                         />
                         <button

--- a/src/components/bio/social-links.test.ts
+++ b/src/components/bio/social-links.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, test } from "bun:test";
+
+import { normalizeSocialUrl } from "./social-links";
+
+describe("normalizeSocialUrl", () => {
+  test("builds profile URLs from bare handles", () => {
+    expect(normalizeSocialUrl("twitter", "jack")).toBe("https://x.com/jack");
+    expect(normalizeSocialUrl("instagram", "jane")).toBe("https://instagram.com/jane");
+    expect(normalizeSocialUrl("github", "octocat")).toBe("https://github.com/octocat");
+    expect(normalizeSocialUrl("tiktok", "charli")).toBe("https://tiktok.com/@charli");
+    expect(normalizeSocialUrl("linkedin", "jane-doe")).toBe("https://linkedin.com/in/jane-doe");
+  });
+
+  test("strips a leading @ from handles", () => {
+    expect(normalizeSocialUrl("twitter", "@jack")).toBe("https://x.com/jack");
+    expect(normalizeSocialUrl("threads", "@jane")).toBe("https://threads.net/@jane");
+  });
+
+  test("keeps handles that legitimately contain dots", () => {
+    expect(normalizeSocialUrl("instagram", "john.doe")).toBe("https://instagram.com/john.doe");
+  });
+
+  test("turns an email into a mailto link", () => {
+    expect(normalizeSocialUrl("email", "me@example.com")).toBe("mailto:me@example.com");
+  });
+
+  test("rejects a non-email for the email platform", () => {
+    expect(normalizeSocialUrl("email", "not-an-email")).toBeNull();
+  });
+
+  test("reduces whatsapp input to digits", () => {
+    expect(normalizeSocialUrl("whatsapp", "+1 (555) 123-4567")).toBe("https://wa.me/15551234567");
+  });
+
+  test("keeps full URLs as written", () => {
+    expect(normalizeSocialUrl("twitter", "https://x.com/jack")).toBe("https://x.com/jack");
+    expect(normalizeSocialUrl("email", "mailto:me@example.com")).toBe("mailto:me@example.com");
+  });
+
+  test("adds a scheme to a pasted host or bare domain", () => {
+    expect(normalizeSocialUrl("instagram", "instagram.com/jane")).toBe("https://instagram.com/jane");
+    expect(normalizeSocialUrl("website", "example.com")).toBe("https://example.com");
+  });
+
+  test("returns null for empty input", () => {
+    expect(normalizeSocialUrl("twitter", "   ")).toBeNull();
+  });
+
+  test("rejects unsafe schemes", () => {
+    expect(normalizeSocialUrl("website", "javascript:alert(1)")).toBeNull();
+  });
+});

--- a/src/components/bio/social-links.ts
+++ b/src/components/bio/social-links.ts
@@ -1,0 +1,64 @@
+// Turn whatever someone types for a social link — a bare handle ("@me"), an
+// email, a bare domain, or a full URL — into a canonical, safe href. The bio
+// editor accepts loose input and this is the single place that canonicalizes it.
+
+// For each handle-style platform: how a bare handle becomes a profile URL, and
+// the hostnames that signal the user pasted a full URL instead of a handle.
+const PLATFORM_LINKS: Record<string, { base: (handle: string) => string; hosts: string[] }> = {
+  twitter: { base: (h) => `https://x.com/${h}`, hosts: ["twitter.com", "x.com"] },
+  instagram: { base: (h) => `https://instagram.com/${h}`, hosts: ["instagram.com"] },
+  tiktok: { base: (h) => `https://tiktok.com/@${h}`, hosts: ["tiktok.com"] },
+  youtube: { base: (h) => `https://youtube.com/@${h}`, hosts: ["youtube.com", "youtu.be"] },
+  facebook: { base: (h) => `https://facebook.com/${h}`, hosts: ["facebook.com", "fb.com"] },
+  linkedin: { base: (h) => `https://linkedin.com/in/${h}`, hosts: ["linkedin.com"] },
+  github: { base: (h) => `https://github.com/${h}`, hosts: ["github.com"] },
+  telegram: { base: (h) => `https://t.me/${h}`, hosts: ["t.me", "telegram.me"] },
+  threads: { base: (h) => `https://threads.net/@${h}`, hosts: ["threads.net"] },
+  twitch: { base: (h) => `https://twitch.tv/${h}`, hosts: ["twitch.tv"] },
+  snapchat: { base: (h) => `https://snapchat.com/add/${h}`, hosts: ["snapchat.com"] },
+  whatsapp: { base: (h) => `https://wa.me/${h.replace(/[^0-9]/g, "")}`, hosts: ["wa.me", "whatsapp.com"] },
+};
+
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+// Only http(s) and mailto are renderable hrefs we want to emit.
+function asSafeUrl(value: string): string | null {
+  try {
+    const protocol = new URL(value).protocol;
+    return protocol === "http:" || protocol === "https:" || protocol === "mailto:" ? value : null;
+  } catch {
+    return null;
+  }
+}
+
+export function normalizeSocialUrl(platform: string, raw: string): string | null {
+  const value = raw.trim();
+  if (!value) return null;
+
+  // Already a full link — keep it as written (after a safety check).
+  if (/^https?:\/\//i.test(value)) return asSafeUrl(value);
+  if (/^mailto:/i.test(value)) return asSafeUrl(value);
+
+  if (platform === "email") {
+    return EMAIL_RE.test(value) ? `mailto:${value}` : null;
+  }
+
+  if (platform === "website") {
+    return asSafeUrl(`https://${value.replace(/^\/+/, "")}`);
+  }
+
+  const config = PLATFORM_LINKS[platform];
+  if (config) {
+    const lower = value.toLowerCase();
+    // Pasted the platform's own host without a scheme → treat it as a URL.
+    if (config.hosts.some((host) => lower.startsWith(host) || lower.startsWith(`www.${host}`))) {
+      return asSafeUrl(`https://${value.replace(/^\/+/, "")}`);
+    }
+    // Otherwise it's a handle: drop a leading @ and stray slashes.
+    const handle = value.replace(/^@+/, "").replace(/^\/+|\/+$/g, "");
+    return handle ? asSafeUrl(config.base(handle)) : null;
+  }
+
+  // Unknown platform: best effort.
+  return asSafeUrl(`https://${value.replace(/^\/+/, "")}`);
+}

--- a/src/server/api/routers/bio-page/bio-page.input.ts
+++ b/src/server/api/routers/bio-page/bio-page.input.ts
@@ -29,7 +29,9 @@ export const bioThemeSchema = z.object({
 
 export const bioSocialLinkSchema = z.object({
   platform: z.string().min(1).max(50),
-  url: z.string().url().max(2048),
+  // Accept a handle, email, bare domain, or full URL; the service canonicalizes
+  // it into a real href via normalizeSocialUrl, so don't force .url() here.
+  url: z.string().trim().min(1).max(2048),
 });
 
 export const bioSlugSchema = z

--- a/src/server/api/routers/bio-page/bio-page.service.ts
+++ b/src/server/api/routers/bio-page/bio-page.service.ts
@@ -9,6 +9,7 @@ import {
   canUseBioCustomThemes,
   getPlanCaps,
 } from "@/lib/billing/plans";
+import { normalizeSocialUrl } from "@/components/bio/social-links";
 import { isPlatformDomain } from "@/lib/constants/domains";
 import {
   bioBlock,
@@ -78,6 +79,25 @@ function parseSocials(content: string | null): BioSocialLink[] {
   } catch {
     return [];
   }
+}
+
+// Canonicalize each social entry to a real href before storing, so the public
+// renderer can use the value directly. Rejects entries that can't be resolved
+// (e.g. a non-email typed for the Email platform) with a clear message.
+function normalizeSocials(socials: BioSocialLink[]): BioSocialLink[] {
+  return socials.map((s) => {
+    const url = normalizeSocialUrl(s.platform, s.url);
+    if (!url) {
+      throw new TRPCError({
+        code: "BAD_REQUEST",
+        message:
+          s.platform === "email"
+            ? "Enter a valid email address for the Email link."
+            : `Enter a valid handle or URL for the ${s.platform} link.`,
+      });
+    }
+    return { platform: s.platform, url };
+  });
 }
 
 function themeHasCustomization(theme: BioPageTheme): boolean {
@@ -379,7 +399,9 @@ export async function addBlock(ctx: WorkspaceTRPCContext, input: AddBioBlockInpu
   const position = Number(row?.maxPos ?? -1) + 1;
 
   const content =
-    input.type === "social" ? JSON.stringify(input.socials ?? []) : input.content ?? null;
+    input.type === "social"
+      ? JSON.stringify(normalizeSocials(input.socials ?? []))
+      : input.content ?? null;
 
   if (input.type === "link") {
     const destination = input.url?.trim();
@@ -435,7 +457,7 @@ export async function updateBlock(ctx: WorkspaceTRPCContext, input: UpdateBioBlo
   if (input.scheduledUntil !== undefined) updates.scheduledUntil = input.scheduledUntil;
 
   if (block.type === "social") {
-    if (input.socials !== undefined) updates.content = JSON.stringify(input.socials);
+    if (input.socials !== undefined) updates.content = JSON.stringify(normalizeSocials(input.socials));
   } else if (input.content !== undefined) {
     updates.content = input.content;
   }


### PR DESCRIPTION
## Summary

Social link inputs on bio pages required a full URL, so entering a bare handle (`@me`) or an email address threw a validation error. This normalizes loose input into a canonical href per platform.

## Changes

- Add `normalizeSocialUrl(platform, raw)` (`src/components/bio/social-links.ts`): turns a handle, email, bare domain, or full URL into a safe `http(s)`/`mailto` href.
  - `@jack` (X) -> `https://x.com/jack`
  - `me@example.com` (Email) -> `mailto:me@example.com`
  - `john.doe` (Instagram) -> `https://instagram.com/john.doe` (handles with dots preserved)
  - `+1 (555) 123-4567` (WhatsApp) -> `https://wa.me/15551234567`
  - already-full URLs and pasted hosts are kept/prefixed as written
- Canonicalize every social entry server-side on add/update; reject values that can't be resolved (e.g. a non-email for the Email platform) with a clear message.
- Relax `bioSocialLinkSchema.url` from `.url()` to a trimmed non-empty string (the service is now the canonicalization point).
- Update editor placeholders to signal handles/emails are accepted.
- Unit tests for the normalizer.

## Type of Change

- [x] feat: New feature

## Testing

- `bun test src/components/bio/social-links.test.ts` (10 pass)
- `bun run typecheck` (0 errors)
- `bun run build` (compiles)

Follow-up to the merged link-in-bio PR (#311).