### PR TITLE
Move crons to the Worker, add migration email script

### DIFF
--- a/custom-worker.ts
+++ b/custom-worker.ts
@@ -7,7 +7,7 @@ import { default as handler } from "./.open-next/worker.js";
 const CRON_ROUTES: Record<string, string> = {
   "0 9 * * *": "/api/cron/domain-reminders",
   "0 0 * * *": "/api/cron/cleanup-teams",
-  "0 2 * * 0": "/api/cron/cleanup-analytics",
+  "0 2 * * SUN": "/api/cron/cleanup-analytics",
   "0 4 * * *": "/api/cron/cleanup-expired",
 };
 

--- a/scripts/send-migration-emails.ts
+++ b/scripts/send-migration-emails.ts
@@ -1,0 +1,171 @@
+/**
+ * Emails every owner of a custom domain that has not yet moved to Cloudflare.
+ *
+ * Usage (from repo root, against production env):
+ *   bunx dotenv -e .env.production.local -- bun scripts/send-migration-emails.ts             # dry run
+ *   bunx dotenv -e .env.production.local -- bun scripts/send-migration-emails.ts --preview <to> [--account <email>]
+ *   bunx dotenv -e .env.production.local -- bun scripts/send-migration-emails.ts --send
+ */
+import mysql from "mysql2/promise";
+import { Resend } from "resend";
+
+import DomainMigrationEmail from "../src/emails/domain-migration";
+
+const CNAME_TARGET = process.env.CUSTOM_DOMAIN_CNAME_TARGET ?? "cname.ishortn.ink";
+const DASHBOARD_URL = "https://ishortn.ink/dashboard/domains";
+const FROM = "Kelvin from iShortn <kelvin@ishortn.ink>";
+const SUBJECT = "Action needed: update your custom domain DNS by August 22";
+
+function required(name: string): string {
+  const value = process.env[name];
+  if (!value) throw new Error(`Missing env var ${name}`);
+  return value;
+}
+
+function deadlineText(): string {
+  const raw = process.env.NEXT_PUBLIC_DOMAIN_MIGRATION_DEADLINE;
+  if (raw) {
+    const parsed = new Date(raw);
+    if (!Number.isNaN(parsed.getTime())) {
+      return `on ${parsed.toLocaleDateString("en-US", {
+        month: "long",
+        day: "numeric",
+        year: "numeric",
+        timeZone: "UTC",
+      })}`;
+    }
+  }
+  return "in the coming weeks";
+}
+
+async function fetchMigratedHostnames(): Promise<Set<string>> {
+  const zoneId = required("CLOUDFLARE_SAAS_ZONE_ID");
+  const token = required("CLOUDFLARE_API_TOKEN");
+  const migrated = new Set<string>();
+
+  for (let page = 1; ; page++) {
+    const response = await fetch(
+      `https://api.cloudflare.com/client/v4/zones/${zoneId}/custom_hostnames?per_page=100&page=${page}`,
+      { headers: { Authorization: `Bearer ${token}` } },
+    );
+    const data = (await response.json()) as {
+      success: boolean;
+      result: { hostname: string; status: string; ssl?: { status: string } | null }[];
+    };
+    if (!data.success) throw new Error("Cloudflare custom hostname list failed");
+    for (const h of data.result) {
+      if (h.status === "active" && h.ssl?.status === "active") {
+        migrated.add(h.hostname.toLowerCase());
+      }
+    }
+    if (data.result.length < 100) break;
+  }
+  return migrated;
+}
+
+type OwnerRow = { domain: string; email: string | null; name: string | null };
+
+async function fetchOwners(): Promise<OwnerRow[]> {
+  const conn = await mysql.createConnection(required("DATABASE_URL"));
+  const [rows] = await conn.query(`
+    SELECT cd.domain, u.email, u.name
+    FROM CustomDomain cd
+    LEFT JOIN User u ON u.id = cd.userId
+    WHERE cd.domain IS NOT NULL
+  `);
+  await conn.end();
+  return rows as OwnerRow[];
+}
+
+type Recipient = { email: string; name: string | null; domains: string[] };
+
+function groupRecipients(rows: OwnerRow[], migrated: Set<string>): Recipient[] {
+  const byEmail = new Map<string, Recipient>();
+  for (const row of rows) {
+    if (!row.email) {
+      console.warn(`skipping ${row.domain}: owner has no email`);
+      continue;
+    }
+    const domain = row.domain.toLowerCase();
+    if (migrated.has(domain)) continue;
+    const entry = byEmail.get(row.email) ?? { email: row.email, name: row.name, domains: [] };
+    if (!entry.domains.includes(domain)) entry.domains.push(domain);
+    byEmail.set(row.email, entry);
+  }
+  return [...byEmail.values()]
+    .filter((r) => r.domains.length > 0)
+    .sort((a, b) => a.email.localeCompare(b.email));
+}
+
+function buildEmail(recipient: Recipient) {
+  return DomainMigrationEmail({
+    recipientName: recipient.name?.split(" ")[0] ?? null,
+    domains: recipient.domains
+      .sort()
+      .map((domain) => ({ domain, isApex: domain.split(".").length === 2 })),
+    cnameTarget: CNAME_TARGET,
+    deadlineText: deadlineText(),
+    dashboardUrl: DASHBOARD_URL,
+  });
+}
+
+const args = process.argv.slice(2);
+const previewIndex = args.indexOf("--preview");
+const accountIndex = args.indexOf("--account");
+const send = args.includes("--send");
+
+const rows = await fetchOwners();
+const migrated = await fetchMigratedHostnames();
+const recipients = groupRecipients(rows, migrated);
+
+if (previewIndex !== -1) {
+  const to = args[previewIndex + 1];
+  if (!to) throw new Error("--preview needs a recipient address");
+  const account = accountIndex !== -1 ? args[accountIndex + 1] : "kelvinamoaba@gmail.com";
+  // Preview ignores migration status so an already-migrated account still renders.
+  const accountRows = rows.filter((r) => r.email === account);
+  if (accountRows.length === 0) throw new Error(`no domains found for account ${account}`);
+  const recipient: Recipient = {
+    email: to,
+    name: accountRows[0]?.name ?? null,
+    domains: [...new Set(accountRows.map((r) => r.domain.toLowerCase()))],
+  };
+  const resend = new Resend(required("RESEND_API_KEY"));
+  const result = await resend.emails.send({
+    from: FROM,
+    to,
+    subject: `[PREVIEW] ${SUBJECT}`,
+    react: buildEmail(recipient),
+  });
+  if (result.error) throw new Error(`Resend error: ${result.error.message}`);
+  console.log(`preview sent to ${to} (id ${result.data?.id}) using ${account}'s domains:`);
+  console.log(recipient.domains.join(", "));
+} else if (send) {
+  const resend = new Resend(required("RESEND_API_KEY"));
+  let sent = 0;
+  const failed: string[] = [];
+  for (const recipient of recipients) {
+    const result = await resend.emails.send({
+      from: FROM,
+      to: recipient.email,
+      subject: SUBJECT,
+      react: buildEmail(recipient),
+    });
+    if (result.error) {
+      failed.push(`${recipient.email}: ${result.error.message}`);
+    } else {
+      sent++;
+      console.log(`sent to ${recipient.email} (${recipient.domains.length} domains)`);
+    }
+    // Resend allows 2 requests/second.
+    await new Promise((resolve) => setTimeout(resolve, 600));
+  }
+  console.log(`\ndone: ${sent} sent, ${failed.length} failed`);
+  for (const f of failed) console.error(f);
+} else {
+  console.log(`dry run — ${recipients.length} recipients, no emails sent:\n`);
+  for (const r of recipients) {
+    console.log(`${r.email}\n  ${r.domains.sort().join("\n  ")}`);
+  }
+  console.log("\nrun with --send to deliver, or --preview <to> to send yourself a sample");
+}

--- a/src/emails/domain-migration.tsx
+++ b/src/emails/domain-migration.tsx
@@ -1,0 +1,226 @@
+import {
+  Body,
+  Button,
+  Container,
+  Head,
+  Html,
+  Preview,
+  Section,
+  Text,
+} from "@react-email/components";
+
+type MigrationDomain = {
+  domain: string;
+  isApex: boolean;
+};
+
+type DomainMigrationEmailProps = {
+  recipientName?: string | null;
+  domains: MigrationDomain[];
+  cnameTarget: string;
+  deadlineText: string;
+  dashboardUrl: string;
+};
+
+export const DomainMigrationEmail = ({
+  recipientName,
+  domains,
+  cnameTarget,
+  deadlineText,
+  dashboardUrl,
+}: DomainMigrationEmailProps) => {
+  const hasApex = domains.some((d) => d.isApex);
+  const plural = domains.length > 1;
+
+  return (
+    <Html>
+      <Head />
+      <Preview>One DNS change keeps your custom domains working on iShortn</Preview>
+      <Body style={main}>
+        <Container style={container}>
+          <Section style={section}>
+            <Text style={text}>Hi {recipientName || "there"},</Text>
+
+            <Text style={text}>
+              We are moving iShortn to a faster, more reliable network. To bring your custom{" "}
+              {plural ? "domains" : "domain"} along, update one DNS record per domain at your
+              provider: point it at <code style={codeStyle}>{cnameTarget}</code>.
+            </Text>
+
+            <Section style={tableContainer}>
+              <table style={table}>
+                <thead>
+                  <tr>
+                    <th style={tableHeader}>Your domain</th>
+                    <th style={tableHeader}>Record</th>
+                    <th style={tableHeader}>Point it to</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {domains.map((entry) => (
+                    <tr key={entry.domain}>
+                      <td style={tableCell}>
+                        <code style={codeStyle}>{entry.domain}</code>
+                      </td>
+                      <td style={tableCell}>CNAME</td>
+                      <td style={tableCellValue}>
+                        <code style={codeStyle}>{cnameTarget}</code>
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </Section>
+
+            <Text style={smallText}>
+              Your domain already has a record pointing at our old network — edit that record and
+              change its value to <code style={codeStyle}>{cnameTarget}</code>. Your DNS provider
+              may show the record name as just the subdomain part.
+            </Text>
+
+            {hasApex && (
+              <Text style={smallText}>
+                For a root domain, your DNS provider must support ALIAS, ANAME, or flattened CNAME
+                records (Cloudflare, Namecheap, Porkbun, and Route 53 all do). Create the record
+                above as an ALIAS or ANAME pointing to the same value.
+              </Text>
+            )}
+
+            <Section style={warningBox}>
+              <Text style={warningText}>
+                Your links keep working as normal until we complete the move {deadlineText}. After
+                that, short links, QR codes, and bio pages on the {plural ? "domains" : "domain"}{" "}
+                above will stop working until the records are updated.
+              </Text>
+            </Section>
+
+            <Section style={buttonContainer}>
+              <Button style={button} href={dashboardUrl}>
+                Verify in your dashboard
+              </Button>
+            </Section>
+
+            <Text style={smallText}>
+              After you make the change, open your dashboard and use &quot;Verify
+              configuration&quot; to confirm it worked. DNS changes can take up to 48 hours to
+              propagate.
+            </Text>
+
+            <Text style={text}>
+              If you need help, reply to this email and we&apos;ll walk you through it.
+            </Text>
+
+            <Text style={text}>Thanks for using iShortn!</Text>
+            <Text style={{ ...text, fontWeight: 500 }}>Kelvin &amp; the iShortn team</Text>
+          </Section>
+        </Container>
+      </Body>
+    </Html>
+  );
+};
+
+const main = {
+  backgroundColor: "#ffffff",
+  fontFamily:
+    '-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen-Sans,Ubuntu,Cantarell,"Helvetica Neue",sans-serif',
+};
+
+const container = {
+  margin: "0 auto",
+  padding: "20px 0 48px",
+  maxWidth: "560px",
+};
+
+const section = {
+  padding: "24px",
+};
+
+const text = {
+  color: "#333",
+  fontSize: "16px",
+  lineHeight: "24px",
+};
+
+const smallText = {
+  color: "#666",
+  fontSize: "14px",
+  lineHeight: "20px",
+  marginTop: "16px",
+};
+
+const warningBox = {
+  backgroundColor: "#fffbeb",
+  border: "1px solid #fde68a",
+  borderRadius: "8px",
+  padding: "4px 16px",
+  marginTop: "16px",
+};
+
+const warningText = {
+  color: "#b45309",
+  fontSize: "14px",
+  lineHeight: "20px",
+};
+
+const buttonContainer = {
+  textAlign: "center" as const,
+  marginTop: "24px",
+  marginBottom: "24px",
+};
+
+const button = {
+  backgroundColor: "#111827",
+  borderRadius: "6px",
+  color: "#fff",
+  fontSize: "16px",
+  fontWeight: 500,
+  textDecoration: "none",
+  textAlign: "center" as const,
+  display: "inline-block",
+  padding: "12px 24px",
+};
+
+const tableContainer = {
+  marginTop: "16px",
+  marginBottom: "16px",
+};
+
+const table = {
+  width: "100%",
+  borderCollapse: "collapse" as const,
+  border: "1px solid #e5e7eb",
+  borderRadius: "8px",
+};
+
+const tableHeader = {
+  backgroundColor: "#f9fafb",
+  padding: "10px 12px",
+  textAlign: "left" as const,
+  fontSize: "12px",
+  fontWeight: 600,
+  color: "#6b7280",
+  borderBottom: "1px solid #e5e7eb",
+};
+
+const tableCell = {
+  padding: "10px 12px",
+  fontSize: "14px",
+  color: "#333",
+  borderBottom: "1px solid #e5e7eb",
+};
+
+const tableCellValue = {
+  ...tableCell,
+  maxWidth: "200px",
+  wordBreak: "break-all" as const,
+};
+
+const codeStyle = {
+  backgroundColor: "#f3f4f6",
+  padding: "2px 6px",
+  borderRadius: "4px",
+  fontSize: "13px",
+  fontFamily: "monospace",
+};
+
+export default DomainMigrationEmail;

--- a/vercel.json
+++ b/vercel.json
@@ -3,23 +3,5 @@
     "app/api/**/*": {
       "maxDuration": 60
     }
-  },
-  "crons": [
-    {
-      "path": "/api/cron/domain-reminders",
-      "schedule": "0 9 * * *"
-    },
-    {
-      "path": "/api/cron/cleanup-teams",
-      "schedule": "0 0 * * *"
-    },
-    {
-      "path": "/api/cron/cleanup-analytics",
-      "schedule": "0 2 * * 0"
-    },
-    {
-      "path": "/api/cron/cleanup-expired",
-      "schedule": "0 4 * * *"
-    }
-  ]
+  }
 }

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -30,11 +30,9 @@
       "id": "ac816bc62707444ab259acdc494f14dc"
     }
   ],
-  // Enable at cutover: while Vercel's crons still run, these would double-execute
-  // the cleanup/reminder jobs against the same database.
-  // "triggers": {
-  //   "crons": ["0 9 * * *", "0 0 * * *", "0 2 * * 0", "0 4 * * *"]
-  // },
+  "triggers": {
+    "crons": ["0 9 * * *", "0 0 * * *", "0 2 * * SUN", "0 4 * * *"]
+  },
   "observability": {
     "enabled": true
   }


### PR DESCRIPTION
Crons now run on the Cloudflare Worker (enabled in wrangler.jsonc, removed from vercel.json). Cloudflare rejects `0` as Sunday, so the weekly job uses `SUN`.

Adds the customer DNS-migration email template and a send script (dry-run by default, `--preview`/`--send` flags).

https://claude.ai/code/session_019hc8t843NiXDDir1bMixLo

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added personalized email notifications to guide custom-domain DNS migrations.
  * Emails include domain-specific CNAME instructions, apex-domain guidance, deadlines, dashboard verification links, and support information.
  * Added tools to preview, simulate, and send migration notifications while reporting delivery results.

* **Bug Fixes**
  * Updated scheduled analytics cleanup to run correctly on Sundays.

* **Chores**
  * Enabled automated schedules for recurring background tasks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->