### PR TITLE
feat(admin): show bio page counts in the admin dashboard

### DIFF
--- a/src/app/(main)/dashboard/admin/_components/system-health-card.tsx
+++ b/src/app/(main)/dashboard/admin/_components/system-health-card.tsx
@@ -5,6 +5,8 @@ import { Card } from "@/components/ui/card";
 type HealthData = {
   totalLinks: number;
   totalUsers: number;
+  totalBioPages: number;
+  bioPagesToday: number;
   blockedLinks: number;
   bannedUsers: number;
   blockedPercent: number;
@@ -103,6 +105,12 @@ export function SystemHealthCard({ data, isLoading }: SystemHealthCardProps) {
         </p>
       </div>
       <div className="divide-y divide-neutral-100 dark:divide-border/50">
+        <StatusRow
+          label="Bio pages"
+          value={data.totalBioPages.toLocaleString()}
+          detail={`${data.bioPagesToday.toLocaleString()} today`}
+          status="neutral"
+        />
         <StatusRow
           label="Blocked links"
           value={`${data.blockedPercent}%`}

--- a/src/server/api/routers/admin/admin.service.ts
+++ b/src/server/api/routers/admin/admin.service.ts
@@ -3,6 +3,7 @@ import { and, between, count, desc, eq, inArray, like, or, sql } from "drizzle-o
 import { buildCacheKey, deleteFromCache } from "@/lib/core/cache";
 import { PAID_PLANS, PLAN_PRICES_USD, type PaidPlan } from "@/lib/constants/plan-pricing";
 import {
+  bioPage,
   blockedDomain,
   feedback,
   flaggedLink,
@@ -949,12 +950,16 @@ export async function getMonthlyBreakdown(
 }
 
 export async function getSystemHealth(ctx: ProtectedTRPCContext) {
+  const today = new Date();
+  today.setHours(0, 0, 0, 0);
+
   const [
     linkStatsResult,
     userStatsResult,
     pendingFlaggedResult,
     openFeedbackResult,
     blockedDomainsResult,
+    bioPageStatsResult,
   ] = await Promise.all([
     ctx.db
       .select({
@@ -977,6 +982,12 @@ export async function getSystemHealth(ctx: ProtectedTRPCContext) {
       .from(feedback)
       .where(eq(feedback.status, "open")),
     ctx.db.select({ count: count() }).from(blockedDomain),
+    ctx.db
+      .select({
+        total: count(),
+        today: sql<number>`SUM(${bioPage.createdAt} >= ${today})`,
+      })
+      .from(bioPage),
   ]);
 
   const totalLinks = linkStatsResult[0]?.total ?? 0;
@@ -996,6 +1007,8 @@ export async function getSystemHealth(ctx: ProtectedTRPCContext) {
     pendingFlagged: pendingFlaggedResult[0]?.count ?? 0,
     openFeedback: openFeedbackResult[0]?.count ?? 0,
     blockedDomains: blockedDomainsResult[0]?.count ?? 0,
+    totalBioPages: bioPageStatsResult[0]?.total ?? 0,
+    bioPagesToday: Number(bioPageStatsResult[0]?.today ?? 0),
   };
 }
 


### PR DESCRIPTION
## Summary

The admin dashboard tracked links, users, and clicks but had no visibility into bio pages. This adds total and today's bio-page counts.

## Changes

- `getSystemHealth`: add a `bioPage` scan to the existing `Promise.all`, returning `totalBioPages` and `bioPagesToday` (mirrors the link/user "today" pattern).
- System Health card: new "Bio pages" row showing the total with a "N today" detail.

## Type of Change

- [x] feat: New feature

## Testing

- `bun run typecheck` (0 errors)
- `bun run build` (compiles)

Follow-up to the merged link-in-bio work (#311).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * System health monitoring now includes bio pages metrics. Administrators can view the total number of bio pages in the system and how many were created today directly in the admin dashboard system health card. This provides real-time visibility into bio page creation activity, helping administrators monitor platform statistics and content growth.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->