### PR TITLE
fix(analytics): show rolled-up clicks and stop deleting paid users' visits

### DIFF
--- a/src/app/(main)/dashboard/analytics/[alias]/page.tsx
+++ b/src/app/(main)/dashboard/analytics/[alias]/page.tsx
@@ -1,7 +1,7 @@
 import { IconClick, IconShieldCheck, IconShieldHalf, IconUsers } from "@tabler/icons-react";
 
 import { DEFAULT_PLATFORM_DOMAIN } from "@/lib/constants/domains";
-import { aggregateVisits } from "@/lib/core/analytics";
+import { aggregateVisits, mergeArchivedClicks } from "@/lib/core/analytics";
 import { cn } from "@/lib/utils";
 import { api } from "@/trpc/server";
 
@@ -40,7 +40,7 @@ export default async function LinkAnalyticsPage(
   const range = (searchParams?.range ?? "7d") as RangeEnum;
   const domain = (searchParams?.domain as string) ?? DEFAULT_PLATFORM_DOMAIN;
 
-  const { totalVisits, uniqueVisits, referers, isProPlan, geoRules, previous } =
+  const { totalVisits, uniqueVisits, referers, isProPlan, geoRules, previous, archived } =
     await api.link.linkVisits.query({
       id: params.alias,
       domain,
@@ -48,11 +48,14 @@ export default async function LinkAnalyticsPage(
     });
 
   const aggregatedVisits = aggregateVisits(totalVisits, uniqueVisits);
+  const series = mergeArchivedClicks(aggregatedVisits, archived);
+  const totalClicks = totalVisits.length + archived.clicks;
+  const uniqueClicks = uniqueVisits.length + archived.uniqueClicks;
   const countryData = aggregatedVisits.clicksPerCountry;
   const verifiedVisits = aggregatedVisits.verifiedClicks;
 
-  const totalGrowth = percentGrowth(totalVisits.length, previous?.total);
-  const uniqueGrowth = percentGrowth(uniqueVisits.length, previous?.unique);
+  const totalGrowth = percentGrowth(totalClicks, previous?.total);
+  const uniqueGrowth = percentGrowth(uniqueClicks, previous?.unique);
   const verifiedGrowth = percentGrowth(verifiedVisits, previous?.verified);
   const verifiedRate = totalVisits.length > 0 ? (verifiedVisits / totalVisits.length) * 100 : 0;
 
@@ -89,13 +92,13 @@ export default async function LinkAnalyticsPage(
       >
         <QuickInfoCard
           title="Total Visits"
-          value={totalVisits.length.toLocaleString()}
+          value={totalClicks.toLocaleString()}
           icon={<IconClick size={14} stroke={1.5} />}
           growth={totalGrowth}
         />
         <QuickInfoCard
           title="Unique Visits"
-          value={uniqueVisits.length.toLocaleString()}
+          value={uniqueClicks.toLocaleString()}
           icon={<IconUsers size={14} stroke={1.5} />}
           growth={uniqueGrowth}
         />
@@ -119,8 +122,8 @@ export default async function LinkAnalyticsPage(
 
       <div className="mt-8 md:mt-10">
         <BarChart
-          clicksPerDate={aggregatedVisits.clicksPerDate}
-          uniqueClicksPerDate={aggregatedVisits.uniqueClicksPerDate ?? {}}
+          clicksPerDate={series.clicksPerDate}
+          uniqueClicksPerDate={series.uniqueClicksPerDate}
           className="h-96"
           isProPlan={isProPlan}
           geoRules={geoRules}

--- a/src/app/(main)/dashboard/qrcodes/[id]/page.tsx
+++ b/src/app/(main)/dashboard/qrcodes/[id]/page.tsx
@@ -1,7 +1,7 @@
 import { IconClick, IconTrendingUp, IconUsers, IconWorld } from "@tabler/icons-react";
 
-import { aggregateVisits } from "@/lib/core/analytics";
 import { DEFAULT_PLATFORM_DOMAIN } from "@/lib/constants/domains";
+import { aggregateVisits, mergeArchivedClicks } from "@/lib/core/analytics";
 import { api } from "@/trpc/server";
 
 import UpgradeText from "../_components/upgrade-text";
@@ -47,6 +47,7 @@ export default async function QRCodeAnalyticsPage(props: QRCodeAnalyticsPageProp
     topReferrer,
     isProPlan,
     geoRules,
+    archived,
   } = await api.link.linkVisits.query({
     id: alias,
     domain,
@@ -54,6 +55,7 @@ export default async function QRCodeAnalyticsPage(props: QRCodeAnalyticsPageProp
   });
 
   const aggregatedVisits = aggregateVisits(totalVisits, uniqueVisits);
+  const series = mergeArchivedClicks(aggregatedVisits, archived);
   const countryData = aggregatedVisits.clicksPerCountry;
 
   return (
@@ -100,12 +102,12 @@ export default async function QRCodeAnalyticsPage(props: QRCodeAnalyticsPageProp
       <div className="mt-6 grid grid-cols-1 gap-4 md:mt-8 md:grid-cols-4">
         <QuickInfoCard
           title="Total Scans"
-          value={totalVisits.length}
+          value={totalVisits.length + archived.clicks}
           icon={<IconClick size={16} stroke={1.5} className="text-blue-600" />}
         />
         <QuickInfoCard
           title="Unique Scans"
-          value={uniqueVisits.length}
+          value={uniqueVisits.length + archived.uniqueClicks}
           icon={<IconUsers size={16} stroke={1.5} className="text-blue-600" />}
         />
         <QuickInfoCard
@@ -122,8 +124,8 @@ export default async function QRCodeAnalyticsPage(props: QRCodeAnalyticsPageProp
 
       <div className="mt-8 md:mt-10">
         <BarChart
-          clicksPerDate={aggregatedVisits.clicksPerDate}
-          uniqueClicksPerDate={aggregatedVisits.uniqueClicksPerDate ?? {}}
+          clicksPerDate={series.clicksPerDate}
+          uniqueClicksPerDate={series.uniqueClicksPerDate}
           className="h-96"
           isProPlan={isProPlan}
           geoRules={geoRules}

--- a/src/app/api/v1/analytics/[alias]/route.ts
+++ b/src/app/api/v1/analytics/[alias]/route.ts
@@ -1,4 +1,4 @@
-import { aggregateVisits } from "@/lib/core/analytics";
+import { aggregateVisits, mergeArchivedClicks, summarizeArchived } from "@/lib/core/analytics";
 import { db } from "@/server/db";
 
 import {
@@ -50,7 +50,16 @@ export async function GET(request: NextRequest, props: { params: Promise<{ alias
     return new Response("Unauthorized", { status: 401 });
   }
 
+  const summaries = await db.query.linkVisitDailySummary.findMany({
+    where: (table, { eq }) => eq(table.linkId, link.id),
+  });
+  const archived = summarizeArchived(summaries);
+
   const aggregatedVisits = aggregateVisits(link.linkVisits, link.uniqueLinkVisits);
 
-  return Response.json(aggregatedVisits);
+  return Response.json({
+    ...aggregatedVisits,
+    ...mergeArchivedClicks(aggregatedVisits, archived),
+    totalClicks: aggregatedVisits.totalClicks + archived.clicks,
+  });
 }

--- a/src/lib/core/analytics/index.ts
+++ b/src/lib/core/analytics/index.ts
@@ -179,3 +179,17 @@ export const mergeArchivedClicks = (
     Object.fromEntries(Object.entries(m).sort(([a], [b]) => a.localeCompare(b)));
   return { clicksPerDate: sortByDate(clicksPerDate), uniqueClicksPerDate: sortByDate(uniqueClicksPerDate) };
 };
+
+export const summarizeArchived = (
+  rows: { date: string; clicks: number; uniqueClicks: number }[],
+): ArchivedClicks =>
+  rows.reduce(
+    (acc, s) => {
+      acc.clicks += s.clicks;
+      acc.uniqueClicks += s.uniqueClicks;
+      acc.clicksPerDate[s.date] = (acc.clicksPerDate[s.date] ?? 0) + s.clicks;
+      acc.uniqueClicksPerDate[s.date] = (acc.uniqueClicksPerDate[s.date] ?? 0) + s.uniqueClicks;
+      return acc;
+    },
+    { clicks: 0, uniqueClicks: 0, clicksPerDate: {}, uniqueClicksPerDate: {} } as ArchivedClicks,
+  );

--- a/src/lib/core/analytics/index.ts
+++ b/src/lib/core/analytics/index.ts
@@ -152,3 +152,30 @@ export const aggregateVisits = (
     clicksPerModel,
   };
 };
+
+export type ArchivedClicks = {
+  clicks: number;
+  uniqueClicks: number;
+  clicksPerDate: Record<string, number>;
+  uniqueClicksPerDate: Record<string, number>;
+};
+
+// Raw visits older than the retention window are rolled up into daily
+// summaries by the cleanup job. Only counts survive, so per-date series and
+// totals can include them but country/device/referrer breakdowns cannot.
+export const mergeArchivedClicks = (
+  aggregated: { clicksPerDate: Record<string, number>; uniqueClicksPerDate?: Record<string, number> },
+  archived: ArchivedClicks,
+) => {
+  const clicksPerDate = { ...aggregated.clicksPerDate };
+  const uniqueClicksPerDate = { ...(aggregated.uniqueClicksPerDate ?? {}) };
+  for (const [date, n] of Object.entries(archived.clicksPerDate)) {
+    clicksPerDate[date] = (clicksPerDate[date] ?? 0) + n;
+  }
+  for (const [date, n] of Object.entries(archived.uniqueClicksPerDate)) {
+    uniqueClicksPerDate[date] = (uniqueClicksPerDate[date] ?? 0) + n;
+  }
+  const sortByDate = (m: Record<string, number>) =>
+    Object.fromEntries(Object.entries(m).sort(([a], [b]) => a.localeCompare(b)));
+  return { clicksPerDate: sortByDate(clicksPerDate), uniqueClicksPerDate: sortByDate(uniqueClicksPerDate) };
+};

--- a/src/server/api/routers/analytics/analytics-cleanup.service.ts
+++ b/src/server/api/routers/analytics/analytics-cleanup.service.ts
@@ -32,8 +32,10 @@ interface AnalyticsCleanupResult {
 const QUERY_BATCH_SIZE = 5000;
 const DELETE_BATCH_SIZE = 1000;
 
-// SQL predicate: user has no active paid subscription (free tier)
-const IS_FREE_TIER = sql`(${subscription.id} IS NULL OR ${subscription.status} != 'active' OR ${subscription.plan} = 'free')`;
+// SQL predicate: user has no active subscription (free tier). An active row
+// whose plan is still the migration default 'free' has not been reconciled
+// with the billing provider yet, so it is not treated as free here.
+const IS_FREE_TIER = sql`(${subscription.id} IS NULL OR ${subscription.status} != 'active')`;
 
 /**
  * Clean up old analytics data based on user subscription plan.

--- a/src/server/api/routers/analytics/analytics-cleanup.service.ts
+++ b/src/server/api/routers/analytics/analytics-cleanup.service.ts
@@ -35,7 +35,7 @@ const DELETE_BATCH_SIZE = 1000;
 // SQL predicate: user has no active subscription (free tier). An active row
 // whose plan is still the migration default 'free' has not been reconciled
 // with the billing provider yet, so it is not treated as free here.
-const IS_FREE_TIER = sql`(${subscription.id} IS NULL OR ${subscription.status} != 'active')`;
+const IS_FREE_TIER = sql`(${subscription.id} IS NULL OR ${subscription.status} IS NULL OR ${subscription.status} != 'active')`;
 
 /**
  * Clean up old analytics data based on user subscription plan.

--- a/src/server/api/routers/link/link.service.ts
+++ b/src/server/api/routers/link/link.service.ts
@@ -26,7 +26,7 @@ import {
 } from "@/lib/billing/plans";
 import { assertUrlSafe } from "@/server/lib/phishing";
 import { DEFAULT_PLATFORM_DOMAIN } from "@/lib/constants/domains";
-import { retrieveDeviceAndGeolocationData } from "@/lib/core/analytics";
+import { retrieveDeviceAndGeolocationData, summarizeArchived } from "@/lib/core/analytics";
 import { logger } from "@/lib/logger";
 import { hashIp } from "@/lib/utils/ip-hash";
 import {
@@ -1100,13 +1100,6 @@ export const shortenLinkWithAutoAlias = async (
   };
 };
 
-const EMPTY_ARCHIVED = {
-  clicks: 0,
-  uniqueClicks: 0,
-  clicksPerDate: {} as Record<string, number>,
-  uniqueClicksPerDate: {} as Record<string, number>,
-};
-
 export const getLinkVisits = async (
   ctx: WorkspaceTRPCContext,
   input: { id: string; domain: string; range: string },
@@ -1134,7 +1127,7 @@ export const getLinkVisits = async (
       isProPlan: userHasPaidPlan,
       geoRules: [],
       previous: null,
-      archived: EMPTY_ARCHIVED,
+      archived: summarizeArchived([]),
     };
   }
 
@@ -1268,22 +1261,7 @@ export const getLinkVisits = async (
       : Promise.resolve(null),
   ]);
 
-  const archived = summaries.reduce(
-    (acc, s) => {
-      acc.clicks += s.clicks;
-      acc.uniqueClicks += s.uniqueClicks;
-      acc.clicksPerDate[s.date] = (acc.clicksPerDate[s.date] ?? 0) + s.clicks;
-      acc.uniqueClicksPerDate[s.date] =
-        (acc.uniqueClicksPerDate[s.date] ?? 0) + s.uniqueClicks;
-      return acc;
-    },
-    {
-      clicks: 0,
-      uniqueClicks: 0,
-      clicksPerDate: {} as Record<string, number>,
-      uniqueClicksPerDate: {} as Record<string, number>,
-    },
-  );
+  const archived = summarizeArchived(summaries);
 
   const previous = prevCounts
     ? {

--- a/src/server/api/routers/link/link.service.ts
+++ b/src/server/api/routers/link/link.service.ts
@@ -1100,6 +1100,13 @@ export const shortenLinkWithAutoAlias = async (
   };
 };
 
+const EMPTY_ARCHIVED = {
+  clicks: 0,
+  uniqueClicks: 0,
+  clicksPerDate: {} as Record<string, number>,
+  uniqueClicksPerDate: {} as Record<string, number>,
+};
+
 export const getLinkVisits = async (
   ctx: WorkspaceTRPCContext,
   input: { id: string; domain: string; range: string },
@@ -1127,6 +1134,7 @@ export const getLinkVisits = async (
       isProPlan: userHasPaidPlan,
       geoRules: [],
       previous: null,
+      archived: EMPTY_ARCHIVED,
     };
   }
 
@@ -1181,7 +1189,10 @@ export const getLinkVisits = async (
   const prevEnd = startDate;
   const prevStart = new Date(startDate.getTime() - windowMs);
 
-  const [totalVisits, uniqueVisits, linkGeoRules, prevCounts] = await Promise.all([
+  const toDateKey = (d: Date) => d.toISOString().split("T")[0]!;
+
+  const [totalVisits, uniqueVisits, linkGeoRules, prevCounts, summaries, prevSummaries] =
+    await Promise.all([
     ctx.db.query.linkVisit.findMany({
       where: (visit, { eq, and, gte, lte }) =>
         and(
@@ -1232,12 +1243,55 @@ export const getLinkVisits = async (
             ),
         ])
       : Promise.resolve(null),
+    ctx.db.query.linkVisitDailySummary.findMany({
+      where: (s, { eq, and, gte, lte }) =>
+        and(
+          eq(s.linkId, foundLink.id),
+          gte(s.date, toDateKey(startDate)),
+          lte(s.date, toDateKey(now)),
+        ),
+    }),
+    hasPreviousPeriod
+      ? ctx.db
+          .select({
+            clicks: sum(linkVisitDailySummary.clicks),
+            uniqueClicks: sum(linkVisitDailySummary.uniqueClicks),
+          })
+          .from(linkVisitDailySummary)
+          .where(
+            and(
+              eq(linkVisitDailySummary.linkId, foundLink.id),
+              gte(linkVisitDailySummary.date, toDateKey(prevStart)),
+              lt(linkVisitDailySummary.date, toDateKey(prevEnd)),
+            ),
+          )
+      : Promise.resolve(null),
   ]);
+
+  const archived = summaries.reduce(
+    (acc, s) => {
+      acc.clicks += s.clicks;
+      acc.uniqueClicks += s.uniqueClicks;
+      acc.clicksPerDate[s.date] = (acc.clicksPerDate[s.date] ?? 0) + s.clicks;
+      acc.uniqueClicksPerDate[s.date] =
+        (acc.uniqueClicksPerDate[s.date] ?? 0) + s.uniqueClicks;
+      return acc;
+    },
+    {
+      clicks: 0,
+      uniqueClicks: 0,
+      clicksPerDate: {} as Record<string, number>,
+      uniqueClicksPerDate: {} as Record<string, number>,
+    },
+  );
 
   const previous = prevCounts
     ? {
-        total: prevCounts[0][0]?.total ?? 0,
-        unique: prevCounts[1][0]?.value ?? 0,
+        total:
+          (prevCounts[0][0]?.total ?? 0) + (Number(prevSummaries?.[0]?.clicks) || 0),
+        unique:
+          (prevCounts[1][0]?.value ?? 0) +
+          (Number(prevSummaries?.[0]?.uniqueClicks) || 0),
         verified: Number(prevCounts[0][0]?.verified ?? 0),
       }
     : null;
@@ -1252,6 +1306,7 @@ export const getLinkVisits = async (
       isProPlan: userHasPaidPlan,
       geoRules: linkGeoRules,
       previous,
+      archived,
     };
   }
 
@@ -1294,6 +1349,7 @@ export const getLinkVisits = async (
     isProPlan: userHasPaidPlan,
     geoRules: linkGeoRules,
     previous,
+    archived,
   };
 };
 


### PR DESCRIPTION
## Summary

A user reported 10 clicks on the dashboard but 0 on the link's analytics page. Two bugs:

- Migration 0027 added `Subscription.plan` with `DEFAULT 'free'`. Legacy rows kept that default until a webhook updated them, so the weekly cleanup applied the 30-day free retention to paying users and rolled their raw visits into `LinkVisitDailySummary`. `IS_FREE_TIER` now only matches a missing, NULL, or non-active subscription; an active row with an unreconciled `plan='free'` gets no cleanup.
- The analytics page, QR page, and v1 analytics API only read raw `LinkVisit` rows. `getLinkVisits` and the API now also load the daily summaries (shared `summarizeArchived` / `mergeArchivedClicks` helpers); totals, growth deltas, and the click chart include them. Breakdown cards (country, device, referrer) stay raw-only, since summaries hold no breakdowns.

## Data restore (already applied to production)

Raw rows deleted by the cleanup since May 10 were recovered from MySQL binlogs: 83,809 `LinkVisit` and 137,664 `UniqueLinkVisit` rows across 68 links for 6 paying users, and the 686 summary rows they replace were removed. Rows deleted before May 10 are outside binlog retention and survive only as daily counts.

## Validation

- `tsc --noEmit` clean; 57 existing tests pass.
- Verified against production: the reported link now has 5 raw visits plus 5 summary rows, totaling the 10 clicks the dashboard shows.

Stacked on #336; retarget to `main` once that lands.

https://claude.ai/code/session_01FeNuUbFVY6ykRDHX4wtX9M
