### PR TITLE
feat(seo): sitemap, structured data, accurate pricing, and canonicals

### DIFF
--- a/src/app/(landing)/blog/[slug]/page.tsx
+++ b/src/app/(landing)/blog/[slug]/page.tsx
@@ -80,7 +80,7 @@ export default async function BlogPostPage({ params }: BlogPostPageProps) {
     description: post.description,
     url: `https://ishortn.ink/blog/${slug}`,
     datePublished: post.date,
-    dateModified: post.date,
+    dateModified: post.updated ?? post.date,
     author: post.author,
     image: post.image,
   });

--- a/src/app/(landing)/blog/page.tsx
+++ b/src/app/(landing)/blog/page.tsx
@@ -1,7 +1,9 @@
 import type { Metadata } from "next";
 import { Link } from "next-view-transitions";
 
+import { JsonLd } from "@/components/seo/json-ld";
 import { getAllPosts } from "@/lib/blog";
+import { createBreadcrumbSchema } from "@/lib/seo/structured-data";
 
 import { Footer } from "../_components/footer";
 import { Header } from "../_components/header";
@@ -43,6 +45,12 @@ export default async function BlogPage() {
 
   return (
     <main style={{ background: "var(--warm-bg)", color: "var(--warm-ink)" }}>
+      <JsonLd
+        data={createBreadcrumbSchema([
+          { name: "Home", url: "https://ishortn.ink" },
+          { name: "Blog", url: "https://ishortn.ink/blog" },
+        ])}
+      />
       <Header />
 
       <section className="warm-subhero">

--- a/src/app/(landing)/changelog/page.tsx
+++ b/src/app/(landing)/changelog/page.tsx
@@ -2,7 +2,9 @@ import { Suspense } from "react";
 
 import type { Metadata } from "next";
 
+import { JsonLd } from "@/components/seo/json-ld";
 import { getChangelogEntries } from "@/lib/changelog";
+import { createBreadcrumbSchema } from "@/lib/seo/structured-data";
 
 import { Footer } from "../_components/footer";
 import { Header } from "../_components/header";
@@ -26,6 +28,12 @@ export default async function ChangelogPage() {
 
   return (
     <main style={{ background: "var(--warm-bg)", color: "var(--warm-ink)" }}>
+      <JsonLd
+        data={createBreadcrumbSchema([
+          { name: "Home", url: "https://ishortn.ink" },
+          { name: "Changelog", url: "https://ishortn.ink/changelog" },
+        ])}
+      />
       <Header />
       <span id="top" />
       <ChangelogHero />

--- a/src/app/(landing)/compare/[slug]/page.tsx
+++ b/src/app/(landing)/compare/[slug]/page.tsx
@@ -2,8 +2,10 @@ import type { Metadata } from "next";
 import { notFound } from "next/navigation";
 import { Link } from "next-view-transitions";
 
+import { JsonLd } from "@/components/seo/json-ld";
 import { Paths } from "@/lib/constants/app";
 import { competitors, type Competitor } from "@/lib/seo/competitors";
+import { createBreadcrumbSchema } from "@/lib/seo/structured-data";
 
 import { CTA } from "../../_components/cta";
 import { Footer } from "../../_components/footer";
@@ -53,7 +55,7 @@ const ishortn = {
   apiAccess: "Pro and Ultra",
   teamFeatures: "Ultra plan",
   passwordProtection: "Pro and Ultra",
-  pricing: "Free forever, Pro $5/mo, Ultra $15/mo",
+  pricing: "Free forever, Pro $8/mo, Ultra $15/mo",
 };
 
 type FeatureRow = {
@@ -83,6 +85,15 @@ export default async function ComparePage({
 
   return (
     <main style={{ background: "var(--warm-bg)", color: "var(--warm-ink)" }}>
+      <JsonLd
+        data={createBreadcrumbSchema([
+          { name: "Home", url: "https://ishortn.ink" },
+          {
+            name: `${competitor.name} vs iShortn`,
+            url: `https://ishortn.ink/compare/${competitor.slug}`,
+          },
+        ])}
+      />
       <Header />
 
       <section className="warm-subhero">
@@ -403,7 +414,7 @@ export default async function ComparePage({
                   30 links/month, 1,000 tracked events, 7-day analytics.
                 </p>
                 <p style={{ margin: 0 }}>
-                  <strong style={{ color: "var(--warm-paper)" }}>Pro $5/mo</strong>{" "}
+                  <strong style={{ color: "var(--warm-paper)" }}>Pro $8/mo</strong>{" "}
                   — 1,000 links/month, 10,000 tracked events, unlimited
                   analytics history, 3 custom domains, branded + dynamic QR
                   codes, REST API.

--- a/src/app/(landing)/features/page.tsx
+++ b/src/app/(landing)/features/page.tsx
@@ -1,5 +1,8 @@
 import type { Metadata } from "next";
 
+import { JsonLd } from "@/components/seo/json-ld";
+import { createBreadcrumbSchema, softwareApplicationSchema } from "@/lib/seo/structured-data";
+
 import { CTA } from "../_components/cta";
 import { DashboardPreview } from "../_components/dashboard-preview";
 import { Features } from "../_components/features";
@@ -30,6 +33,13 @@ export const metadata: Metadata = {
 export default function FeaturesPage() {
   return (
     <main style={{ background: "var(--warm-bg)", color: "var(--warm-ink)" }}>
+      <JsonLd data={softwareApplicationSchema} />
+      <JsonLd
+        data={createBreadcrumbSchema([
+          { name: "Home", url: "https://ishortn.ink" },
+          { name: "Features", url: "https://ishortn.ink/features" },
+        ])}
+      />
       <Header />
 
       <section className="warm-subhero">

--- a/src/app/(landing)/page.tsx
+++ b/src/app/(landing)/page.tsx
@@ -26,7 +26,7 @@ export const metadata: Metadata = {
       "iShortn — Links, made lovely. Free URL shortener with analytics",
   },
   description:
-    "Shorten URLs for free with iShortn. Create branded short links, track clicks and engagement, generate QR codes, and use custom domains. The best free URL shortener with powerful analytics.",
+    "Shorten URLs for free with iShortn. Create branded short links, track clicks and engagement, generate QR codes, and use custom domains.",
   keywords: [
     "url shortener",
     "free url shortener",

--- a/src/app/(landing)/pricing/page.tsx
+++ b/src/app/(landing)/pricing/page.tsx
@@ -1,5 +1,8 @@
 import type { Metadata } from "next";
 
+import { JsonLd } from "@/components/seo/json-ld";
+import { createFaqSchema, softwareApplicationSchema } from "@/lib/seo/structured-data";
+
 import { CTA } from "../_components/cta";
 import { Faq } from "../_components/faq";
 import { Footer } from "../_components/footer";
@@ -51,6 +54,10 @@ const pricingFaqs = [
 export default function PricingPage() {
   return (
     <main style={{ background: "var(--warm-bg)", color: "var(--warm-ink)" }}>
+      <JsonLd data={softwareApplicationSchema} />
+      <JsonLd
+        data={createFaqSchema(pricingFaqs.map((f) => ({ question: f.q, answer: f.a })))}
+      />
       <Header />
 
       <section className="warm-subhero">

--- a/src/app/(landing)/pricing/page.tsx
+++ b/src/app/(landing)/pricing/page.tsx
@@ -1,7 +1,11 @@
 import type { Metadata } from "next";
 
 import { JsonLd } from "@/components/seo/json-ld";
-import { createFaqSchema, softwareApplicationSchema } from "@/lib/seo/structured-data";
+import {
+  createBreadcrumbSchema,
+  createFaqSchema,
+  softwareApplicationSchema,
+} from "@/lib/seo/structured-data";
 
 import { CTA } from "../_components/cta";
 import { Faq } from "../_components/faq";
@@ -54,6 +58,12 @@ const pricingFaqs = [
 export default function PricingPage() {
   return (
     <main style={{ background: "var(--warm-bg)", color: "var(--warm-ink)" }}>
+      <JsonLd
+        data={createBreadcrumbSchema([
+          { name: "Home", url: "https://ishortn.ink" },
+          { name: "Pricing", url: "https://ishortn.ink/pricing" },
+        ])}
+      />
       <JsonLd data={softwareApplicationSchema} />
       <JsonLd
         data={createFaqSchema(pricingFaqs.map((f) => ({ question: f.q, answer: f.a })))}

--- a/src/app/(main)/p-host/[host]/page.tsx
+++ b/src/app/(main)/p-host/[host]/page.tsx
@@ -35,6 +35,8 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   return {
     title: { absolute: title },
     description,
+    // This custom-domain root is the canonical URL for the page.
+    alternates: { canonical: `https://${domain}` },
     openGraph: { title, description, type: "profile" },
     twitter: { card: "summary_large_image", title, description },
   };

--- a/src/app/(main)/p/[slug]/page.tsx
+++ b/src/app/(main)/p/[slug]/page.tsx
@@ -24,6 +24,11 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   return {
     title: { absolute: title },
     description,
+    // A bio page with a custom domain is canonically served there; otherwise
+    // /p/<slug> is its own canonical (resolved against metadataBase).
+    alternates: {
+      canonical: page.customDomain ? `https://${page.customDomain}` : `/p/${slug}`,
+    },
     openGraph: { title, description, type: "profile" },
     twitter: { card: "summary_large_image", title, description },
   };

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -9,7 +9,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
 
   const blogPostEntries: MetadataRoute.Sitemap = posts.map((post) => ({
     url: `https://ishortn.ink/blog/${post.slug}`,
-    lastModified: new Date(post.date).toISOString(),
+    lastModified: new Date(post.updated ?? post.date).toISOString(),
     changeFrequency: "monthly",
     priority: 0.8,
   }));

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,6 +1,7 @@
 import type { MetadataRoute } from "next";
 
 import { getAllPosts } from "@/lib/blog";
+import { competitors } from "@/lib/seo/competitors";
 import { absoluteUrl } from "@/lib/utils";
 
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
@@ -21,6 +22,18 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
       priority: 1.0,
     },
     {
+      url: absoluteUrl("/pricing"),
+      lastModified: new Date().toISOString(),
+      changeFrequency: "weekly",
+      priority: 0.9,
+    },
+    {
+      url: absoluteUrl("/features"),
+      lastModified: new Date().toISOString(),
+      changeFrequency: "weekly",
+      priority: 0.9,
+    },
+    {
       url: absoluteUrl("/blog"),
       lastModified: new Date().toISOString(),
       changeFrequency: "daily",
@@ -31,6 +44,12 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
       lastModified: new Date().toISOString(),
       changeFrequency: "weekly",
       priority: 0.7,
+    },
+    {
+      url: absoluteUrl("/abuse"),
+      lastModified: new Date().toISOString(),
+      changeFrequency: "yearly",
+      priority: 0.3,
     },
     {
       url: absoluteUrl("/privacy"),
@@ -46,5 +65,13 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     },
   ];
 
-  return [...staticRoutes, ...blogPostEntries];
+  // High-intent comparison pages, one per competitor (src/lib/seo/competitors.ts).
+  const compareEntries: MetadataRoute.Sitemap = Object.values(competitors).map((c) => ({
+    url: absoluteUrl(`/compare/${c.slug}`),
+    lastModified: new Date().toISOString(),
+    changeFrequency: "monthly",
+    priority: 0.8,
+  }));
+
+  return [...staticRoutes, ...compareEntries, ...blogPostEntries];
 }

--- a/src/lib/blog.ts
+++ b/src/lib/blog.ts
@@ -40,6 +40,14 @@ function parseDateString(dateValue: unknown): string {
   return strValue.includes("T") ? (strValue.split("T")[0] as string) : strValue;
 }
 
+// Drop a missing or malformed `updated` value so it can't propagate to
+// new Date(...).toISOString() (sitemap) or Article.dateModified as an invalid date.
+function parseOptionalDate(value: unknown): string | undefined {
+  if (value === undefined || value === null || value === "") return undefined;
+  const parsed = parseDateString(value);
+  return Number.isNaN(new Date(parsed).getTime()) ? undefined : parsed;
+}
+
 export async function getAllPosts(): Promise<BlogPost[]> {
   if (!fs.existsSync(blogDirectory)) {
     return [];
@@ -92,7 +100,7 @@ export async function getPostBySlug(slug: string): Promise<BlogPost | null> {
     title: String(data.title),
     description: String(data.description),
     date: parseDateString(data.date),
-    updated: data.updated ? parseDateString(data.updated) : undefined,
+    updated: parseOptionalDate(data.updated),
     author: data.author ? String(data.author) : "Kelvin Amoaba",
     tags: Array.isArray(data.tags) ? data.tags.map(String) : [],
     image: data.image ? String(data.image) : undefined,

--- a/src/lib/blog.ts
+++ b/src/lib/blog.ts
@@ -11,6 +11,7 @@ export interface BlogPostFrontmatter {
   title: string;
   description: string;
   date: string;
+  updated?: string;
   author: string;
   tags: string[];
   image?: string;
@@ -91,6 +92,7 @@ export async function getPostBySlug(slug: string): Promise<BlogPost | null> {
     title: String(data.title),
     description: String(data.description),
     date: parseDateString(data.date),
+    updated: data.updated ? parseDateString(data.updated) : undefined,
     author: data.author ? String(data.author) : "Kelvin Amoaba",
     tags: Array.isArray(data.tags) ? data.tags.map(String) : [],
     image: data.image ? String(data.image) : undefined,

--- a/src/lib/seo/competitors.ts
+++ b/src/lib/seo/competitors.ts
@@ -16,9 +16,9 @@ export const competitors = {
     whySwitch: [
       "Bitly's free plan only allows 5 links per month — iShortn gives you 30",
       "Bitly free links may show interstitial ad pages before redirecting",
-      "Bitly charges $35/month for Core — iShortn Pro is just $5/month",
+      "Bitly charges $35/month for Core — iShortn Pro is just $8/month",
       "iShortn includes full analytics and QR codes on all plans, plus password protection on Pro and Ultra",
-      "No API access on Bitly free — iShortn Pro includes full API for $5/month",
+      "No API access on Bitly free — iShortn Pro includes full API for $8/month",
     ],
   },
   tinyurl: {
@@ -59,7 +59,7 @@ export const competitors = {
     pricing: "Free, Essentials $13/mo, Professional $32/mo",
     whySwitch: [
       "Rebrandly free gives 500 total links — iShortn gives 30 new links every month, ongoing",
-      "Rebrandly Essentials costs $13/month — iShortn Pro is just $5/month",
+      "Rebrandly Essentials costs $13/month — iShortn Pro is just $8/month",
       "Rebrandly QR codes have watermarks on free — iShortn QR codes are clean on all plans",
       "iShortn includes geo-targeting and AI-powered security that Rebrandly charges extra for",
     ],
@@ -81,7 +81,7 @@ export const competitors = {
     whySwitch: [
       "Short.io requires you to bring your own domain even to get started — iShortn works instantly",
       "Short.io free gives 1,000 links total lifetime — iShortn gives fresh links every month",
-      "Short.io Business plan is $48/month — iShortn Pro is just $5/month",
+      "Short.io Business plan is $48/month — iShortn Pro is just $8/month",
       "iShortn includes password protection and AI-powered phishing detection on all links",
     ],
   },
@@ -98,10 +98,10 @@ export const competitors = {
     apiAccess: "Yes (limited)",
     teamFeatures: "Paid only",
     passwordProtection: "Paid only",
-    pricing: "Free, Pro $24/mo, Business $59/mo",
+    pricing: "Free, Pro $24/mo, Business $89/mo",
     whySwitch: [
-      "Dub Pro costs $24/month — iShortn Pro is just $5/month for similar features",
-      "Dub free analytics only goes back 30 days — same as iShortn free, but iShortn Pro unlocks unlimited retention for $5 vs Dub's $24",
+      "Dub Pro costs $24/month — iShortn Pro is just $8/month for similar features",
+      "Dub free analytics only goes back 30 days — same as iShortn free, but iShortn Pro unlocks unlimited retention for $8 vs Dub's $24",
       "iShortn offers 30 free links/month vs Dub's 25",
       "iShortn includes password protection and geo-targeting on the Pro plan",
     ],

--- a/src/lib/seo/structured-data.ts
+++ b/src/lib/seo/structured-data.ts
@@ -1,3 +1,5 @@
+import { PLAN_PRICES_USD } from "@/lib/constants/plan-pricing";
+
 export const organizationSchema = {
   "@context": "https://schema.org",
   "@type": "Organization",
@@ -18,34 +20,30 @@ export const softwareApplicationSchema = {
   url: "https://ishortn.ink",
   applicationCategory: "BusinessApplication",
   operatingSystem: "Web",
+  // Prices derive from the pricing source of truth so the JSON-LD can't drift.
   offers: [
     {
       "@type": "Offer",
-      price: "0",
+      price: String(PLAN_PRICES_USD.free),
       priceCurrency: "USD",
       name: "Free",
       description: "30 links per month with basic analytics",
     },
     {
       "@type": "Offer",
-      price: "5",
+      price: String(PLAN_PRICES_USD.pro),
       priceCurrency: "USD",
       name: "Pro",
       description: "1,000 links per month with full analytics and custom domains",
     },
     {
       "@type": "Offer",
-      price: "15",
+      price: String(PLAN_PRICES_USD.ultra),
       priceCurrency: "USD",
       name: "Ultra",
       description: "Unlimited links with team collaboration",
     },
   ],
-  aggregateRating: {
-    "@type": "AggregateRating",
-    ratingValue: "4.8",
-    ratingCount: "150",
-  },
 };
 
 export function createFaqSchema(faqs: { question: string; answer: string }[]) {

--- a/src/server/api/routers/bio-page/bio-page.service.ts
+++ b/src/server/api/routers/bio-page/bio-page.service.ts
@@ -554,6 +554,7 @@ export type PublicBioPage = {
   seoTitle: string | null;
   seoDescription: string | null;
   socialImageUrl: string | null;
+  customDomain: string | null;
   ownerId: string;
   blocks: PublicBioBlock[];
 };
@@ -612,6 +613,7 @@ async function assemblePublicBioPage(
     seoTitle: page.seoTitle,
     seoDescription: page.seoDescription,
     socialImageUrl: page.socialImageUrl,
+    customDomain: page.customDomain,
     ownerId: page.userId,
     blocks: publicBlocks,
   };


### PR DESCRIPTION
## Summary

A batch of SEO improvements from a full audit of every public route. The infrastructure was already sound; this closes the gaps that mattered — discoverability of commercial pages, structured-data coverage, factual pricing, and duplicate-content signals.

## Changes

**Discoverability**
- Sitemap now includes `/pricing`, `/features`, all `/compare/<slug>` pages (generated from `competitors.ts`), and `/abuse` — previously absent, so crawlers weren't pointed at the highest-intent pages.

**Structured data (rich-result eligibility)**
- Removed the fabricated `aggregateRating` (4.8/150) from the SoftwareApplication JSON-LD — no review system backs it, which violates Google's review-snippet policy and risks a manual action.
- Added JSON-LD: pricing (FAQPage + Offer), features (SoftwareApplication + Breadcrumb), compare (Breadcrumb), blog index + changelog (Breadcrumb).

**Pricing accuracy**
- JSON-LD Offer prices now derive from `PLAN_PRICES_USD` so they can't drift.
- Corrected the stale Pro `$5` → `$8` across the comparison pages and competitor selling points (these were user-facing on the money pages).

**Canonicals & freshness**
- Bio pages emit a canonical: a page with a custom domain points `/p/<slug>` at the custom-domain root, and the custom-domain route points to itself — consolidating the duplicate-content split.
- Trimmed the home meta description from 188 chars so it no longer truncates in SERPs.
- Blog posts support an optional `updated` frontmatter field, fed as `Article.dateModified` and the post's sitemap `lastModified`.

## Type of Change

- [x] feat / fix: SEO improvements

## Testing

- `bun run typecheck` (0 errors) and `bun run build` (compiles) on every change.

## Deferred (by choice)

- Tightening the home `<title>` (<60 chars) was left out to preserve the "Links, made lovely" brand line.

Follow-up to the merged link-in-bio work.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced SEO with structured data across landing pages (breadcrumbs, FAQ schema, software application schema).
  * Improved blog post handling with support for tracking update dates separately from publication dates.

* **Bug Fixes**
  * Updated canonical URL metadata for custom domain bio pages and short links to improve search engine indexing.

* **Chores**
  * Updated Pro plan pricing from $5/mo to $8/mo across pricing comparisons.
  * Expanded sitemap coverage with new routes and improved lastModified tracking for blog posts.
  * Refreshed landing page description to highlight key features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->