### PR TITLE
Scrape link metadata in-app

### DIFF
--- a/src/app/(main)/cloaked/[url]/page.tsx
+++ b/src/app/(main)/cloaked/[url]/page.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from "next";
 
 import { logger } from "@/lib/logger";
-import { fetchMetadataInfo } from "@/lib/utils/fetch-link-metadata";
+import { scrapeMetadata } from "@/server/lib/metadata";
 import { buildBeaconScript } from "@/lib/utils/verified-click-token";
 
 export const fetchCache = "force-no-store";
@@ -44,7 +44,7 @@ export async function generateMetadata(props: CloakedPageProps): Promise<Metadat
   const url = decodeURIComponent(params.url);
 
   try {
-    const metatags = await fetchMetadataInfo(url);
+    const metatags = await scrapeMetadata(url);
     const apexDomain = getApexDomain(url);
 
     return {

--- a/src/app/api/metadata/route.ts
+++ b/src/app/api/metadata/route.ts
@@ -1,0 +1,16 @@
+import { NextResponse } from "next/server";
+
+import { scrapeMetadata } from "@/server/lib/metadata";
+
+export async function GET(request: Request) {
+  const url = new URL(request.url).searchParams.get("url");
+  if (!url) {
+    return NextResponse.json({ error: "url query parameter is required" }, { status: 400 });
+  }
+
+  try {
+    return NextResponse.json(await scrapeMetadata(url));
+  } catch {
+    return NextResponse.json({ error: "could not fetch metadata" }, { status: 422 });
+  }
+}

--- a/src/lib/utils/fetch-link-metadata.ts
+++ b/src/lib/utils/fetch-link-metadata.ts
@@ -1,8 +1,10 @@
+// Client-side helper; server code should call scrapeMetadata from
+// @/server/lib/metadata directly instead of going through HTTP.
 export async function fetchMetadataInfo(url: string) {
-  const response = await fetch(`https://meta.kelvinamoaba.com/metadata?url=${url}`);
+  const response = await fetch(`/api/metadata?url=${encodeURIComponent(url)}`);
 
   if (!response.ok) {
-    throw new Error(`metadata service responded ${response.status}`);
+    throw new Error(`metadata endpoint responded ${response.status}`);
   }
 
   const data = (await response.json()) as {

--- a/src/server/api/routers/link/link.service.ts
+++ b/src/server/api/routers/link/link.service.ts
@@ -41,7 +41,7 @@ import {
 } from "@/lib/core/cache";
 import { generateShortLink } from "@/lib/core/links";
 import { runBackgroundTask } from "@/lib/utils/background";
-import { fetchMetadataInfo } from "@/lib/utils/fetch-link-metadata";
+import { scrapeMetadata } from "@/server/lib/metadata";
 import { db } from "@/server/db";
 import {
   campaign,
@@ -383,7 +383,7 @@ export const createLink = async (
   await assertUrlSafe(input.url);
 
   // Best-effort: a metadata-service outage must not block link creation.
-  const fetchedMetadata = await fetchMetadataInfo(input.url).catch(() => null);
+  const fetchedMetadata = await scrapeMetadata(input.url).catch(() => null);
 
   if (input.alias) {
     await validateAlias(ctx, input.alias, domain, isPaidPlan);
@@ -1071,7 +1071,7 @@ export const shortenLinkWithAutoAlias = async (
 
   await assertUrlSafe(input.url);
 
-  const fetchedMetadata = await fetchMetadataInfo(input.url).catch(() => null);
+  const fetchedMetadata = await scrapeMetadata(input.url).catch(() => null);
   const name = fetchedMetadata?.title ?? "Untitled Link";
   const tagNames = input.tags ?? [];
   const ownership = workspaceOwnership(ctx.workspace);

--- a/src/server/lib/metadata.ts
+++ b/src/server/lib/metadata.ts
@@ -1,0 +1,101 @@
+export type ScrapedMetadata = {
+  title: string;
+  description: string;
+  image: string;
+  favicon: string;
+};
+
+const FETCH_TIMEOUT_MS = 8_000;
+// YouTube buries its OG tags past the first ~600KB of inline script.
+const MAX_HTML_BYTES = 2_000_000;
+
+const BLOCKED_HOSTS = /^(localhost|127\.|10\.|192\.168\.|169\.254\.|0\.|\[?::1)/i;
+
+function attr(tag: string, name: string): string | null {
+  const match = tag.match(new RegExp(`${name}\\s*=\\s*("([^"]*)"|'([^']*)')`, "i"));
+  return match ? (match[2] ?? match[3] ?? null) : null;
+}
+
+function findMeta(html: string, keys: string[]): string | null {
+  for (const tag of html.match(/<meta\s[^>]*>/gi) ?? []) {
+    const key = attr(tag, "property") ?? attr(tag, "name");
+    if (key && keys.includes(key.toLowerCase())) {
+      const content = attr(tag, "content");
+      if (content) return content;
+    }
+  }
+  return null;
+}
+
+function absolutize(href: string | null, base: string): string {
+  if (!href) return "";
+  try {
+    return new URL(href, base).toString();
+  } catch {
+    return "";
+  }
+}
+
+function decodeEntities(text: string): string {
+  return text
+    .replace(/&amp;/g, "&")
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&quot;/g, '"')
+    .replace(/&#0?39;|&apos;/g, "'");
+}
+
+export async function scrapeMetadata(url: string): Promise<ScrapedMetadata> {
+  const target = new URL(url);
+  if (target.protocol !== "http:" && target.protocol !== "https:") {
+    throw new Error("only http(s) URLs are supported");
+  }
+  if (BLOCKED_HOSTS.test(target.hostname)) {
+    throw new Error("host not allowed");
+  }
+
+  const response = await fetch(target, {
+    headers: {
+      // Sites gate their OG tags on link-preview crawlers; a plain browser UA
+      // gets a consent wall or JS shell from e.g. YouTube, while Wikipedia
+      // blocks "facebookexternalhit". The Twitterbot token passes both.
+      "User-Agent": "Mozilla/5.0 (compatible; iShortn/1.0; +https://ishortn.ink) Twitterbot/1.0",
+      Accept: "text/html,application/xhtml+xml",
+    },
+    redirect: "follow",
+    signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+  });
+
+  const base = response.url || target.toString();
+  const fallbackFavicon = absolutize("/favicon.ico", base);
+
+  if (!(response.headers.get("content-type") ?? "").includes("html")) {
+    return { title: "", description: "", image: "", favicon: fallbackFavicon };
+  }
+
+  const html = (await response.text()).slice(0, MAX_HTML_BYTES);
+
+  const title =
+    findMeta(html, ["og:title", "twitter:title"]) ??
+    html.match(/<title[^>]*>([^<]*)<\/title>/i)?.[1]?.trim() ??
+    "";
+  const description =
+    findMeta(html, ["og:description", "twitter:description", "description"]) ?? "";
+  const image = findMeta(html, ["og:image", "twitter:image"]);
+
+  let favicon: string | null = null;
+  for (const tag of html.match(/<link\s[^>]*>/gi) ?? []) {
+    const rel = attr(tag, "rel")?.toLowerCase() ?? "";
+    if (rel === "icon" || rel === "shortcut icon" || rel === "apple-touch-icon") {
+      favicon = attr(tag, "href");
+      if (rel !== "apple-touch-icon") break;
+    }
+  }
+
+  return {
+    title: decodeEntities(title),
+    description: decodeEntities(description),
+    image: absolutize(image, base),
+    favicon: absolutize(favicon, base) || fallbackFavicon,
+  };
+}

--- a/src/server/lib/phishing/index.ts
+++ b/src/server/lib/phishing/index.ts
@@ -2,7 +2,7 @@ import { TRPCError } from "@trpc/server";
 
 import { logger } from "@/lib/logger";
 import { detectPhishingLink } from "@/server/api/routers/ai/ai.service";
-import { fetchMetadataInfo } from "@/lib/utils/fetch-link-metadata";
+import { scrapeMetadata } from "@/server/lib/metadata";
 
 import { checkBlocklist } from "./blocklist";
 import { checkGoogleSafeBrowsing } from "./google-safe-browsing";
@@ -118,7 +118,7 @@ export async function assertUrlSafe(url: string): Promise<void> {
   // metadata service or the LLM provider must not block link creation.
   let phishingResult: { url: string; phishing: boolean };
   try {
-    const fetchedMetadata = await fetchMetadataInfo(url);
+    const fetchedMetadata = await scrapeMetadata(url);
     phishingResult = await detectPhishingLink(url, fetchedMetadata);
   } catch (error) {
     log.warn({ err: error, url }, "LLM phishing check failed, allowing link");


### PR DESCRIPTION
Replaces the external meta.kelvinamoaba.com service (lost in this morning's DNS move) with an in-app scraper: server code calls scrapeMetadata directly, the browser uses a new /api/metadata route. OG-tag parsing with no new dependencies; crawler UA so sites like YouTube serve their tags.

https://claude.ai/code/session_019hc8t843NiXDDir1bMixLo

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added metadata retrieval for HTTP and HTTPS links, including titles, descriptions, images, and favicons.
  * Added a metadata API endpoint with clear responses for missing or invalid URLs.
  * Improved metadata support across cloaked pages, link creation, aliases, and phishing checks.

* **Bug Fixes**
  * Added protections against unsafe URLs and private hosts.
  * Improved handling of non-HTML pages, relative links, and metadata retrieval failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->