### PR TITLE
Accept www custom hostname as apex migration fallback

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -33,7 +33,10 @@ export default clerkMiddleware(async (auth, req) => {
     !isPlatformDomain(bareHost) &&
     extractPlatformSubdomain(bareHost) === null
   ) {
-    return NextResponse.rewrite(new URL(`/p-host/${encodeURIComponent(bareHost)}`, req.url));
+    // www serves the bare domain's bio page, matching link resolution's
+    // www-stripping (apex customers on www-CNAME setups depend on this).
+    const bioHost = bareHost.replace(/^www\./, "");
+    return NextResponse.rewrite(new URL(`/p-host/${encodeURIComponent(bioHost)}`, req.url));
   }
 });
 

--- a/src/server/api/routers/domains/cloudflare.ts
+++ b/src/server/api/routers/domains/cloudflare.ts
@@ -51,10 +51,7 @@ async function cloudflareFetch(url: string, init: RequestInit) {
   try {
     return await fetch(url, { ...init, signal: AbortSignal.timeout(CLOUDFLARE_API_TIMEOUT_MS) });
   } catch (error) {
-    if (
-      error instanceof Error &&
-      (error.name === "TimeoutError" || error.name === "AbortError")
-    ) {
+    if (error instanceof Error && (error.name === "TimeoutError" || error.name === "AbortError")) {
       throw new Error("The domain service took too long to respond. Please try again.");
     }
     throw error;
@@ -132,6 +129,19 @@ export async function deleteCustomHostname(domain: string) {
 
 export function mapStatus(hostname: CloudflareCustomHostname): "active" | "pending" {
   return hostname.status === "active" && hostname.ssl?.status === "active" ? "active" : "pending";
+}
+
+// An apex customer whose DNS host cannot ALIAS at the root serves through a
+// www custom hostname plus an apex redirect instead; an active www hostname
+// counts as the apex being migrated.
+export async function wwwFallbackActive(domain: string): Promise<boolean> {
+  if (domain.split(".").length !== 2) return false;
+  try {
+    const hostname = await getCustomHostname(`www.${domain}`);
+    return hostname !== null && mapStatus(hostname) === "active";
+  } catch {
+    return false;
+  }
 }
 
 export function buildVerificationChallenges(

--- a/src/server/api/routers/domains/domains.procedure.ts
+++ b/src/server/api/routers/domains/domains.procedure.ts
@@ -7,7 +7,12 @@ import { createTRPCRouter, workspaceProcedure } from "@/server/api/trpc";
 import { customDomain } from "@/server/db/schema";
 import { workspaceFilter } from "@/server/lib/workspace";
 
-import { buildVerificationChallenges, getCustomHostname, mapStatus } from "./cloudflare";
+import {
+  buildVerificationChallenges,
+  getCustomHostname,
+  mapStatus,
+  wwwFallbackActive,
+} from "./cloudflare";
 import * as input from "./domains.input";
 import * as services from "./domains.service";
 import { isDomainActiveOnVercel } from "./vercel-legacy";
@@ -44,8 +49,8 @@ export const customDomainRouter = createTRPCRouter({
           .then((res) => res[0]?.count ?? 0);
 
         if (domainCount >= (caps.domainLimit ?? 0)) {
-           throw new Error(
-            `You have reached the limit of ${caps.domainLimit} custom domains for your plan. Please upgrade to add more.`
+          throw new Error(
+            `You have reached the limit of ${caps.domainLimit} custom domains for your plan. Please upgrade to add more.`,
           );
         }
       }
@@ -80,7 +85,9 @@ export const customDomainRouter = createTRPCRouter({
 
           try {
             const hostname = await getCustomHostname(domain);
-            const cloudflareActive = hostname !== null && mapStatus(hostname) === "active";
+            const cloudflareActive =
+              (hostname !== null && mapStatus(hostname) === "active") ||
+              (await wwwFallbackActive(domain));
 
             return {
               domain,
@@ -119,7 +126,7 @@ export const customDomainRouter = createTRPCRouter({
         "Cloudflare custom hostname state",
       );
 
-      if (hostname && mapStatus(hostname) === "active") {
+      if ((hostname && mapStatus(hostname) === "active") || (await wwwFallbackActive(domain))) {
         await ctx.db
           .update(customDomain)
           .set({ status: "active" })


### PR DESCRIPTION
Apex customers whose DNS host cannot ALIAS at the root (e.g. cPanel) migrate via a www CNAME plus an apex redirect. Domain status checks now count an active www.<domain> hostname as the apex being migrated, and the bio-page rewrite strips www to match link resolution.

https://claude.ai/code/session_019hc8t843NiXDDir1bMixLo

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Custom-domain routing now supports apex domains that have an active `www` hostname configured.
  - Leading `www.` prefixes are normalized when routing visitors to owner bio pages.

- **Bug Fixes**
  - Domain status and migration checks now correctly recognize active `www` fallback configurations.
  - Existing domain-limit and timeout handling remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->