### PR TITLE
Don't block link creation when the metadata service is down

### DIFF
--- a/src/lib/utils/fetch-link-metadata.ts
+++ b/src/lib/utils/fetch-link-metadata.ts
@@ -1,6 +1,10 @@
 export async function fetchMetadataInfo(url: string) {
   const response = await fetch(`https://meta.kelvinamoaba.com/metadata?url=${url}`);
 
+  if (!response.ok) {
+    throw new Error(`metadata service responded ${response.status}`);
+  }
+
   const data = (await response.json()) as {
     title: string;
     description: string;

--- a/src/server/api/routers/link/link.service.ts
+++ b/src/server/api/routers/link/link.service.ts
@@ -382,7 +382,8 @@ export const createLink = async (
 
   await assertUrlSafe(input.url);
 
-  const fetchedMetadata = await fetchMetadataInfo(input.url);
+  // Best-effort: a metadata-service outage must not block link creation.
+  const fetchedMetadata = await fetchMetadataInfo(input.url).catch(() => null);
 
   if (input.alias) {
     await validateAlias(ctx, input.alias, domain, isPaidPlan);
@@ -458,12 +459,12 @@ export const createLink = async (
   }
 
   input.metadata = {
-    title: inputMetaData?.title ?? fetchedMetadata.title,
-    description: inputMetaData?.description ?? fetchedMetadata.description,
-    image: inputMetaData?.image ?? fetchedMetadata.image,
+    title: inputMetaData?.title ?? fetchedMetadata?.title,
+    description: inputMetaData?.description ?? fetchedMetadata?.description,
+    image: inputMetaData?.image ?? fetchedMetadata?.image,
   };
 
-  const name = input.name ?? fetchedMetadata.title ?? "Untitled Link";
+  const name = input.name ?? fetchedMetadata?.title ?? "Untitled Link";
   const tagNames = input.tags ?? [];
 
   // Create link without tags field
@@ -1070,8 +1071,8 @@ export const shortenLinkWithAutoAlias = async (
 
   await assertUrlSafe(input.url);
 
-  const fetchedMetadata = await fetchMetadataInfo(input.url);
-  const name = fetchedMetadata.title ?? "Untitled Link";
+  const fetchedMetadata = await fetchMetadataInfo(input.url).catch(() => null);
+  const name = fetchedMetadata?.title ?? "Untitled Link";
   const tagNames = input.tags ?? [];
   const ownership = workspaceOwnership(ctx.workspace);
 
@@ -1085,9 +1086,9 @@ export const shortenLinkWithAutoAlias = async (
     createdByUserId: ctx.auth.userId, // Track the actual user who created the link
     name,
     metadata: {
-      title: fetchedMetadata.title,
-      description: fetchedMetadata.description,
-      image: fetchedMetadata.image,
+      title: fetchedMetadata?.title,
+      description: fetchedMetadata?.description,
+      image: fetchedMetadata?.image,
     },
   });
 


### PR DESCRIPTION
meta.kelvinamoaba.com went NXDOMAIN after this morning's nameserver move, and the unguarded fetch made every dashboard link creation fail (JSON-parsing Cloudflare's 1016 error page). Metadata is now best-effort: creation proceeds with empty metadata when the service is unreachable, and the fetcher throws a clean error on non-200s.

https://claude.ai/code/session_019hc8t843NiXDDir1bMixLo