### PR TITLE
fix(analytics): include archived daily-summary clicks in total click counts

### DIFF
--- a/src/app/(main)/expired/[linkId]/page.tsx
+++ b/src/app/(main)/expired/[linkId]/page.tsx
@@ -1,11 +1,12 @@
 import { IconClockOff } from "@tabler/icons-react";
-import { count, eq } from "drizzle-orm";
+import { eq } from "drizzle-orm";
 import { Funnel_Sans } from "next/font/google";
 import { notFound } from "next/navigation";
 
 import { cn } from "@/lib/utils";
 import { db } from "@/server/db";
-import { link, linkVisit } from "@/server/db/schema";
+import { link } from "@/server/db/schema";
+import { getTotalClicks } from "@/server/lib/total-clicks";
 
 const funnelSans = Funnel_Sans({
   subsets: ["latin"],
@@ -40,12 +41,8 @@ export default async function ExpiredPage({ params }: ExpiredPageProps) {
 
   let clicksExpired = false;
   if (linkRecord.disableLinkAfterClicks != null) {
-    const result = await db
-      .select({ clickCount: count(linkVisit.id) })
-      .from(linkVisit)
-      .where(eq(linkVisit.linkId, linkRecord.id));
-    clicksExpired =
-      (result[0]?.clickCount ?? 0) >= linkRecord.disableLinkAfterClicks;
+    const clickCount = await getTotalClicks(linkRecord.id);
+    clicksExpired = clickCount >= linkRecord.disableLinkAfterClicks;
   }
 
   if (!linkRecord.disabled && !dateExpired && !clicksExpired) {

--- a/src/app/api/link/route.ts
+++ b/src/app/api/link/route.ts
@@ -1,4 +1,4 @@
-import { asc, count, eq } from "drizzle-orm";
+import { asc, eq } from "drizzle-orm";
 import type { NextRequest } from "next/server";
 
 import {
@@ -17,7 +17,8 @@ import {
 } from "@/lib/utils/verified-click-token";
 import { recordClick, resolveLink } from "@/middlewares/record-click";
 import { db } from "@/server/db";
-import { geoRule, link as linkTable, linkVisit } from "@/server/db/schema";
+import { geoRule, link as linkTable } from "@/server/db/schema";
+import { getTotalClicks } from "@/server/lib/total-clicks";
 import { isOwnerOnPaidPlan } from "@/server/lib/user-plan";
 
 const log = logger.child({ component: "link-resolver" });
@@ -54,14 +55,9 @@ async function checkLinkExpiration(
     return true;
   }
 
-  // Click-based expiration
+  // Click-based expiration (true total: raw visits + archived daily summaries)
   if (link.disableLinkAfterClicks) {
-    const result = await db
-      .select({ clickCount: count(linkVisit.id) })
-      .from(linkVisit)
-      .where(eq(linkVisit.linkId, link.id));
-
-    const clickCount = result[0]?.clickCount ?? 0;
+    const clickCount = await getTotalClicks(link.id);
 
     if (clickCount >= link.disableLinkAfterClicks) {
       void runBackgroundTask(autoDisableLink(link.id, cacheKey));

--- a/src/server/api/routers/domains/domains.service.ts
+++ b/src/server/api/routers/domains/domains.service.ts
@@ -1,8 +1,8 @@
 import { TRPCError } from "@trpc/server";
-import { and, count, eq, inArray, ne } from "drizzle-orm";
+import { and, count, eq, inArray, ne, sum } from "drizzle-orm";
 
 import { isSubscriptionEntitled, PLAN_CAPS, resolvePlan } from "@/lib/billing/plans";
-import { customDomain, link, linkVisit } from "@/server/db/schema";
+import { customDomain, link, linkVisit, linkVisitDailySummary } from "@/server/db/schema";
 import {
   requirePermission,
   workspaceFilter,
@@ -248,15 +248,23 @@ export async function getDomainStatistics(ctx: WorkspaceTRPCContext, domain: str
   // Calculate link count
   const linkCount = domainLinks.length;
 
-  // Calculate total clicks
+  // Calculate total clicks (raw visits + archived clicks rolled up by the
+  // analytics cleanup job)
   let totalClicks = 0;
   if (linkIds.length > 0) {
-    const clicksResult = await ctx.db
-      .select({ count: count() })
-      .from(linkVisit)
-      .where(inArray(linkVisit.linkId, linkIds));
+    const [clicksResult, archivedResult] = await Promise.all([
+      ctx.db
+        .select({ count: count() })
+        .from(linkVisit)
+        .where(inArray(linkVisit.linkId, linkIds)),
+      ctx.db
+        .select({ total: sum(linkVisitDailySummary.clicks) })
+        .from(linkVisitDailySummary)
+        .where(inArray(linkVisitDailySummary.linkId, linkIds)),
+    ]);
 
-    totalClicks = clicksResult[0]?.count ?? 0;
+    totalClicks =
+      (clicksResult[0]?.count ?? 0) + (Number(archivedResult[0]?.total) || 0);
   }
 
   // Find last used date (most recent link creation)

--- a/src/server/api/routers/folder/folder.service.ts
+++ b/src/server/api/routers/folder/folder.service.ts
@@ -1,8 +1,15 @@
 import { TRPCError } from "@trpc/server";
-import { and, count, desc, eq, getTableColumns, inArray, sql } from "drizzle-orm";
+import { and, count, desc, eq, getTableColumns, inArray, sql, sum } from "drizzle-orm";
 
 import { getPlanCaps } from "@/lib/billing/plans";
-import { folder, folderPermission, link, linkVisit, teamMember } from "@/server/db/schema";
+import {
+  folder,
+  folderPermission,
+  link,
+  linkVisit,
+  linkVisitDailySummary,
+  teamMember,
+} from "@/server/db/schema";
 import {
   getAccessibleFolderIds,
   getFolderPermissionMap,
@@ -169,14 +176,27 @@ export const getFolder = async (
   // Check access permission for team members
   await requireFolderAccess(ctx.db, ctx.workspace, input.id);
 
-  // Get all links in this folder with totalClicks
+  // Get all links in this folder with totalClicks. True totals combine raw
+  // visits with archived clicks rolled up by the analytics cleanup job.
+  const archivedClicksPerLink = ctx.db
+    .select({
+      linkId: linkVisitDailySummary.linkId,
+      clicks: sum(linkVisitDailySummary.clicks).as("archived_clicks"),
+    })
+    .from(linkVisitDailySummary)
+    .groupBy(linkVisitDailySummary.linkId)
+    .as("archivedClicksPerLink");
+
   const folderLinks = await ctx.db
     .select({
       ...getTableColumns(link),
-      totalClicks: count(linkVisit.id).as("total_clicks"),
+      totalClicks: sql<number>`${count(linkVisit.id)} + COALESCE(MAX(${archivedClicksPerLink.clicks}), 0)`
+        .mapWith(Number)
+        .as("total_clicks"),
     })
     .from(link)
     .leftJoin(linkVisit, eq(link.id, linkVisit.linkId))
+    .leftJoin(archivedClicksPerLink, eq(link.id, archivedClicksPerLink.linkId))
     .where(
       and(eq(link.folderId, input.id), workspaceFilter(ctx.workspace, link.userId, link.teamId))
     )

--- a/src/server/api/routers/link/link.service.ts
+++ b/src/server/api/routers/link/link.service.ts
@@ -15,6 +15,7 @@ import {
   lt,
   or,
   sql,
+  sum,
 } from "drizzle-orm";
 import {
   canUseGeoRules,
@@ -48,6 +49,7 @@ import {
   linkMilestone,
   linkTag,
   linkVisit,
+  linkVisitDailySummary,
   qrcode,
   tag,
   uniqueLinkVisit,
@@ -198,14 +200,29 @@ export const getLinks = async (
     }
   }
 
+  // Archived clicks rolled up by the analytics cleanup job — raw LinkVisit
+  // rows older than the retention window are deleted, so true totals must
+  // combine both sources (see LinkVisitDailySummary).
+  const archivedClicksPerLink = ctx.db
+    .select({
+      linkId: linkVisitDailySummary.linkId,
+      clicks: sum(linkVisitDailySummary.clicks).as("archived_clicks"),
+    })
+    .from(linkVisitDailySummary)
+    .groupBy(linkVisitDailySummary.linkId)
+    .as("archivedClicksPerLink");
+
   // Prepare the query parts
   const linksQuery = ctx.db
     .select({
       ...getTableColumns(link),
-      totalClicks: count(linkVisit.id).as("total_clicks"),
+      totalClicks: sql<number>`${count(linkVisit.id)} + COALESCE(MAX(${archivedClicksPerLink.clicks}), 0)`
+        .mapWith(Number)
+        .as("total_clicks"),
     })
     .from(link)
     .leftJoin(linkVisit, eq(link.id, linkVisit.linkId))
+    .leftJoin(archivedClicksPerLink, eq(link.id, archivedClicksPerLink.linkId))
     .where(baseCondition)
     .groupBy(link.id)
     .limit(pageSize)
@@ -213,28 +230,34 @@ export const getLinks = async (
 
   // Apply ordering based on the orderBy parameter
   if (orderBy === "totalClicks") {
-    linksQuery.orderBy(orderFunc(count(linkVisit.id)));
+    linksQuery.orderBy(orderFunc(sql`total_clicks`));
   } else if (orderBy === "lastClicked") {
     linksQuery.orderBy(orderFunc(sql`MAX(${linkVisit.createdAt})`));
   } else {
     linksQuery.orderBy(orderFunc(link.createdAt));
   }
 
-  const [totalLinksResult, totalClicksResult, links] = await Promise.all([
-    ctx.db.select({ count: count() }).from(link).where(baseCondition),
-    ctx.db
-      .select({ totalClicks: count(linkVisit.id) })
-      .from(linkVisit)
-      .innerJoin(link, eq(link.id, linkVisit.linkId))
-      .where(
-        and(
-          workspaceFilter(ctx.workspace, link.userId, link.teamId),
-          eq(link.isQrCode, false),
-          eq(link.isBioLink, false),
-        ),
-      ),
-    linksQuery,
-  ]);
+  const workspaceLinkCondition = and(
+    workspaceFilter(ctx.workspace, link.userId, link.teamId),
+    eq(link.isQrCode, false),
+    eq(link.isBioLink, false),
+  );
+
+  const [totalLinksResult, totalClicksResult, archivedClicksResult, links] =
+    await Promise.all([
+      ctx.db.select({ count: count() }).from(link).where(baseCondition),
+      ctx.db
+        .select({ totalClicks: count(linkVisit.id) })
+        .from(linkVisit)
+        .innerJoin(link, eq(link.id, linkVisit.linkId))
+        .where(workspaceLinkCondition),
+      ctx.db
+        .select({ archivedClicks: sum(linkVisitDailySummary.clicks) })
+        .from(linkVisitDailySummary)
+        .innerJoin(link, eq(link.id, linkVisitDailySummary.linkId))
+        .where(workspaceLinkCondition),
+      linksQuery,
+    ]);
 
   // Batch fetch creator info for team workspaces (avoid N+1)
   let creatorMap: Map<
@@ -290,7 +313,9 @@ export const getLinks = async (
   );
 
   const totalLinks = totalLinksResult?.[0]?.count ?? 0;
-  const totalClicks = totalClicksResult?.[0]?.totalClicks ?? 0;
+  const totalClicks =
+    (totalClicksResult?.[0]?.totalClicks ?? 0) +
+    (Number(archivedClicksResult?.[0]?.archivedClicks) || 0);
 
   return {
     links: linksWithTags,

--- a/src/server/api/routers/qrcode/qrcode.service.ts
+++ b/src/server/api/routers/qrcode/qrcode.service.ts
@@ -1,11 +1,18 @@
 import { TRPCError } from "@trpc/server";
-import { and, count, eq, inArray, sql } from "drizzle-orm";
+import { and, count, eq, inArray, sql, sum } from "drizzle-orm";
 
 import { buildCacheKey, deleteFromCache } from "@/lib/core/cache";
 import { logger } from "@/lib/logger";
 import { runBackgroundTask } from "@/lib/utils/background";
 import { assertUrlSafe } from "@/server/lib/phishing";
-import { link, linkVisit, qrcode, qrPreset, uniqueLinkVisit } from "@/server/db/schema";
+import {
+  link,
+  linkVisit,
+  linkVisitDailySummary,
+  qrcode,
+  qrPreset,
+  uniqueLinkVisit,
+} from "@/server/db/schema";
 import { deleteImage, uploadImage } from "@/server/lib/storage";
 import {
   insertHiddenTrackingLink,
@@ -209,18 +216,32 @@ export const retrieveUserQrCodes = userFacing(
       },
     });
 
-    // Get visit counts in a single aggregation query instead of loading all visit rows
+    // Get visit counts in a single aggregation query instead of loading all visit rows.
+    // Combine raw visits with archived clicks rolled up by the analytics cleanup job.
     const linkIds = qrCodes.map((qr) => qr.linkId).filter((id): id is number => id != null && id > 0);
-    const visitCounts =
+    const [visitCounts, archivedCounts] =
       linkIds.length > 0
-        ? await ctx.db
-            .select({ linkId: linkVisit.linkId, count: count() })
-            .from(linkVisit)
-            .where(inArray(linkVisit.linkId, linkIds))
-            .groupBy(linkVisit.linkId)
-        : [];
+        ? await Promise.all([
+            ctx.db
+              .select({ linkId: linkVisit.linkId, count: count() })
+              .from(linkVisit)
+              .where(inArray(linkVisit.linkId, linkIds))
+              .groupBy(linkVisit.linkId),
+            ctx.db
+              .select({
+                linkId: linkVisitDailySummary.linkId,
+                total: sum(linkVisitDailySummary.clicks),
+              })
+              .from(linkVisitDailySummary)
+              .where(inArray(linkVisitDailySummary.linkId, linkIds))
+              .groupBy(linkVisitDailySummary.linkId),
+          ])
+        : [[], []];
 
     const countMap = new Map(visitCounts.map((v) => [v.linkId, v.count]));
+    for (const row of archivedCounts) {
+      countMap.set(row.linkId, (countMap.get(row.linkId) ?? 0) + (Number(row.total) || 0));
+    }
 
     return qrCodes.map((qr) => ({
       ...qr,

--- a/src/server/lib/milestone-check.ts
+++ b/src/server/lib/milestone-check.ts
@@ -1,33 +1,12 @@
-import { and, count, eq, isNull, sum } from "drizzle-orm";
+import { and, eq, isNull } from "drizzle-orm";
 
 import { logger } from "@/lib/logger";
 import { db } from "@/server/db";
-import { link, linkMilestone, linkVisit, linkVisitDailySummary, user } from "@/server/db/schema";
+import { link, linkMilestone, user } from "@/server/db/schema";
 import { sendLinkMilestoneEmail } from "@/server/lib/notifications/link-milestone";
+import { getTotalClicks } from "@/server/lib/total-clicks";
 
 const log = logger.child({ component: "milestone-check" });
-
-/**
- * Get the true total click count for a link by combining:
- * - Archived clicks from the daily summary table (survives cleanup)
- * - Recent raw clicks not yet rolled up
- */
-async function getTotalClicks(linkId: number): Promise<number> {
-  const [summaryResult, rawResult] = await Promise.all([
-    db
-      .select({ total: sum(linkVisitDailySummary.clicks) })
-      .from(linkVisitDailySummary)
-      .where(eq(linkVisitDailySummary.linkId, linkId)),
-    db
-      .select({ total: count() })
-      .from(linkVisit)
-      .where(eq(linkVisit.linkId, linkId)),
-  ]);
-
-  const archivedClicks = Number(summaryResult[0]?.total) || 0;
-  const recentClicks = rawResult[0]?.total ?? 0;
-  return archivedClicks + recentClicks;
-}
 
 /**
  * Check if any pending milestones have been reached for a link and fire

--- a/src/server/lib/total-clicks.ts
+++ b/src/server/lib/total-clicks.ts
@@ -1,0 +1,26 @@
+import { count, eq, sum } from "drizzle-orm";
+
+import { db } from "@/server/db";
+import { linkVisit, linkVisitDailySummary } from "@/server/db/schema";
+
+/**
+ * Get the true total click count for a link by combining:
+ * - Archived clicks from the daily summary table (survives analytics cleanup)
+ * - Recent raw clicks not yet rolled up
+ */
+export async function getTotalClicks(linkId: number): Promise<number> {
+  const [summaryResult, rawResult] = await Promise.all([
+    db
+      .select({ total: sum(linkVisitDailySummary.clicks) })
+      .from(linkVisitDailySummary)
+      .where(eq(linkVisitDailySummary.linkId, linkId)),
+    db
+      .select({ total: count() })
+      .from(linkVisit)
+      .where(eq(linkVisit.linkId, linkId)),
+  ]);
+
+  const archivedClicks = Number(summaryResult[0]?.total) || 0;
+  const recentClicks = rawResult[0]?.total ?? 0;
+  return archivedClicks + recentClicks;
+}


### PR DESCRIPTION
## Summary

Fixes the total click count regression reported in #317. The analytics cleanup cron rolls raw `LinkVisit` rows older than the retention window (30 days free, 365 days Pro) into `LinkVisitDailySummary` before deleting them, but the dashboard and several other surfaces counted raw `LinkVisit` rows only. Once cleanup ran, displayed totals collapsed to clicks within the retention window, which is why a link with several hundred clicks showed only 25.

No data was lost; the historical clicks were preserved in the summary table but never included in the displayed totals.

## Changes

- Links dashboard (`link.service.ts`): per-link `totalClicks`, the workspace "Total Clicks" header, and sort-by-clicks now combine raw visit counts with archived daily-summary clicks via a pre-aggregated left-joined subquery
- Folder detail (`folder.service.ts`): per-link totals use the same combined count
- QR code list (`qrcode.service.ts`): `visitCount` includes archived clicks
- Domain statistics (`domains.service.ts`): `totalClicks` includes archived clicks
- Click-based expiration (`src/app/api/link/route.ts` and the expired page): uses the true combined total. This was a functional bug, not just display — a link set to disable after N clicks could effectively re-enable once its old visits were pruned
- Extracted the existing combined-count helper from `milestone-check.ts` into a shared `src/server/lib/total-clicks.ts` and reused it in the redirect path, the expired page, and milestone checks

Range-scoped analytics (per-link analytics ranges, bio-page analytics, admin date-range reports) are intentionally unchanged since they are windowed by design and plan caps align with retention.

## Type of Change

- [x] fix: Bug fix

## Testing

- `bunx tsc --noEmit` passes with no errors in changed files
- Verified the generated SQL for the new dashboard query via drizzle `toSQL()`: the summary subquery aggregates one row per link before joining, so the `LinkVisit` join fan-out cannot skew either count, and `ORDER BY total_clicks` sorts on the combined value
- Biome reports no new issues in changed files (remaining warnings are pre-existing)

## Related Issues

Fixes #317

https://claude.ai/code/session_01XfXFcGWrhrUTdBeA9JXBLY

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Click totals now include both recent activity and archived click data, so counts are more accurate across links, folders, domains, and QR codes.
  * Expired-link handling now uses the improved click totals, making click-based expiration more reliable.
  * Automatic link disabling and milestone notifications continue to trigger correctly using the updated totals.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->