### PR TITLE
fix: strip ssl-mode from Hyperdrive connection string

### DIFF
--- a/src/server/db/index.ts
+++ b/src/server/db/index.ts
@@ -9,8 +9,13 @@ import * as schema from "./schema";
 type Database = MySql2Database<typeof schema>;
 
 function createDb(uri: string, connectionLimit: number): Database {
+  // Hyperdrive's connection string carries ssl-mode, which mysql2 rejects and
+  // warns about via console.error on every connection; Hyperdrive terminates
+  // TLS itself, so the param does nothing here.
+  const url = new URL(uri);
+  url.searchParams.delete("ssl-mode");
   // disableEval: workerd forbids eval(), which mysql2's parser codegen uses.
-  return drizzle(mysql.createPool({ uri, connectionLimit, disableEval: true }), {
+  return drizzle(mysql.createPool({ uri: url.toString(), connectionLimit, disableEval: true }), {
     schema,
     mode: "default",
   });


### PR DESCRIPTION
mysql2 does not recognize the `ssl-mode` query param in Hyperdrive's connection string and warns through `console.error` on every new connection. Workers observability counts each of those as an error event, which is what has been showing as elevated worker errors on the ishortn Worker since cutover. The requests themselves succeed.

Fix: parse the connection string and drop the `ssl-mode` param before handing it to mysql2. Hyperdrive terminates TLS itself, so the param has no effect there. Reproduced the warning locally against the prod pool and verified the stripped URI connects cleanly with no warning.

https://claude.ai/code/session_01Wa2rV9jjrfmYCV3yScHVjq

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved database connection handling by removing an unsupported SSL parameter before establishing connections.
  * Preserved existing connection limits and security configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->