### PR TITLE
Restore click recording in the link resolution path

### DIFF
--- a/src/app/(main)/[linkAlias]/page.tsx
+++ b/src/app/(main)/[linkAlias]/page.tsx
@@ -3,8 +3,12 @@ import { notFound, redirect } from "next/navigation";
 
 import { socialMediaAgents } from "@/lib/constants/app";
 import { DEFAULT_PLATFORM_DOMAIN } from "@/lib/constants/domains";
+import { getClientIp, getRequestGeo } from "@/lib/platform";
+import { resolveShortLink } from "@/middlewares/resolve-link";
 import { api } from "@/trpc/server";
 
+import CloakedPage from "../cloaked/[url]/page";
+import VerifiedRedirectPage from "../verified-redirect/[alias]/page";
 import { LinkPasswordVerification } from "./link-password-verification";
 import LinkPreview from "./link-preview";
 
@@ -87,46 +91,92 @@ const LinkRedirectionPage = async (props: LinkRedirectionPageProps) => {
   const headersList = await headers();
   const incomingDomain = headersList.get("x-forwarded-host") ?? headersList.get("host");
   const userAgent = headersList.get("user-agent");
-  const domain = getDomain(incomingDomain);
+  const domain = cleanUrl(getDomain(incomingDomain));
+  const alias = cleanAlias(params.linkAlias);
 
   if (params.linkAlias.toLowerCase().endsWith(".png")) {
     return notFound();
   }
 
-  const link = await api.link.retrieveOriginalUrl.query({
-    alias: cleanAlias(params.linkAlias),
-    domain: cleanUrl(domain),
-    from: "redirection",
-  });
+  // OG scrapers and "!"-preview links need the link rendered, not followed —
+  // neither counts as a click.
+  if (isSocialMediaAgent(userAgent) || params.linkAlias.endsWith("!")) {
+    const link = await api.link.retrieveOriginalUrl.query({
+      alias,
+      domain,
+      from: "redirection",
+    });
 
-  if (!link) return notFound();
-
-  // Blocked links must never resolve, preview, or redirect.
-  if (link.blocked) {
-    redirect(`/blocked/${link.id}`);
-  }
-
-  // Check link expiration (disabled flag and date-based)
-  if (link.disabled) {
-    redirect(`/expired/${link.id}`);
-  }
-  if (link.disableLinkAfterDate && new Date() >= link.disableLinkAfterDate) {
-    redirect(`/expired/${link.id}`);
-  }
-
-  if (link.passwordHash) {
-    return <LinkPasswordVerification id={link.id} />;
-  }
-
-  if (isSocialMediaAgent(userAgent)) {
-    return <div>Redirecting...</div>;
-  }
-
-  if (params.linkAlias.endsWith("!")) {
+    if (!link) return notFound();
+    if (link.blocked) {
+      redirect(`/blocked/${link.id}`);
+    }
+    if (link.disabled) {
+      redirect(`/expired/${link.id}`);
+    }
+    if (link.disableLinkAfterDate && new Date() >= link.disableLinkAfterDate) {
+      redirect(`/expired/${link.id}`);
+    }
+    if (link.passwordHash) {
+      return <LinkPasswordVerification id={link.id} />;
+    }
+    if (isSocialMediaAgent(userAgent)) {
+      return <div>Redirecting...</div>;
+    }
     return <LinkPreview link={link} />;
   }
 
-  redirect(link.url!);
+  // Full resolution: geo rules, expiration, click recording, verified-click
+  // tokens — the pipeline the pre-OpenNext middleware used to run.
+  const geo = getRequestGeo(headersList);
+  const resolution = await resolveShortLink({
+    domain,
+    alias,
+    country: geo.country ?? "Unknown",
+    city: geo.city ?? "Unknown",
+    ip: getClientIp(headersList) ?? "",
+    headers: headersList,
+    baseUrl: "",
+  });
+
+  if (!resolution?.url) {
+    return notFound();
+  }
+
+  // Blocked/expired/password resolutions come back as relative app routes.
+  if (!resolution.url.startsWith("/")) {
+    try {
+      const parsed = new URL(resolution.url);
+      if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+        return notFound();
+      }
+    } catch {
+      return notFound();
+    }
+  }
+
+  // The interstitial routes still exist for direct hits; rendering their page
+  // components inline keeps the short-link URL in the address bar, which a
+  // page (unlike middleware) cannot do via rewrite.
+  if (resolution.cloaking) {
+    return (
+      <CloakedPage
+        params={Promise.resolve({ url: encodeURIComponent(resolution.url) })}
+        searchParams={Promise.resolve({ t: resolution.verificationToken ?? undefined })}
+      />
+    );
+  }
+
+  if (resolution.verificationToken) {
+    return (
+      <VerifiedRedirectPage
+        params={Promise.resolve({ alias })}
+        searchParams={Promise.resolve({ to: resolution.url, t: resolution.verificationToken })}
+      />
+    );
+  }
+
+  redirect(resolution.url);
 };
 
 export default LinkRedirectionPage;

--- a/src/app/api/bio/view/route.ts
+++ b/src/app/api/bio/view/route.ts
@@ -1,5 +1,5 @@
 import { and, eq } from "drizzle-orm";
-import { type NextRequest } from "next/server";
+import type { NextRequest } from "next/server";
 
 import { setStringIfAbsent } from "@/lib/core/cache";
 import { getClientIp, getRequestGeo } from "@/lib/platform";
@@ -31,7 +31,7 @@ export async function POST(request: NextRequest) {
   });
   if (!page) return new Response(null, { status: 204 });
 
-  const ip = getClientIp(request);
+  const ip = getClientIp(request.headers);
 
   // Rate-limit: record at most one view per IP per page per minute, so this
   // unauthenticated endpoint can't be spammed to inflate views or drain the
@@ -41,7 +41,7 @@ export async function POST(request: NextRequest) {
     if (!fresh) return new Response(null, { status: 204 });
   }
 
-  const geo = getRequestGeo(request);
+  const geo = getRequestGeo(request.headers);
 
   void runBackgroundTask(
     recordBioPageView({

--- a/src/app/api/geo/route.ts
+++ b/src/app/api/geo/route.ts
@@ -1,7 +1,7 @@
 import { getClientIp, getRequestGeo } from "@/lib/platform";
 
 export function GET(request: Request) {
-  const details = getRequestGeo(request);
-  const ip = getClientIp(request);
+  const details = getRequestGeo(request.headers);
+  const ip = getClientIp(request.headers);
   return Response.json({ ...details, ip });
 }

--- a/src/lib/platform.ts
+++ b/src/lib/platform.ts
@@ -4,25 +4,25 @@ import { waitUntil } from "@vercel/functions";
 // getCloudflareContext() throws when not running on Cloudflare, so each helper
 // tries it first and falls back to the Vercel equivalent.
 
-export function getRequestGeo(request: Request): { country?: string; city?: string } {
+export function getRequestGeo(headers: Headers): { country?: string; city?: string } {
   try {
     const { cf } = getCloudflareContext();
     if (cf) return { country: cf.country, city: cf.city };
   } catch {
     // not on Cloudflare; fall through to the Vercel headers
   }
-  const city = request.headers.get("x-vercel-ip-city");
+  const city = headers.get("x-vercel-ip-city");
   return {
-    country: request.headers.get("x-vercel-ip-country") ?? undefined,
+    country: headers.get("x-vercel-ip-country") ?? undefined,
     city: city ? decodeURIComponent(city) : undefined,
   };
 }
 
-export function getClientIp(request: Request): string | undefined {
+export function getClientIp(headers: Headers): string | undefined {
   return (
-    request.headers.get("cf-connecting-ip") ??
-    request.headers.get("x-real-ip") ??
-    request.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ??
+    headers.get("cf-connecting-ip") ??
+    headers.get("x-real-ip") ??
+    headers.get("x-forwarded-for")?.split(",")[0]?.trim() ??
     undefined
   );
 }


### PR DESCRIPTION
PR #327 deleted proxy.ts believing it was dead, but it was the live middleware doing click recording, geo rules, verified-click tokens, and cloaking. All of that silently stopped at cutover — dashboards showed zero visits.

The [linkAlias] page now runs the same resolveShortLink pipeline the middleware ran: clicks are recorded again (with event-usage limits and milestones), geo rules route/block, and cloaked/verified-click links render their interstitials inline since a page cannot rewrite. Platform geo/IP helpers take Headers so a server component can call them.

Verified locally against the production database: redirect works and a LinkVisit row lands per click.

https://claude.ai/code/session_019hc8t843NiXDDir1bMixLo